### PR TITLE
test: enhance testing and stability with shared helpers and 15 new widget tests

### DIFF
--- a/test/features/performers/performers_ui_test.dart
+++ b/test/features/performers/performers_ui_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:stash_app_flutter/features/performers/domain/entities/performer.dart';
+import 'package:stash_app_flutter/features/performers/presentation/pages/performers_page.dart';
+import 'package:stash_app_flutter/features/performers/presentation/providers/performer_list_provider.dart';
+import 'package:stash_app_flutter/features/performers/presentation/widgets/performer_card.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  const testPerformer = Performer(
+    id: 'p1',
+    name: 'Test Performer',
+    disambiguation: 'D',
+    urls: [],
+    gender: 'FEMALE',
+    birthdate: '1990-01-01',
+    aliasList: [],
+    favorite: false,
+    imagePath: 'path/to/image',
+    sceneCount: 10,
+    imageCount: 0,
+    galleryCount: 0,
+    groupCount: 0,
+    tagIds: [],
+    tagNames: [],
+  );
+
+  const testPerformer2 = Performer(
+    id: 'p2',
+    name: 'Alice',
+    disambiguation: null,
+    urls: [],
+    gender: 'FEMALE',
+    birthdate: null,
+    aliasList: [],
+    favorite: true,
+    imagePath: null,
+    sceneCount: 5,
+    imageCount: 0,
+    galleryCount: 0,
+    groupCount: 0,
+    tagIds: [],
+    tagNames: [],
+  );
+
+  testWidgets('PerformersPage displays list of performers', (tester) async {
+    final mockRepo = MockPerformerRepository()..withData([testPerformer, testPerformer2]);
+    
+    await pumpTestWidget(
+      tester,
+      prefs: prefs,
+      overrides: [performerRepositoryProvider.overrideWithValue(mockRepo)],
+      child: const PerformersPage(),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PerformerCard), findsNWidgets(2));
+    expect(find.text('Test Performer'), findsOneWidget);
+    expect(find.text('Alice'), findsOneWidget);
+  });
+
+  testWidgets('PerformersPage search filters list', (tester) async {
+    final mockRepo = MockPerformerRepository()..withData([testPerformer, testPerformer2]);
+    
+    await pumpTestWidget(
+      tester,
+      prefs: prefs,
+      overrides: [performerRepositoryProvider.overrideWithValue(mockRepo)],
+      child: const PerformersPage(),
+    );
+    await tester.pumpAndSettle();
+
+    // Open search
+    await tester.tap(find.byIcon(Icons.search));
+    await tester.pumpAndSettle();
+
+    // Mock data update on search query change (normally repo handles filtering)
+    mockRepo.withData([testPerformer2]);
+
+    await tester.enterText(find.byType(TextField), 'Alice');
+    await tester.pumpAndSettle();
+
+    expect(find.descendant(of: find.byType(PerformerCard), matching: find.text('Alice')), findsOneWidget);
+    expect(find.descendant(of: find.byType(PerformerCard), matching: find.text('Test Performer')), findsNothing);
+  });
+
+  testWidgets('PerformersPage filters by favorites only', (tester) async {
+    final mockRepo = MockPerformerRepository()..withData([testPerformer, testPerformer2]);
+    
+    await pumpTestWidget(
+      tester,
+      prefs: prefs,
+      overrides: [performerRepositoryProvider.overrideWithValue(mockRepo)],
+      child: const PerformersPage(),
+    );
+    await tester.pumpAndSettle();
+
+    // Open filter
+    await tester.tap(find.byIcon(Icons.filter_list));
+    await tester.pumpAndSettle();
+
+    // Change mock to reflect filtered data
+    mockRepo.withData([testPerformer2]);
+
+    // Tap favorites only switch
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pumpAndSettle();
+    
+    // Apply filter
+    await tester.tap(find.text('Apply Filters'));
+    await tester.pumpAndSettle();
+
+    expect(find.descendant(of: find.byType(PerformerCard), matching: find.text('Alice')), findsOneWidget);
+    expect(find.descendant(of: find.byType(PerformerCard), matching: find.text('Test Performer')), findsNothing);
+  });
+}

--- a/test/features/scenes/fullscreen_mode_test.dart
+++ b/test/features/scenes/fullscreen_mode_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:stash_app_flutter/features/scenes/domain/entities/scene.dart';
+import 'package:stash_app_flutter/features/scenes/presentation/widgets/scene_video_player.dart';
+import 'package:stash_app_flutter/features/scenes/presentation/providers/scene_details_provider.dart';
+import 'package:stash_app_flutter/features/scenes/presentation/providers/scene_list_provider.dart';
+import 'package:stash_app_flutter/features/scenes/presentation/providers/video_player_provider.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'prefer_scene_streams': false});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  final testScene = Scene(
+    id: 's1',
+    title: 'Test Scene',
+    date: DateTime(2024, 1, 1),
+    rating100: 40,
+    oCounter: 5,
+    organized: true,
+    interactive: false,
+    resumeTime: null,
+    playCount: 10,
+    files: [],
+    paths: const ScenePaths(
+      screenshot: null,
+      preview: null,
+      stream: 'http://test.com/stream.mp4',
+    ),
+    studioId: 'st1',
+    studioName: 'Test Studio',
+    studioImagePath: null,
+    performerIds: [],
+    performerNames: [],
+    performerImagePaths: [],
+    tagIds: [],
+    tagNames: [],
+  );
+
+  testWidgets('FullscreenPlayerPage renders and pops', (tester) async {
+    final mockRepo = MockSceneRepository()..withData([testScene]);
+    
+    // Pump a widget that has a navigator
+    await pumpTestWidget(
+      tester,
+      prefs: prefs,
+      overrides: [
+        sceneRepositoryProvider.overrideWithValue(mockRepo),
+        sceneDetailsProvider(testScene.id).overrideWith((ref) => testScene),
+      ],
+      child: Builder(
+        builder: (context) {
+          return ElevatedButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => FullscreenPlayerPage(sceneId: testScene.id),
+                ),
+              );
+            },
+            child: const Text('Open'),
+          );
+        },
+      ),
+    );
+    
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.byType(FullscreenPlayerPage), findsOneWidget);
+    
+    // Test popping
+    final context = tester.element(find.byType(FullscreenPlayerPage));
+    Navigator.of(context).pop();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    
+    expect(find.byType(FullscreenPlayerPage), findsNothing);
+  });
+}

--- a/test/features/scenes/video_player_ui_test.dart
+++ b/test/features/scenes/video_player_ui_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:stash_app_flutter/features/scenes/domain/entities/scene.dart';
+import 'package:stash_app_flutter/features/scenes/presentation/pages/scene_details_page.dart';
+import 'package:stash_app_flutter/features/scenes/presentation/providers/scene_details_provider.dart';
+import 'package:stash_app_flutter/features/scenes/presentation/providers/scene_list_provider.dart';
+import 'package:stash_app_flutter/features/scenes/presentation/widgets/scene_video_player.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'prefer_scene_streams': false});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  final testScene = Scene(
+    id: 's1',
+    title: 'Test Scene',
+    date: DateTime(2024, 1, 1),
+    rating100: 40,
+    oCounter: 5,
+    organized: true,
+    interactive: false,
+    resumeTime: null,
+    playCount: 10,
+    files: [],
+    paths: const ScenePaths(
+      screenshot: null,
+      preview: null,
+      stream: 'http://test.com/stream.mp4',
+    ),
+    studioId: 'st1',
+    studioName: 'Test Studio',
+    studioImagePath: null,
+    performerIds: [],
+    performerNames: [],
+    performerImagePaths: [],
+    tagIds: [],
+    tagNames: [],
+  );
+
+  testWidgets('SceneDetailsPage renders scene info', (tester) async {
+    tester.view.physicalSize = const Size(1200, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    final mockRepo = MockSceneRepository()..withData([testScene]);
+    
+    await pumpTestWidget(
+      tester,
+      prefs: prefs,
+      overrides: [
+        sceneRepositoryProvider.overrideWithValue(mockRepo),
+        sceneDetailsProvider(testScene.id).overrideWith((ref) => testScene),
+      ],
+      child: SceneDetailsPage(sceneId: testScene.id),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.text('Test Scene'), findsOneWidget);
+    expect(find.text('Test Studio'), findsOneWidget);
+  });
+
+  testWidgets('SceneDetailsPage updates rating', (tester) async {
+    tester.view.physicalSize = const Size(1200, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    final mockRepo = MockSceneRepository()..withData([testScene]);
+    
+    await pumpTestWidget(
+      tester,
+      prefs: prefs,
+      overrides: [
+        sceneRepositoryProvider.overrideWithValue(mockRepo),
+        sceneDetailsProvider(testScene.id).overrideWith((ref) => testScene),
+      ],
+      child: SceneDetailsPage(sceneId: testScene.id),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    final starIcons = find.byWidgetPredicate((widget) => 
+      widget is Icon && widget.icon == Icons.star && widget.size == 28
+    );
+    final borderIcons = find.byWidgetPredicate((widget) => 
+      widget is Icon && widget.icon == Icons.star_border && widget.size == 28
+    );
+
+    expect(starIcons, findsNWidgets(2));
+    expect(borderIcons, findsNWidgets(3));
+
+    await tester.tap(borderIcons.first); 
+    await tester.pump(const Duration(milliseconds: 500));
+  });
+
+  testWidgets('SceneDetailsPage increments O count', (tester) async {
+    tester.view.physicalSize = const Size(1200, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    final mockRepo = MockSceneRepository()..withData([testScene]);
+    
+    await pumpTestWidget(
+      tester,
+      prefs: prefs,
+      overrides: [
+        sceneRepositoryProvider.overrideWithValue(mockRepo),
+        sceneDetailsProvider(testScene.id).overrideWith((ref) => testScene),
+      ],
+      child: SceneDetailsPage(sceneId: testScene.id),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.text('5'), findsOneWidget); 
+    
+    await tester.tap(find.byIcon(Icons.water_drop_outlined));
+    await tester.pump(const Duration(milliseconds: 500));
+  });
+}

--- a/test/features/studios/studios_ui_test.dart
+++ b/test/features/studios/studios_ui_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:stash_app_flutter/features/studios/domain/entities/studio.dart';
+import 'package:stash_app_flutter/features/studios/presentation/pages/studios_page.dart';
+import 'package:stash_app_flutter/features/studios/presentation/providers/studio_list_provider.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  const testStudio = Studio(
+    id: 's1',
+    name: 'Test Studio',
+    sceneCount: 10,
+    imageCount: 0,
+    galleryCount: 0,
+    performerCount: 2,
+    favorite: false,
+  );
+
+  testWidgets('StudiosPage displays list of studios', (tester) async {
+    final mockRepo = MockStudioRepository()..withData([testStudio]);
+    
+    await pumpTestWidget(
+      tester,
+      prefs: prefs,
+      overrides: [studioRepositoryProvider.overrideWithValue(mockRepo)],
+      child: const StudiosPage(),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ListTile), findsOneWidget);
+    expect(find.text('Test Studio'), findsOneWidget);
+  });
+}

--- a/test/features/tags/tags_ui_test.dart
+++ b/test/features/tags/tags_ui_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:stash_app_flutter/features/tags/domain/entities/tag.dart';
+import 'package:stash_app_flutter/features/tags/presentation/pages/tags_page.dart';
+import 'package:stash_app_flutter/features/tags/presentation/providers/tag_list_provider.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  const testTag = Tag(
+    id: 't1',
+    name: 'Test Tag',
+    sceneCount: 10,
+    imageCount: 0,
+    galleryCount: 0,
+    performerCount: 2,
+    favorite: false,
+  );
+
+  testWidgets('TagsPage displays list of tags', (tester) async {
+    final mockRepo = MockTagRepository()..withData([testTag]);
+    
+    await pumpTestWidget(
+      tester,
+      prefs: prefs,
+      overrides: [tagRepositoryProvider.overrideWithValue(mockRepo)],
+      child: const TagsPage(),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ListTile), findsOneWidget);
+    expect(find.text('Test Tag'), findsOneWidget);
+  });
+}

--- a/test/global_ui_states_test.dart
+++ b/test/global_ui_states_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:stash_app_flutter/features/scenes/presentation/pages/scenes_page.dart';
+import 'package:stash_app_flutter/features/scenes/presentation/providers/scene_list_provider.dart';
+import 'package:stash_app_flutter/features/performers/presentation/pages/performers_page.dart';
+import 'package:stash_app_flutter/features/performers/presentation/providers/performer_list_provider.dart';
+import 'package:stash_app_flutter/features/studios/presentation/pages/studios_page.dart';
+import 'package:stash_app_flutter/features/studios/presentation/providers/studio_list_provider.dart';
+import 'package:stash_app_flutter/features/tags/presentation/pages/tags_page.dart';
+import 'package:stash_app_flutter/features/tags/presentation/providers/tag_list_provider.dart';
+
+import 'helpers/test_helpers.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  group('Global Empty States', () {
+    testWidgets('Scenes page shows empty message', (tester) async {
+      final mockRepo = MockSceneRepository()..withEmpty();
+      await pumpTestWidget(
+        tester,
+        prefs: prefs,
+        overrides: [sceneRepositoryProvider.overrideWithValue(mockRepo)],
+        child: const ScenesPage(),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No items found'), findsOneWidget);
+    });
+
+    testWidgets('Performers page shows empty message', (tester) async {
+      final mockRepo = MockPerformerRepository()..withEmpty();
+      await pumpTestWidget(
+        tester,
+        prefs: prefs,
+        overrides: [performerRepositoryProvider.overrideWithValue(mockRepo)],
+        child: const PerformersPage(),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No items found'), findsOneWidget);
+    });
+
+    testWidgets('Studios page shows empty message', (tester) async {
+      final mockRepo = MockStudioRepository()..withEmpty();
+      await pumpTestWidget(
+        tester,
+        prefs: prefs,
+        overrides: [studioRepositoryProvider.overrideWithValue(mockRepo)],
+        child: const StudiosPage(),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No items found'), findsOneWidget);
+    });
+
+    testWidgets('Tags page shows empty message', (tester) async {
+      final mockRepo = MockTagRepository()..withEmpty();
+      await pumpTestWidget(
+        tester,
+        prefs: prefs,
+        overrides: [tagRepositoryProvider.overrideWithValue(mockRepo)],
+        child: const TagsPage(),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No items found'), findsOneWidget);
+    });
+  });
+
+  group('Global Error States & Retry', () {
+    testWidgets('Scenes page shows error and retries', (tester) async {
+      final mockRepo = MockSceneRepository()..withError('Network Error');
+      await pumpTestWidget(
+        tester,
+        prefs: prefs,
+        overrides: [sceneRepositoryProvider.overrideWithValue(mockRepo)],
+        child: const ScenesPage(),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.errorView(message: 'Network Error'), findsOneWidget);
+      expect(find.retryButton(), findsOneWidget);
+
+      // Change mock to success
+      mockRepo.withData([]);
+      await tester.tap(find.retryButton());
+      await tester.pumpAndSettle();
+
+      expect(find.errorView(), findsNothing);
+      expect(find.text('No items found'), findsOneWidget);
+    });
+
+    testWidgets('Performers page shows error and retries', (tester) async {
+      final mockRepo = MockPerformerRepository()..withError('Failed to fetch performers');
+      await pumpTestWidget(
+        tester,
+        prefs: prefs,
+        overrides: [performerRepositoryProvider.overrideWithValue(mockRepo)],
+        child: const PerformersPage(),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.errorView(message: 'Failed to fetch performers'), findsOneWidget);
+      
+      mockRepo.withData([]);
+      await tester.tap(find.retryButton());
+      await tester.pumpAndSettle();
+
+      expect(find.text('No items found'), findsOneWidget);
+    });
+  });
+}

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:stash_app_flutter/core/presentation/theme/app_theme.dart';
+import 'package:stash_app_flutter/core/data/preferences/shared_preferences_provider.dart';
+
+import 'package:stash_app_flutter/features/scenes/domain/entities/scene.dart';
+import 'package:stash_app_flutter/features/scenes/domain/entities/scene_filter.dart';
+import 'package:stash_app_flutter/features/scenes/domain/repositories/scene_repository.dart';
+import 'package:stash_app_flutter/features/scenes/presentation/providers/scene_list_provider.dart';
+
+import 'package:stash_app_flutter/features/performers/domain/entities/performer.dart';
+import 'package:stash_app_flutter/features/performers/domain/repositories/performer_repository.dart';
+import 'package:stash_app_flutter/features/performers/presentation/providers/performer_list_provider.dart';
+
+import 'package:stash_app_flutter/features/studios/domain/entities/studio.dart';
+import 'package:stash_app_flutter/features/studios/domain/repositories/studio_repository.dart';
+import 'package:stash_app_flutter/features/studios/presentation/providers/studio_list_provider.dart';
+
+import 'package:stash_app_flutter/features/tags/domain/entities/tag.dart';
+import 'package:stash_app_flutter/features/tags/domain/repositories/tag_repository.dart';
+import 'package:stash_app_flutter/features/tags/presentation/providers/tag_list_provider.dart';
+
+import 'package:stash_app_flutter/core/presentation/widgets/error_state_view.dart';
+
+/// Base class for manual mock repositories with common state control
+class MockRepositoryState<T> {
+  List<T> data = [];
+  bool shouldThrow = false;
+  String errorMessage = 'Something went wrong';
+
+  void withData(List<T> data) {
+    this.data = data;
+    shouldThrow = false;
+  }
+
+  void withEmpty() {
+    data = [];
+    shouldThrow = false;
+  }
+
+  void withError(String message) {
+    errorMessage = message;
+    shouldThrow = true;
+  }
+}
+
+class MockSceneRepository extends MockRepositoryState<Scene> implements SceneRepository {
+  @override
+  Future<List<Scene>> findScenes({
+    int? page,
+    int? perPage,
+    String? filter,
+    String? sort,
+    bool descending = true,
+    bool? organized,
+    bool? performerFavorite,
+    String? performerId,
+    String? studioId,
+    String? tagId,
+    SceneFilter? sceneFilter,
+  }) async {
+    if (shouldThrow) throw Exception(errorMessage);
+    return data;
+  }
+
+  @override
+  Future<Scene> getSceneById(String id) async {
+    if (shouldThrow) throw Exception(errorMessage);
+    return data.firstWhere((s) => s.id == id);
+  }
+
+  @override
+  Future<void> updateSceneRating(String id, int rating100) async {
+    if (shouldThrow) throw Exception(errorMessage);
+  }
+
+  @override
+  Future<void> incrementSceneOCounter(String id) async {}
+
+  @override
+  Future<void> incrementScenePlayCount(String id) async {}
+}
+
+class MockPerformerRepository extends MockRepositoryState<Performer> implements PerformerRepository {
+  @override
+  Future<List<Performer>> findPerformers({
+    int? page,
+    int? perPage,
+    String? filter,
+    String? sort,
+    bool descending = true,
+    bool favoritesOnly = false,
+    List<String>? genders,
+  }) async {
+    if (shouldThrow) throw Exception(errorMessage);
+    return data;
+  }
+
+  @override
+  Future<Performer> getPerformerById(String id) async {
+    if (shouldThrow) throw Exception(errorMessage);
+    return data.firstWhere((p) => p.id == id);
+  }
+
+  @override
+  Future<void> setPerformerFavorite(String id, bool favorite) async {
+    if (shouldThrow) throw Exception(errorMessage);
+  }
+}
+
+class MockStudioRepository extends MockRepositoryState<Studio> implements StudioRepository {
+  @override
+  Future<List<Studio>> findStudios({
+    int? page,
+    int? perPage,
+    String? filter,
+    String? sort,
+    bool? descending,
+    bool favoritesOnly = false,
+  }) async {
+    if (shouldThrow) throw Exception(errorMessage);
+    return data;
+  }
+
+  @override
+  Future<Studio> getStudioById(String id) async {
+    if (shouldThrow) throw Exception(errorMessage);
+    return data.firstWhere((s) => s.id == id);
+  }
+
+  @override
+  Future<void> setStudioFavorite(String id, bool favorite) async {
+    if (shouldThrow) throw Exception(errorMessage);
+  }
+}
+
+class MockTagRepository extends MockRepositoryState<Tag> implements TagRepository {
+  @override
+  Future<List<Tag>> findTags({
+    int? page,
+    int? perPage,
+    String? filter,
+    String? sort,
+    bool? descending,
+    bool favoritesOnly = false,
+  }) async {
+    if (shouldThrow) throw Exception(errorMessage);
+    return data;
+  }
+
+  @override
+  Future<Tag> getTagById(String id) async {
+    if (shouldThrow) throw Exception(errorMessage);
+    return data.firstWhere((t) => t.id == id);
+  }
+
+  @override
+  Future<void> setTagFavorite(String id, bool favorite) async {
+    if (shouldThrow) throw Exception(errorMessage);
+  }
+}
+
+/// Helper to pump a widget with all necessary providers and theme
+Future<void> pumpTestWidget(
+  WidgetTester tester, {
+  required Widget child,
+  List<Override> overrides = const [],
+  SharedPreferences? prefs,
+}) async {
+  final finalPrefs = prefs ?? await SharedPreferences.getInstance();
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(finalPrefs),
+        ...overrides,
+      ],
+      child: MaterialApp(
+        theme: AppTheme.darkTheme,
+        home: child,
+      ),
+    ),
+  );
+}
+
+/// Extension for common finders
+extension CommonFindersX on CommonFinders {
+  Finder loadingSpinner() => byType(CircularProgressIndicator);
+  
+  Finder errorView({String? message}) {
+    if (message != null) {
+      return find.descendant(
+        of: find.byType(ErrorStateView),
+        matching: find.textContaining(message),
+      );
+    }
+    return find.byType(ErrorStateView);
+  }
+
+  Finder retryButton() => find.descendant(
+    of: find.byType(ErrorStateView),
+    matching: find.byType(FilledButton),
+  );
+}


### PR DESCRIPTION
## Summary
- Implemented shared test helpers and manual mocks in `test/helpers/test_helpers.dart`.
- Added global UI state tests for empty and error scenarios across all major pages.
- Added focused widget tests for Performers, Studios, and Tags modules.
- Added UI tests for Video Player and Fullscreen Mode.

## Test Plan
- Run `flutter test test/global_ui_states_test.dart test/features/performers/ test/features/studios/ test/features/tags/ test/features/scenes/`
- Verified 15 tests passing.