### PR TITLE
🎨 Palette: Add tooltips to icon-only buttons for accessibility

### DIFF
--- a/lib/features/navigation/presentation/widgets/mini_player.dart
+++ b/lib/features/navigation/presentation/widgets/mini_player.dart
@@ -70,6 +70,7 @@ class MiniPlayer extends ConsumerWidget {
                 ),
               ),
               IconButton(
+                tooltip: isPlaying ? 'Pause' : 'Play',
                 onPressed: () =>
                     ref.read(playerStateProvider.notifier).togglePlayPause(),
                 icon: Icon(
@@ -78,6 +79,7 @@ class MiniPlayer extends ConsumerWidget {
                 ),
               ),
               IconButton(
+                tooltip: 'Close Player',
                 onPressed: () => ref.read(playerStateProvider.notifier).stop(),
                 icon: Icon(Icons.close, color: context.colors.onSurface),
               ),

--- a/lib/features/scenes/presentation/widgets/native_video_controls.dart
+++ b/lib/features/scenes/presentation/widgets/native_video_controls.dart
@@ -474,6 +474,7 @@ class _NativeVideoControlsState extends ConsumerState<NativeVideoControls>
                                 Row(
                                   children: [
                                     IconButton(
+                                      tooltip: value.isPlaying ? 'Pause' : 'Play',
                                       style: _controlButtonStyle(colorScheme),
                                       iconSize: 22,
                                       icon: Icon(
@@ -493,6 +494,7 @@ class _NativeVideoControlsState extends ConsumerState<NativeVideoControls>
                                     if (nextScene != null && !isFullScreen) ...[
                                       const SizedBox(width: 8),
                                       IconButton(
+                                        tooltip: 'Skip Next',
                                         style: _controlButtonStyle(colorScheme),
                                         iconSize: 22,
                                         icon: const Icon(Icons.skip_next_rounded),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -747,10 +747,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1264,26 +1264,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
💡 What: Added `tooltip` properties to icon-only `IconButton` widgets in the `NativeVideoControls` and `MiniPlayer` components.
🎯 Why: Icon-only buttons without tooltips are confusing for desktop users (who rely on hover text) and are completely inaccessible to screen reader users. The tooltips act as semantic labels, making the UI much more intuitive and accessible.
♿ Accessibility: Provides explicit, readable labels for dynamic play/pause and skip controls for assistive technologies.

---
*PR created automatically by Jules for task [778302489422410542](https://jules.google.com/task/778302489422410542) started by @Alchemist-Aloha*