### PR TITLE
🧪 [testing improvement description]

### DIFF
--- a/test/features/scenes/presentation/providers/playback_queue_state_test.dart
+++ b/test/features/scenes/presentation/providers/playback_queue_state_test.dart
@@ -15,6 +15,7 @@ Scene mockScene({required String id, required String title}) {
     resumeTime: 0.0,
     playCount: 0,
     files: [],
+    urls: [],
     paths: const ScenePaths(screenshot: '', preview: '', stream: ''),
     studioId: 's1',
     studioName: 'Studio 1',

--- a/test/features/scenes/presentation/widgets/native_video_controls_test.dart
+++ b/test/features/scenes/presentation/widgets/native_video_controls_test.dart
@@ -97,6 +97,7 @@ void main() {
     resumeTime: null,
     playCount: 0,
     files: [],
+    urls: [],
     paths: const ScenePaths(screenshot: null, preview: null, stream: null),
     studioId: '',
     studioName: '',

--- a/test/features/scenes/presentation/widgets/scene_video_player_test.dart
+++ b/test/features/scenes/presentation/widgets/scene_video_player_test.dart
@@ -46,6 +46,7 @@ void main() {
     resumeTime: null,
     playCount: 10,
     files: [],
+    urls: [],
     paths: const ScenePaths(
       screenshot: null,
       preview: null,

--- a/test/features/scenes/presentation/widgets/tiktok_scenes_view_test.dart
+++ b/test/features/scenes/presentation/widgets/tiktok_scenes_view_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stash_app_flutter/features/scenes/presentation/widgets/tiktok_scenes_view.dart';
+
+void main() {
+  group('FullScreenMode', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('initial state is false', () {
+      final isFullScreen = container.read(fullScreenModeProvider);
+      expect(isFullScreen, isFalse);
+    });
+
+    test('toggle changes state', () {
+      final isFullScreenInitial = container.read(fullScreenModeProvider);
+      expect(isFullScreenInitial, isFalse);
+
+      container.read(fullScreenModeProvider.notifier).toggle();
+      final isFullScreenAfterToggle = container.read(fullScreenModeProvider);
+      expect(isFullScreenAfterToggle, isTrue);
+
+      container.read(fullScreenModeProvider.notifier).toggle();
+      final isFullScreenAfterSecondToggle = container.read(fullScreenModeProvider);
+      expect(isFullScreenAfterSecondToggle, isFalse);
+    });
+
+    test('set updates state to specific value', () {
+      final isFullScreenInitial = container.read(fullScreenModeProvider);
+      expect(isFullScreenInitial, isFalse);
+
+      container.read(fullScreenModeProvider.notifier).set(true);
+      final isFullScreenAfterSetTrue = container.read(fullScreenModeProvider);
+      expect(isFullScreenAfterSetTrue, isTrue);
+
+      container.read(fullScreenModeProvider.notifier).set(false);
+      final isFullScreenAfterSetFalse = container.read(fullScreenModeProvider);
+      expect(isFullScreenAfterSetFalse, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the `FullScreenMode` Notifier located in `lib/features/scenes/presentation/widgets/tiktok_scenes_view.dart`.

📊 **Coverage:** The new test file fully covers the Notifier, verifying that:
1. The initial state correctly defaults to `false`.
2. The `toggle()` method successfully switches the state back and forth.
3. The `set(bool)` method successfully forces the state to a specific boolean value.

✨ **Result:** Test coverage for `tiktok_scenes_view.dart` has been increased, ensuring that any future refactoring of the `FullScreenMode` state management will be reliably caught by the test suite.

---
*PR created automatically by Jules for task [1118617278655601630](https://jules.google.com/task/1118617278655601630) started by @Alchemist-Aloha*