### PR TITLE
🧪 Add tests for ListPageScaffold

### DIFF
--- a/test/core/presentation/widgets/list_page_scaffold_test.dart
+++ b/test/core/presentation/widgets/list_page_scaffold_test.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stash_app_flutter/core/presentation/widgets/list_page_scaffold.dart';
+import 'package:stash_app_flutter/core/presentation/widgets/error_state_view.dart';
+import 'package:stash_app_flutter/core/presentation/theme/app_theme.dart';
+
+void main() {
+  Widget buildTestApp(Widget child) {
+    return ProviderScope(
+      child: MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: child,
+      ),
+    );
+  }
+
+  group('ListPageScaffold', () {
+    testWidgets('shows loading state correctly', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          ListPageScaffold<String>(
+            title: 'Test Title',
+            searchHint: 'Search...',
+            onSearchChanged: (_) {},
+            provider: const AsyncValue.loading(),
+            itemBuilder: (context, item) => Text(item),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Title'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('shows empty state correctly', (WidgetTester tester) async {
+      const emptyMessage = 'Nothing here';
+      await tester.pumpWidget(
+        buildTestApp(
+          ListPageScaffold<String>(
+            title: 'Test Title',
+            searchHint: 'Search...',
+            onSearchChanged: (_) {},
+            provider: const AsyncValue.data([]),
+            emptyMessage: emptyMessage,
+            itemBuilder: (context, item) => Text(item),
+          ),
+        ),
+      );
+
+      expect(find.text(emptyMessage), findsOneWidget);
+    });
+
+    testWidgets('shows error state correctly', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          ListPageScaffold<String>(
+            title: 'Test Title',
+            searchHint: 'Search...',
+            onSearchChanged: (_) {},
+            provider: AsyncValue.error('An error occurred', StackTrace.empty),
+            itemBuilder: (context, item) => Text(item),
+          ),
+        ),
+      );
+
+      expect(find.byType(ErrorStateView), findsOneWidget);
+      expect(find.textContaining('An error occurred'), findsOneWidget);
+    });
+
+    testWidgets('shows list view when gridDelegate is null',
+        (WidgetTester tester) async {
+      final items = ['Item 1', 'Item 2', 'Item 3'];
+      await tester.pumpWidget(
+        buildTestApp(
+          ListPageScaffold<String>(
+            title: 'Test Title',
+            searchHint: 'Search...',
+            onSearchChanged: (_) {},
+            provider: AsyncValue.data(items),
+            itemBuilder: (context, item) => ListTile(title: Text(item)),
+          ),
+        ),
+      );
+
+      expect(find.byType(ListView), findsOneWidget);
+      for (final item in items) {
+        expect(find.text(item), findsOneWidget);
+      }
+    });
+
+    testWidgets('shows grid view when gridDelegate is provided',
+        (WidgetTester tester) async {
+      final items = ['Item 1', 'Item 2', 'Item 3'];
+      await tester.pumpWidget(
+        buildTestApp(
+          ListPageScaffold<String>(
+            title: 'Test Title',
+            searchHint: 'Search...',
+            onSearchChanged: (_) {},
+            provider: AsyncValue.data(items),
+            useResponsiveGrid: false,
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+            ),
+            itemBuilder: (context, item) => GridTile(child: Text(item)),
+          ),
+        ),
+      );
+
+      expect(find.byType(GridView), findsOneWidget);
+      for (final item in items) {
+        expect(find.text(item), findsOneWidget);
+      }
+    });
+
+    testWidgets('toggles search bar when search icon is tapped',
+        (WidgetTester tester) async {
+      String searchQuery = '';
+      await tester.pumpWidget(
+        buildTestApp(
+          ListPageScaffold<String>(
+            title: 'Test Title',
+            searchHint: 'Search hint...',
+            onSearchChanged: (val) => searchQuery = val,
+            provider: const AsyncValue.loading(),
+            itemBuilder: (context, item) => Text(item),
+          ),
+        ),
+      );
+
+      // Initially, title is shown, search icon is visible
+      expect(find.text('Test Title'), findsOneWidget);
+      expect(find.byIcon(Icons.search), findsOneWidget);
+      expect(find.byIcon(Icons.close), findsNothing);
+      expect(find.byType(TextField), findsNothing);
+
+      // Tap search icon
+      await tester.tap(find.byIcon(Icons.search));
+      await tester.pump();
+
+      // Now, TextField is shown, close icon is visible, title is hidden
+      expect(find.text('Test Title'), findsNothing);
+      expect(find.byIcon(Icons.close), findsOneWidget);
+      expect(find.byIcon(Icons.search), findsNothing);
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.text('Search hint...'), findsOneWidget); // Hint text
+
+      // Type in search field
+      await tester.enterText(find.byType(TextField), 'hello');
+      expect(searchQuery, 'hello');
+
+      // Tap close icon
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+
+      // Back to initial state, search query cleared
+      expect(find.text('Test Title'), findsOneWidget);
+      expect(find.byIcon(Icons.search), findsOneWidget);
+      expect(find.byType(TextField), findsNothing);
+      expect(searchQuery, '');
+    });
+
+    testWidgets('displays custom sortBar', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          ListPageScaffold<String>(
+            title: 'Test Title',
+            searchHint: 'Search...',
+            onSearchChanged: (_) {},
+            provider: const AsyncValue.loading(),
+            sortBar: const Text('Custom Sort Bar'),
+            itemBuilder: (context, item) => Text(item),
+          ),
+        ),
+      );
+
+      expect(find.text('Custom Sort Bar'), findsOneWidget);
+    });
+
+    testWidgets('displays custom floatingActionButton',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          ListPageScaffold<String>(
+            title: 'Test Title',
+            searchHint: 'Search...',
+            onSearchChanged: (_) {},
+            provider: const AsyncValue.loading(),
+            floatingActionButton: const FloatingActionButton(
+              onPressed: null,
+              child: Icon(Icons.add),
+            ),
+            itemBuilder: (context, item) => Text(item),
+          ),
+        ),
+      );
+
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+      expect(find.byIcon(Icons.add), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
No test file existed for the `ListPageScaffold` widget. This PR introduces a new test file `test/core/presentation/widgets/list_page_scaffold_test.dart` to verify the different states and layout configurations of the widget.

📊 **Coverage:** What scenarios are now tested
- Initialization and loading state (`AsyncValue.loading()`).
- Empty state (`AsyncValue.data([])`).
- Error state (`AsyncValue.error()`).
- Success state showing a standard list view.
- Success state showing a grid view with custom delegate.
- Search bar interaction (tapping search icon, typing, and closing).
- Custom properties such as `sortBar` and `floatingActionButton`.

✨ **Result:** The improvement in test coverage
`ListPageScaffold` is heavily utilized throughout the app for data presentation. By thoroughly testing its different permutations, we ensure UI consistency, prevent regression bugs when modifying base scaffold behavior, and improve the reliability of all list pages in the app.

---
*PR created automatically by Jules for task [4542319793123421080](https://jules.google.com/task/4542319793123421080) started by @Alchemist-Aloha*