### PR TITLE
🎨 Palette: Add accessibility tooltips to icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-10 - Adding Tooltips to Icon Buttons
+**Learning:** Icon-only buttons (`IconButton` without text) require the `tooltip` property to ensure accessibility. This property acts as an accessible label for screen readers and provides hover text for mouse users.
+**Action:** Always check `IconButton` widgets to ensure they have a descriptive `tooltip` property.

--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -398,6 +398,7 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                 actions: [
                   if (_isSearching)
                     IconButton(
+                      tooltip: 'Close search',
                       icon: const Icon(Icons.close),
                       onPressed: () {
                         setState(() => _isSearching = false);

--- a/lib/core/presentation/widgets/rating_bottom_sheet.dart
+++ b/lib/core/presentation/widgets/rating_bottom_sheet.dart
@@ -63,6 +63,7 @@ class RatingBottomSheet extends StatelessWidget {
                 final starValue = (index + 1) * 20;
                 final isSelected = initialRating >= starValue;
                 return IconButton(
+                  tooltip: 'Rate ${index + 1} ${index == 0 ? 'star' : 'stars'}',
                   icon: Icon(
                     isSelected ? Icons.star : Icons.star_border,
                     size: 48,

--- a/lib/features/scenes/presentation/widgets/entity_picker.dart
+++ b/lib/features/scenes/presentation/widgets/entity_picker.dart
@@ -76,6 +76,7 @@ class _EntityPickerState<T> extends ConsumerState<EntityPicker<T>> {
                 hintText: 'Search...',
                 prefixIcon: const Icon(Icons.search),
                 suffixIcon: IconButton(
+                  tooltip: 'Clear search',
                   icon: const Icon(Icons.clear),
                   onPressed: () {
                     _searchController.clear();

--- a/lib/features/scenes/presentation/widgets/scene_card.dart
+++ b/lib/features/scenes/presentation/widgets/scene_card.dart
@@ -173,6 +173,7 @@ class SceneCard extends ConsumerWidget {
                   ),
                 ),
                 IconButton(
+                  tooltip: 'More options',
                   padding: EdgeInsets.zero,
                   constraints: const BoxConstraints(),
                   onPressed: () => _showMenu(context, ref),
@@ -273,6 +274,7 @@ class SceneCard extends ConsumerWidget {
                   ),
                 ),
                 IconButton(
+                  tooltip: 'More options',
                   padding: EdgeInsets.zero,
                   constraints: const BoxConstraints(),
                   onPressed: () => _showMenu(context, ref),


### PR DESCRIPTION
## 🎨 Palette: Add accessibility tooltips to icon buttons

### 💡 What
Added the `tooltip` property to several `IconButton` components throughout the application that were previously missing them.

### 🎯 Why
Icon-only buttons rely entirely on their visual representation, which can be inaccessible to users reliant on screen readers and unintuitive for mouse users without hover text. Adding `tooltip` properties serves a dual purpose in Flutter: it acts as a semantic accessibility label (`aria-label` equivalent) for screen readers and displays a helpful native tooltip on long-press/hover.

### ♿ Accessibility
This change provides semantic labels to interactive, icon-only components, directly improving the app's overall accessibility.

Affected locations:
- `lib/core/presentation/widgets/list_page_scaffold.dart` (Close Search)
- `lib/features/scenes/presentation/widgets/scene_card.dart` (More Options menu)
- `lib/core/presentation/widgets/rating_bottom_sheet.dart` (Dynamic star rating)
- `lib/features/scenes/presentation/widgets/entity_picker.dart` (Clear Search)

---
*PR created automatically by Jules for task [17856815552213292511](https://jules.google.com/task/17856815552213292511) started by @Alchemist-Aloha*