### PR TITLE
🧪 Add tests for ErrorStateView

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -723,10 +723,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1240,26 +1240,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:

--- a/test/core/presentation/widgets/error_state_view_test.dart
+++ b/test/core/presentation/widgets/error_state_view_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stash_app_flutter/core/presentation/widgets/error_state_view.dart';
+import 'package:stash_app_flutter/core/presentation/theme/app_theme.dart';
+
+void main() {
+  Widget buildTestApp(Widget child) {
+    return MaterialApp(
+      theme: AppTheme.lightTheme,
+      home: Scaffold(body: child),
+    );
+  }
+
+  group('ErrorStateView', () {
+    testWidgets('renders the error message correctly', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildTestApp(const ErrorStateView(message: 'Something went wrong')),
+      );
+
+      expect(find.text('Something went wrong'), findsOneWidget);
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+    });
+
+    testWidgets('renders the default \'Retry\' button when onRetry is provided', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildTestApp(ErrorStateView(message: 'Error', onRetry: () {})),
+      );
+
+      expect(find.byType(FilledButton), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+
+    testWidgets('does not render a retry button when onRetry is null', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildTestApp(const ErrorStateView(message: 'Error')),
+      );
+
+      expect(find.byType(FilledButton), findsNothing);
+      expect(find.text('Retry'), findsNothing);
+    });
+
+    testWidgets('uses custom retryLabel when provided alongside onRetry', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildTestApp(ErrorStateView(
+          message: 'Error',
+          onRetry: () {},
+          retryLabel: 'Try Again',
+        )),
+      );
+
+      expect(find.byType(FilledButton), findsOneWidget);
+      expect(find.text('Try Again'), findsOneWidget);
+      expect(find.text('Retry'), findsNothing);
+    });
+
+    testWidgets('triggers onRetry callback when the retry button is tapped', (WidgetTester tester) async {
+      bool callbackFired = false;
+
+      await tester.pumpWidget(
+        buildTestApp(ErrorStateView(
+          message: 'Error',
+          onRetry: () {
+            callbackFired = true;
+          },
+        )),
+      );
+
+      final buttonFinder = find.byType(FilledButton);
+      expect(buttonFinder, findsOneWidget);
+
+      await tester.tap(buttonFinder);
+      await tester.pumpAndSettle();
+
+      expect(callbackFired, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** Addressed a testing gap by adding missing unit tests for the `ErrorStateView` widget.

📊 **Coverage:** The new test file (`test/core/presentation/widgets/error_state_view_test.dart`) covers the following scenarios:
- Renders the error message text and error icon correctly.
- Renders the default 'Retry' button when the `onRetry` callback is provided.
- Does not render a retry button when `onRetry` is null.
- Uses a custom `retryLabel` when provided alongside `onRetry`.
- Correctly triggers the `onRetry` callback when the retry button is tapped.

✨ **Result:** Test coverage for core UI widgets has been improved, ensuring the error display component behaves reliably under different configurations.

---
*PR created automatically by Jules for task [6088188182533227811](https://jules.google.com/task/6088188182533227811) started by @Alchemist-Aloha*