### PR TITLE
🧹 Refactor: Simplify ListPageScaffold Layout Logic

### DIFF
--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -359,6 +359,91 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
     }
   }
 
+  Widget _buildGridView(
+    BuildContext context,
+    List<T> items,
+    int? memCacheWidth,
+  ) {
+    return GridView.builder(
+      controller: widget.scrollController,
+      padding: widget.padding,
+      gridDelegate: _getResponsiveGridDelegate(context),
+      itemCount: items.length,
+      itemBuilder: (context, index) {
+        if (index == 0 &&
+            widget.imageUrlBuilder != null &&
+            _measuredItemExtent == null) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (_measuredItemExtent == null &&
+                _firstItemKey.currentContext != null) {
+              final size = _firstItemKey.currentContext!.size;
+              if (size != null) {
+                setState(() {
+                  _measuredItemExtent = size.height;
+                });
+              }
+            }
+          });
+        }
+
+        return RepaintBoundary(
+          child: KeyedSubtree(
+            key: index == 0 ? _firstItemKey : null,
+            child: widget.itemBuilder!(
+              context,
+              items[index],
+              memCacheWidth,
+              null,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildListView(
+    BuildContext context,
+    List<T> items,
+    int? memCacheWidth,
+  ) {
+    return ListView.builder(
+      controller: widget.scrollController,
+      padding: widget.padding,
+      itemCount: items.length,
+      itemExtent: widget.itemExtent,
+      itemBuilder: (context, index) {
+        if (index == 0 &&
+            widget.imageUrlBuilder != null &&
+            widget.itemExtent == null &&
+            _measuredItemExtent == null) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (_measuredItemExtent == null &&
+                _firstItemKey.currentContext != null) {
+              final size = _firstItemKey.currentContext!.size;
+              if (size != null) {
+                setState(() {
+                  _measuredItemExtent = size.height;
+                });
+              }
+            }
+          });
+        }
+
+        return RepaintBoundary(
+          child: KeyedSubtree(
+            key: index == 0 ? _firstItemKey : null,
+            child: widget.itemBuilder!(
+              context,
+              items[index],
+              memCacheWidth,
+              null,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -484,83 +569,8 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                 Widget body =
                     widget.customBody ??
                     (widget.gridDelegate != null
-                        ? GridView.builder(
-                            controller: widget.scrollController,
-                            padding: widget.padding,
-                            gridDelegate: _getResponsiveGridDelegate(context),
-                            itemCount: items.length,
-                            itemBuilder: (context, index) {
-                              if (index == 0 &&
-                                  widget.imageUrlBuilder != null &&
-                                  _measuredItemExtent == null) {
-                                WidgetsBinding.instance.addPostFrameCallback((
-                                  _,
-                                ) {
-                                  if (_measuredItemExtent == null &&
-                                      _firstItemKey.currentContext != null) {
-                                    final size =
-                                        _firstItemKey.currentContext!.size;
-                                    if (size != null) {
-                                      setState(() {
-                                        _measuredItemExtent = size.height;
-                                      });
-                                    }
-                                  }
-                                });
-                              }
-
-                              return RepaintBoundary(
-                                child: KeyedSubtree(
-                                  key: index == 0 ? _firstItemKey : null,
-                                  child: widget.itemBuilder!(
-                                    context,
-                                    items[index],
-                                    memCacheWidth,
-                                    null,
-                                  ),
-                                ),
-                              );
-                            },
-                          )
-                        : ListView.builder(
-                            controller: widget.scrollController,
-                            padding: widget.padding,
-                            itemCount: items.length,
-                            itemExtent: widget.itemExtent,
-                            itemBuilder: (context, index) {
-                              if (index == 0 &&
-                                  widget.imageUrlBuilder != null &&
-                                  widget.itemExtent == null &&
-                                  _measuredItemExtent == null) {
-                                WidgetsBinding.instance.addPostFrameCallback((
-                                  _,
-                                ) {
-                                  if (_measuredItemExtent == null &&
-                                      _firstItemKey.currentContext != null) {
-                                    final size =
-                                        _firstItemKey.currentContext!.size;
-                                    if (size != null) {
-                                      setState(() {
-                                        _measuredItemExtent = size.height;
-                                      });
-                                    }
-                                  }
-                                });
-                              }
-
-                              return RepaintBoundary(
-                                child: KeyedSubtree(
-                                  key: index == 0 ? _firstItemKey : null,
-                                  child: widget.itemBuilder!(
-                                    context,
-                                    items[index],
-                                    memCacheWidth,
-                                    null,
-                                  ),
-                                ),
-                              );
-                            },
-                          ));
+                        ? _buildGridView(context, items, memCacheWidth)
+                        : _buildListView(context, items, memCacheWidth));
 
                 if (widget.onRefresh != null) {
                   body = RefreshIndicator(


### PR DESCRIPTION
🎯 **What:** Extracted `GridView.builder` and `ListView.builder` inside `ListPageScaffold`'s `build` method into `_buildGridView` and `_buildListView` helper methods.
💡 **Why:** The original `build` method was becoming overly complex and long due to the inline handling of scroll behaviors and grid/list delegates. Splitting these into dedicated helper methods significantly improves readability and maintainability.
✅ **Verification:** Verified by running `dart format`, manually checking the file contents, and successfully running the full test suite via `flutter test`.
✨ **Result:** The `build` method is now much more concise and the rendering logic is cleanly modularized into well-named private methods.

---
*PR created automatically by Jules for task [6654172429496820057](https://jules.google.com/task/6654172429496820057) started by @Alchemist-Aloha*