### PR TITLE
🧪 Add test file for GlobalPlayerState

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -723,10 +723,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1240,26 +1240,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:

--- a/test/features/scenes/presentation/providers/global_player_state_test.dart
+++ b/test/features/scenes/presentation/providers/global_player_state_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stash_app_flutter/features/scenes/domain/entities/scene.dart';
+import 'package:stash_app_flutter/features/scenes/presentation/providers/video_player_provider.dart';
+
+Scene mockScene({required String id, required String title}) {
+  return Scene(
+    id: id,
+    title: title,
+    details: '',
+    date: DateTime(2023),
+    rating100: 0,
+    oCounter: 0,
+    organized: false,
+    interactive: false,
+    resumeTime: 0.0,
+    playCount: 0,
+    files: [],
+    urls: [],
+    paths: const ScenePaths(screenshot: '', preview: '', stream: ''),
+    studioId: 's1',
+    studioName: 'Studio 1',
+    studioImagePath: '',
+    performerIds: [],
+    performerNames: [],
+    performerImagePaths: [],
+    tagIds: [],
+    tagNames: [],
+  );
+}
+
+void main() {
+  group('GlobalPlayerState', () {
+    test('initializes with default values', () {
+      final state = GlobalPlayerState();
+
+      expect(state.activeScene, isNull);
+      expect(state.videoPlayerController, isNull);
+      expect(state.isPlaying, isFalse);
+      expect(state.isFullScreen, isFalse);
+      expect(state.isInPipMode, isFalse);
+      expect(state.streamMimeType, isNull);
+      expect(state.streamLabel, isNull);
+      expect(state.streamSource, isNull);
+      expect(state.startupLatencyMs, isNull);
+      expect(state.prewarmAttempted, isNull);
+      expect(state.prewarmSucceeded, isNull);
+      expect(state.prewarmLatencyMs, isNull);
+      expect(state.autoplayNext, isFalse);
+      expect(state.showVideoDebugInfo, isFalse);
+      expect(state.useDoubleTapSeek, isTrue);
+      expect(state.enableBackgroundPlayback, isFalse);
+      expect(state.enableNativePip, isFalse);
+    });
+
+    test('initializes with provided values', () {
+      final scene = mockScene(id: '1', title: 'Scene 1');
+      final state = GlobalPlayerState(
+        activeScene: scene,
+        isPlaying: true,
+        isFullScreen: true,
+        isInPipMode: true,
+        streamMimeType: 'video/mp4',
+        streamLabel: 'Direct',
+        streamSource: 'source1',
+        startupLatencyMs: 100,
+        prewarmAttempted: true,
+        prewarmSucceeded: true,
+        prewarmLatencyMs: 50,
+        autoplayNext: true,
+        showVideoDebugInfo: true,
+        useDoubleTapSeek: false,
+        enableBackgroundPlayback: true,
+        enableNativePip: true,
+      );
+
+      expect(state.activeScene, equals(scene));
+      expect(state.isPlaying, isTrue);
+      expect(state.isFullScreen, isTrue);
+      expect(state.isInPipMode, isTrue);
+      expect(state.streamMimeType, equals('video/mp4'));
+      expect(state.streamLabel, equals('Direct'));
+      expect(state.streamSource, equals('source1'));
+      expect(state.startupLatencyMs, equals(100));
+      expect(state.prewarmAttempted, isTrue);
+      expect(state.prewarmSucceeded, isTrue);
+      expect(state.prewarmLatencyMs, equals(50));
+      expect(state.autoplayNext, isTrue);
+      expect(state.showVideoDebugInfo, isTrue);
+      expect(state.useDoubleTapSeek, isFalse);
+      expect(state.enableBackgroundPlayback, isTrue);
+      expect(state.enableNativePip, isTrue);
+    });
+
+    group('copyWith', () {
+      test('returns same values when called without arguments', () {
+        final scene = mockScene(id: '1', title: 'Scene 1');
+        final state = GlobalPlayerState(
+          activeScene: scene,
+          isPlaying: true,
+          streamMimeType: 'video/mp4',
+          autoplayNext: true,
+        );
+
+        final newState = state.copyWith();
+
+        expect(newState.activeScene, equals(scene));
+        expect(newState.isPlaying, isTrue);
+        expect(newState.streamMimeType, equals('video/mp4'));
+        expect(newState.autoplayNext, isTrue);
+      });
+
+      test('updates specified values', () {
+        final state = GlobalPlayerState(
+          isPlaying: false,
+          isFullScreen: false,
+        );
+
+        final newState = state.copyWith(
+          isPlaying: true,
+          isFullScreen: true,
+          streamMimeType: 'video/webm',
+        );
+
+        expect(newState.isPlaying, isTrue);
+        expect(newState.isFullScreen, isTrue);
+        expect(newState.streamMimeType, equals('video/webm'));
+      });
+
+      test('clears active values when clearActive is true', () {
+        final scene = mockScene(id: '1', title: 'Scene 1');
+        final state = GlobalPlayerState(
+          activeScene: scene,
+          isPlaying: true,
+          streamMimeType: 'video/mp4',
+          streamLabel: 'Direct',
+          streamSource: 'source1',
+          startupLatencyMs: 100,
+          prewarmAttempted: true,
+          prewarmSucceeded: true,
+          prewarmLatencyMs: 50,
+          autoplayNext: true, // Should remain true
+        );
+
+        final newState = state.copyWith(clearActive: true);
+
+        // Cleared fields
+        expect(newState.activeScene, isNull);
+        expect(newState.videoPlayerController, isNull);
+        expect(newState.streamMimeType, isNull);
+        expect(newState.streamLabel, isNull);
+        expect(newState.streamSource, isNull);
+        expect(newState.startupLatencyMs, isNull);
+        expect(newState.prewarmAttempted, isNull);
+        expect(newState.prewarmSucceeded, isNull);
+        expect(newState.prewarmLatencyMs, isNull);
+
+        // Retained fields
+        expect(newState.isPlaying, isTrue);
+        expect(newState.autoplayNext, isTrue);
+      });
+
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** Addressed the missing test file for `GlobalPlayerState` which is defined in `lib/features/scenes/presentation/providers/video_player_provider.dart:22`.
📊 **Coverage:** Covered initialization with default and provided values, and scenarios for the `copyWith` method including testing the special `clearActive` parameter which explicitly nulls out active scene and stream information.
✨ **Result:** Improved test coverage and reliability for global playback state data structures.

---
*PR created automatically by Jules for task [3482492558304000475](https://jules.google.com/task/3482492558304000475) started by @Alchemist-Aloha*