### PR TITLE
🎨 Palette: Add tooltip to API key visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-17 - [Added Tooltip to API Key Visibility Toggle]
+**Learning:** Icon-only buttons used for input field toggles (like obscuring text) need tooltips for accessibility, acting as both an ARIA-like label for screen readers and helpful context for mouse users.
+**Action:** Always verify that 'suffixIcon' widgets in forms have an associated 'tooltip' property explaining their function.

--- a/lib/features/setup/presentation/pages/settings/server_settings_page.dart
+++ b/lib/features/setup/presentation/pages/settings/server_settings_page.dart
@@ -262,6 +262,7 @@ class _ServerSettingsPageState extends ConsumerState<ServerSettingsPage> {
                             labelText: 'API key',
                             hintText: 'Paste ApiKey header value',
                             suffixIcon: IconButton(
+                              tooltip: 'Toggle API key visibility',
                               icon: Icon(
                                 _obscureApiKey
                                     ? Icons.visibility_off


### PR DESCRIPTION
💡 What: Added a `tooltip` to the `IconButton` used to toggle the visibility of the API key in the Server Settings page.
🎯 Why: To provide a descriptive label for screen readers and helpful context on hover for mouse users.
📸 Before/After: Visual change only on hover.
♿ Accessibility: Improved screen reader accessibility for the icon-only toggle button.

---
*PR created automatically by Jules for task [2832656447143562961](https://jules.google.com/task/2832656447143562961) started by @Alchemist-Aloha*