### PR TITLE
🛡️ Sentinel: [SECURITY ENHANCEMENT] Add visibility toggle to API key

### DIFF
--- a/lib/features/setup/presentation/settings_page.dart
+++ b/lib/features/setup/presentation/settings_page.dart
@@ -63,6 +63,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   Color _seedColor = const Color(0xFF0F766E);
   bool _forceShowCustom = false;
   bool _preferSceneStreams = true;
+  bool _obscureApiKey = true;
   bool _sceneGridLayout = false;
   bool _sceneTiktokLayout = false;
   bool _autoplayNext = false;
@@ -356,14 +357,24 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   TextField(
                     controller: _apiKeyController,
                     focusNode: _apiKeyFocusNode,
-                    decoration: const InputDecoration(
+                    decoration: InputDecoration(
                       labelText: 'API key',
-                      border: OutlineInputBorder(),
+                      border: const OutlineInputBorder(),
                       hintText: 'Paste ApiKey header value',
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          _obscureApiKey ? Icons.visibility : Icons.visibility_off,
+                        ),
+                        onPressed: () {
+                          setState(() {
+                            _obscureApiKey = !_obscureApiKey;
+                          });
+                        },
+                      ),
                     ),
                     autocorrect: false,
                     enableSuggestions: false,
-                    obscureText: true,
+                    obscureText: _obscureApiKey,
                     textInputAction: TextInputAction.done,
                     onSubmitted: (_) => _saveServerSettings(),
                     onEditingComplete: () {


### PR DESCRIPTION
🛡️ Sentinel: [SECURITY ENHANCEMENT] Add visibility toggle to API key

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Lack of visibility toggle for sensitive API key input.
🎯 **Impact:** Users might resort to risky workarounds (e.g., pasting the API key into a plaintext editor) to verify their input since they cannot see it in the app.
🔧 **Fix:** Added a state-managed visibility toggle (`_obscureApiKey`) to the API key `TextField` in `lib/features/setup/presentation/settings_page.dart`. This aligns with security-UX best practices.
✅ **Verification:** Verified that the API key field defaults to obscured and toggles correctly when the suffix icon is pressed. Ran `flutter test` and confirmed all tests passed. Reverted unintended `pubspec.lock` modifications caused by `flutter pub get`.

---
*PR created automatically by Jules for task [8881596700854466831](https://jules.google.com/task/8881596700854466831) started by @Alchemist-Aloha*