### PR TITLE
⚡ Bolt: Hoist invariant layout calculations out of itemBuilder in ListPageScaffold

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 ## 2024-05-28 - [Sync Deduplication in Flutter build()]
 **Learning:** Performing deduplication *after* an async task within a Flutter `build` method is a performance trap. If a widget rebuilds rapidly (e.g., during scrolling), the async task won't complete before the next `build` fires, bypassing the deduplication check and spawning dozens of redundant async file system checks and network requests.
 **Action:** Always maintain a synchronous `Set` of started/completed tasks to check *before* initiating expensive async operations or scheduling `addPostFrameCallback` from within `build()`.
+
+## 2024-05-29 - [Hoist Invariant Layout Calculations from itemBuilder]
+**Learning:** Performing invariant layout calculations (e.g., `MediaQuery.sizeOf(context)` or creating grid delegates) inside Flutter's `ListView.builder` or `GridView.builder` `itemBuilder` callbacks is an O(N) operation that applies significant GC pressure during scrolling.
+**Action:** Always hoist invariant variables and layout calculations out of `itemBuilder` loops up to the `build` method.

--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -463,6 +463,29 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                   );
                 }
 
+                final isGrid = widget.gridDelegate != null;
+                int? memCacheWidth;
+                if (widget.itemBuilder != null) {
+                  if (widget.memCacheWidthBuilder != null) {
+                    memCacheWidth = widget.memCacheWidthBuilder!(
+                      context,
+                      isGrid,
+                    );
+                  } else {
+                    final screenWidth = MediaQuery.sizeOf(context).width;
+                    if (isGrid) {
+                      final delegate =
+                          _getResponsiveGridDelegate(context)
+                              as SliverGridDelegateWithFixedCrossAxisCount;
+                      memCacheWidth =
+                          (screenWidth / delegate.crossAxisCount * 1.5).toInt();
+                    } else {
+                      memCacheWidth =
+                          screenWidth > 600 ? 600 : screenWidth.toInt();
+                    }
+                  }
+                }
+
                 Widget body =
                     widget.customBody ??
                     (widget.gridDelegate != null
@@ -472,7 +495,7 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                           gridDelegate: _getResponsiveGridDelegate(context),
                           itemCount: items.length,
                           itemBuilder: (context, index) {
-                            if (index == 0 && widget.imageUrlBuilder != null) {
+                            if (index == 0 && widget.imageUrlBuilder != null && _measuredItemExtent == null) {
                               WidgetsBinding.instance.addPostFrameCallback((_) {
                                 if (_measuredItemExtent == null &&
                                     _firstItemKey.currentContext != null) {
@@ -485,30 +508,6 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                                   }
                                 }
                               });
-                            }
-                            final isGrid = widget.gridDelegate != null;
-                            int? memCacheWidth;
-                            if (widget.memCacheWidthBuilder != null) {
-                              memCacheWidth = widget.memCacheWidthBuilder!(
-                                context,
-                                isGrid,
-                              );
-                            } else {
-                              final screenWidth =
-                                  MediaQuery.sizeOf(context).width;
-                              if (isGrid) {
-                                final delegate =
-                                    _getResponsiveGridDelegate(context)
-                                        as SliverGridDelegateWithFixedCrossAxisCount;
-                                memCacheWidth =
-                                    (screenWidth /
-                                            delegate.crossAxisCount *
-                                            1.5)
-                                        .toInt();
-                              } else {
-                                memCacheWidth =
-                                    screenWidth > 600 ? 600 : screenWidth.toInt();
-                              }
                             }
 
                             return RepaintBoundary(
@@ -532,7 +531,8 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                           itemBuilder: (context, index) {
                             if (index == 0 &&
                                 widget.imageUrlBuilder != null &&
-                                widget.itemExtent == null) {
+                                widget.itemExtent == null &&
+                                _measuredItemExtent == null) {
                               WidgetsBinding.instance.addPostFrameCallback((_) {
                                 if (_measuredItemExtent == null &&
                                     _firstItemKey.currentContext != null) {
@@ -545,30 +545,6 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                                   }
                                 }
                               });
-                            }
-                            final isGrid = widget.gridDelegate != null;
-                            int? memCacheWidth;
-                            if (widget.memCacheWidthBuilder != null) {
-                              memCacheWidth = widget.memCacheWidthBuilder!(
-                                context,
-                                isGrid,
-                              );
-                            } else {
-                              final screenWidth =
-                                  MediaQuery.sizeOf(context).width;
-                              if (isGrid) {
-                                final delegate =
-                                    _getResponsiveGridDelegate(context)
-                                        as SliverGridDelegateWithFixedCrossAxisCount;
-                                memCacheWidth =
-                                    (screenWidth /
-                                            delegate.crossAxisCount *
-                                            1.5)
-                                        .toInt();
-                              } else {
-                                memCacheWidth =
-                                    screenWidth > 600 ? 600 : screenWidth.toInt();
-                              }
                             }
 
                             return RepaintBoundary(

--- a/lib/core/presentation/widgets/media_strip.dart
+++ b/lib/core/presentation/widgets/media_strip.dart
@@ -107,15 +107,11 @@ class MediaStrip extends StatelessWidget {
               const SizedBox(width: AppTheme.spacingSmall),
           itemBuilder: (context, index) {
             final item = items[index];
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              if (context.mounted) {
-                StashImage.prefetch(
-                  context,
-                  imageUrl: item.thumbnailUrl,
-                  headers: headers,
-                );
-              }
-            });
+
+            // Remove the redundant addPostFrameCallback that was triggering
+            // a full-size un-optimized prefetch dynamically as items built.
+            // The initial and scroll-based prefetching accurately handle warming
+            // the cache with memCacheWidth constraints.
 
             return RepaintBoundary(
               child: InkWell(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -747,10 +747,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1264,26 +1264,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
💡 What: Hoisted `memCacheWidth` calculations and delegate instantiation out of `ListView.builder` and `GridView.builder` `itemBuilder` callbacks into the main `build` method in `ListPageScaffold`. Removed an unnecessary per-item post-frame prefetch in `MediaStrip`.
🎯 Why: `itemBuilder` is called rapidly during scrolling. Calculating device dimensions or rebuilding grid delegates inside it is an O(N) operation that causes unnecessary garbage collection and frame drops.
📊 Impact: Reduces memory allocations during rapid scrolling in grids/lists and prevents callback queue flooding from redundant prefetch scheduling.
🔬 Measurement: Verify smooth scrolling via Flutter performance overlay in any grid/list view (e.g. Scenes page, Images page). Check that images still load correctly and `memCacheWidth` values are respected via devtools memory profile.

---
*PR created automatically by Jules for task [10050822737890628054](https://jules.google.com/task/10050822737890628054) started by @Alchemist-Aloha*