### PR TITLE
🛡️ Sentinel: [HIGH] Migrate API key from plaintext to encrypted secure storage

### DIFF
--- a/lib/core/data/graphql/graphql_client.dart
+++ b/lib/core/data/graphql/graphql_client.dart
@@ -1,4 +1,5 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import '../preferences/shared_preferences_provider.dart';
 
@@ -51,12 +52,14 @@ String serverUrl(Ref ref) {
   return normalizeGraphqlServerUrl(storedServerUrl);
 }
 
+/// StateProvider for the internal Stash server API Key value.
+final serverApiKeyInternalProvider = StateProvider<String>((ref) => '');
+
 /// Provider for the Stash server API Key.
 @riverpod
 String serverApiKey(Ref ref) {
   ref.watch(sharedPreferencesTriggerProvider);
-  final prefs = ref.watch(sharedPreferencesProvider);
-  return prefs.getString('server_api_key')?.trim() ?? '';
+  return ref.watch(serverApiKeyInternalProvider);
 }
 
 /// A centralized [GraphQLClient] provider for all feature repositories.

--- a/lib/core/data/graphql/graphql_client.g.dart
+++ b/lib/core/data/graphql/graphql_client.g.dart
@@ -157,7 +157,7 @@ final class ServerApiKeyProvider
   }
 }
 
-String _$serverApiKeyHash() => r'a7caa4f8a9dc8726451b81345aadcf92f96a60fa';
+String _$serverApiKeyHash() => r'b62fa2ae4117b0cb38b1394859da901242380e5e';
 
 /// A centralized [GraphQLClient] provider for all feature repositories.
 ///

--- a/lib/core/data/preferences/secure_storage_provider.dart
+++ b/lib/core/data/preferences/secure_storage_provider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+final secureStorageProvider = Provider<FlutterSecureStorage>((ref) {
+  return const FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
+});

--- a/lib/features/galleries/presentation/providers/gallery_list_provider.g.dart
+++ b/lib/features/galleries/presentation/providers/gallery_list_provider.g.dart
@@ -360,7 +360,7 @@ final class GalleryListProvider
   GalleryList create() => GalleryList();
 }
 
-String _$galleryListHash() => r'4e14733c2f7ff2d32adf386b62362ea5fd1c1381';
+String _$galleryListHash() => r'0b3edfcbb8b925aeb823d29efee6008a2b0434c9';
 
 abstract class _$GalleryList extends $AsyncNotifier<List<Gallery>> {
   FutureOr<List<Gallery>> build();

--- a/lib/features/images/presentation/providers/image_list_provider.g.dart
+++ b/lib/features/images/presentation/providers/image_list_provider.g.dart
@@ -320,7 +320,7 @@ final class ImageListProvider
   ImageList create() => ImageList();
 }
 
-String _$imageListHash() => r'1b425d88e550b395a863c1cf67f380baef55cd34';
+String _$imageListHash() => r'4ebeeda70e94686f5cb633ffaeb3f08c5043bf38';
 
 abstract class _$ImageList extends $AsyncNotifier<List<entity.Image>> {
   FutureOr<List<entity.Image>> build();

--- a/lib/features/setup/presentation/pages/settings/server_settings_page.dart
+++ b/lib/features/setup/presentation/pages/settings/server_settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:graphql/client.dart';
 import 'package:stash_app_flutter/core/data/graphql/graphql_client.dart';
 import 'package:stash_app_flutter/core/data/graphql/media_headers_provider.dart';
+import 'package:stash_app_flutter/core/data/preferences/secure_storage_provider.dart';
 import 'package:stash_app_flutter/core/data/preferences/shared_preferences_provider.dart';
 import 'package:stash_app_flutter/core/presentation/theme/app_theme.dart';
 import 'package:stash_app_flutter/features/galleries/presentation/providers/gallery_details_provider.dart';
@@ -58,8 +59,9 @@ class _ServerSettingsPageState extends ConsumerState<ServerSettingsPage> {
 
   Future<void> _load() async {
     final prefs = ref.read(sharedPreferencesProvider);
+    final secureStorage = ref.read(secureStorageProvider);
     final url = prefs.getString('server_base_url') ?? '';
-    final apiKey = prefs.getString('server_api_key') ?? '';
+    final apiKey = await secureStorage.read(key: 'server_api_key') ?? '';
 
     _baseUrlController.text = url;
     _apiKeyController.text = apiKey;
@@ -137,12 +139,18 @@ class _ServerSettingsPageState extends ConsumerState<ServerSettingsPage> {
     }
 
     final prefs = ref.read(sharedPreferencesProvider);
+    final secureStorage = ref.read(secureStorageProvider);
     final previousUrl = prefs.getString('server_base_url')?.trim() ?? '';
-    final previousApiKey = prefs.getString('server_api_key')?.trim() ?? '';
+    final previousApiKey = await secureStorage.read(key: 'server_api_key') ?? '';
     final newApiKey = _apiKeyController.text.trim();
 
     await prefs.setString('server_base_url', normalizedUrl);
-    await prefs.setString('server_api_key', newApiKey);
+    if (newApiKey.isEmpty) {
+      await secureStorage.delete(key: 'server_api_key');
+    } else {
+      await secureStorage.write(key: 'server_api_key', value: newApiKey);
+    }
+    ref.read(serverApiKeyInternalProvider.notifier).state = newApiKey;
 
     ref.read(sharedPreferencesTriggerProvider.notifier).trigger();
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'features/navigation/presentation/router.dart';
+import 'core/data/graphql/graphql_client.dart';
+import 'core/data/preferences/secure_storage_provider.dart';
 import 'core/data/preferences/shared_preferences_provider.dart';
 import 'core/utils/app_log_store.dart';
 import 'core/utils/pip_mode.dart';
@@ -58,6 +61,21 @@ Future<void> main() async {
 
   final sharedPreferences = await SharedPreferences.getInstance();
 
+  const secureStorage = FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
+
+  // Migrate API key from SharedPreferences to Secure Storage if needed.
+  if (sharedPreferences.containsKey('server_api_key')) {
+    final oldApiKey = sharedPreferences.getString('server_api_key');
+    if (oldApiKey != null && oldApiKey.isNotEmpty) {
+      await secureStorage.write(key: 'server_api_key', value: oldApiKey);
+    }
+    await sharedPreferences.remove('server_api_key');
+  }
+
+  final initialApiKey = await secureStorage.read(key: 'server_api_key') ?? '';
+
   final oldDebugPrint = debugPrint;
   debugPrint = (String? message, {int? wrapWidth}) {
     if (message != null) {
@@ -83,6 +101,8 @@ Future<void> main() async {
     ProviderScope(
       overrides: [
         sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+        secureStorageProvider.overrideWithValue(secureStorage),
+        serverApiKeyInternalProvider.overrideWith((ref) => initialApiKey),
       ],
       child: const MyApp(),
     ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -395,6 +395,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.1"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: da922f2aab2d733db7e011a6bcc4a825b844892d4edd6df83ff156b09a9b2e40
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "8878c25136a79def1668c75985e8e193d9d7d095453ec28730da0315dc69aee3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: "2b5c76dce569ab752d55a1cee6a2242bcc11fdba927078fb88c503f150767cda"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: "6a1137df62b84b54261dca582c1c09ea72f4f9a4b2fcee21b025964132d5d0c3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   flutter_staggered_grid_view:
     dependency: "direct main"
     description:
@@ -747,10 +795,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1264,26 +1312,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   http: ^1.6.0
   flutter_staggered_grid_view: ^0.7.0
   extended_image: ^10.0.1
+  flutter_secure_storage: ^10.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Migrates the plaintext API key to flutter_secure_storage, preventing it from being leaked via device backups or unencrypted local storage extraction. This represents a significant security enhancement for sensitive credentials.

---
*PR created automatically by Jules for task [1153036297473441339](https://jules.google.com/task/1153036297473441339) started by @Alchemist-Aloha*