### PR TITLE
🎨 Palette: Add visibility toggle to API key field

### DIFF
--- a/lib/features/setup/presentation/settings_page.dart
+++ b/lib/features/setup/presentation/settings_page.dart
@@ -73,6 +73,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   bool _showRandomNavigation = true;
   ThemeMode _themeMode = ThemeMode.system;
   bool _loading = true;
+  bool _obscureApiKey = true;
 
   bool _isHostOnlyInput(String raw) {
     final parsed = Uri.tryParse(raw.trim());
@@ -169,8 +170,12 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     _seedColor = seedColor;
 
     if (!_presetColors.contains(seedColor)) {
-      _customHexController.text =
-          seedColor.toARGB32().toUnsigned(32).toRadixString(16).padLeft(8, '0').toUpperCase();
+      _customHexController.text = seedColor
+          .toARGB32()
+          .toUnsigned(32)
+          .toRadixString(16)
+          .padLeft(8, '0')
+          .toUpperCase();
     }
 
     setState(() => _loading = false);
@@ -356,14 +361,26 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   TextField(
                     controller: _apiKeyController,
                     focusNode: _apiKeyFocusNode,
-                    decoration: const InputDecoration(
+                    decoration: InputDecoration(
                       labelText: 'API key',
-                      border: OutlineInputBorder(),
+                      border: const OutlineInputBorder(),
                       hintText: 'Paste ApiKey header value',
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          _obscureApiKey
+                              ? Icons.visibility_off
+                              : Icons.visibility,
+                        ),
+                        onPressed: () {
+                          setState(() {
+                            _obscureApiKey = !_obscureApiKey;
+                          });
+                        },
+                      ),
                     ),
                     autocorrect: false,
                     enableSuggestions: false,
-                    obscureText: true,
+                    obscureText: _obscureApiKey,
                     textInputAction: TextInputAction.done,
                     onSubmitted: (_) => _saveServerSettings(),
                     onEditingComplete: () {
@@ -519,7 +536,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   const SizedBox(height: AppTheme.spacingLarge),
                   _buildSectionHeader('Display'),
                   Padding(
-                    padding: const EdgeInsets.symmetric(vertical: AppTheme.spacingSmall),
+                    padding: const EdgeInsets.symmetric(
+                      vertical: AppTheme.spacingSmall,
+                    ),
                     child: Row(
                       crossAxisAlignment: CrossAxisAlignment.center,
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -528,17 +547,26 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              const Text('Scenes Layout', style: TextStyle(fontSize: 16)),
+                              const Text(
+                                'Scenes Layout',
+                                style: TextStyle(fontSize: 16),
+                              ),
                               const SizedBox(height: 4),
-                              Text('Choose the default layout for the Scenes page', style: TextStyle(fontSize: 14, color: context.colors.onSurfaceVariant)),
+                              Text(
+                                'Choose the default layout for the Scenes page',
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  color: context.colors.onSurfaceVariant,
+                                ),
+                              ),
                             ],
                           ),
                         ),
                         const SizedBox(width: AppTheme.spacingMedium),
                         DropdownMenu<String>(
                           initialSelection: _sceneTiktokLayout
-                                  ? 'tiktok'
-                                  : (_sceneGridLayout ? 'grid' : 'list'),
+                              ? 'tiktok'
+                              : (_sceneGridLayout ? 'grid' : 'list'),
                           onSelected: (String? value) async {
                             if (value == null) return;
                             setState(() {
@@ -653,9 +681,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                         }
                       } catch (e) {
                         if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(content: Text('Error: $e')),
-                          );
+                          ScaffoldMessenger.of(
+                            context,
+                          ).showSnackBar(SnackBar(content: Text('Error: $e')));
                         }
                       }
                     },
@@ -714,7 +742,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 if (colorValue != null) {
                   // We don't reset _forceShowCustom while typing as we stay in this mode.
                   _seedColor = Color(colorValue);
-                  ref.read(appThemeColorProvider.notifier).setThemeColor(_seedColor);
+                  ref
+                      .read(appThemeColorProvider.notifier)
+                      .setThemeColor(_seedColor);
                 }
               }
             },
@@ -741,8 +771,12 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
             setState(() {
               _forceShowCustom = true;
               if (_customHexController.text.isEmpty) {
-                _customHexController.text =
-                    _seedColor.toARGB32().toUnsigned(32).toRadixString(16).padLeft(8, '0').toUpperCase();
+                _customHexController.text = _seedColor
+                    .toARGB32()
+                    .toUnsigned(32)
+                    .toRadixString(16)
+                    .padLeft(8, '0')
+                    .toUpperCase();
               }
             });
 
@@ -767,18 +801,19 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
               ? Icon(
                   Icons.palette_outlined,
                   size: 20,
-                  color:
-                      displayColor.computeLuminance() > 0.5 ? Colors.black : Colors.white,
+                  color: displayColor.computeLuminance() > 0.5
+                      ? Colors.black
+                      : Colors.white,
                 )
               : isSelected
-                  ? Icon(
-                      Icons.check,
-                      size: 20,
-                      color: displayColor.computeLuminance() > 0.5
-                          ? Colors.black
-                          : Colors.white,
-                    )
-                  : null,
+              ? Icon(
+                  Icons.check,
+                  size: 20,
+                  color: displayColor.computeLuminance() > 0.5
+                      ? Colors.black
+                      : Colors.white,
+                )
+              : null,
         ),
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -715,10 +715,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1232,26 +1232,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
💡 What: Added an eye icon toggle to the API key input field in the settings page to let users view or hide their inputted key.
🎯 Why: It's easy to make mistakes when copying and pasting API keys on mobile devices. Allowing users to temporarily reveal the obscured text reduces frustration and connection errors.
♿ Accessibility: Uses standard Material `IconButton` with semantic `visibility` and `visibility_off` icons. Keyboard navigatable.

---
*PR created automatically by Jules for task [2279773039509775826](https://jules.google.com/task/2279773039509775826) started by @Alchemist-Aloha*