### PR TITLE
🎨 Palette: Add tooltips to visibility toggles in server settings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - Tooltips for Dynamic State Toggles
+**Learning:** In Flutter, adding a `tooltip` to an `IconButton` automatically sets its semantic accessibility label for screen readers. For dynamic state toggles like password visibility (`_obscurePassword`), the tooltip must conditionally update its text (e.g., 'Show password' vs 'Hide password') to maintain accurate screen reader announcements matching the visual state.
+**Action:** When adding or reviewing tooltips on toggle buttons, always ensure the tooltip text dynamically reflects the active state rather than using a static label.

--- a/lib/features/setup/presentation/pages/settings/server_settings_page.dart
+++ b/lib/features/setup/presentation/pages/settings/server_settings_page.dart
@@ -412,6 +412,9 @@ class _ServerSettingsPageState extends ConsumerState<ServerSettingsPage> {
                               labelText: 'API key',
                               hintText: 'Paste ApiKey header value',
                               suffixIcon: IconButton(
+                                tooltip: _obscureApiKey
+                                    ? 'Show API key'
+                                    : 'Hide API key',
                                 icon: Icon(
                                   _obscureApiKey
                                       ? Icons.visibility_off
@@ -451,6 +454,9 @@ class _ServerSettingsPageState extends ConsumerState<ServerSettingsPage> {
                             decoration: InputDecoration(
                               labelText: 'Password',
                               suffixIcon: IconButton(
+                                tooltip: _obscurePassword
+                                    ? 'Show password'
+                                    : 'Hide password',
                                 icon: Icon(
                                   _obscurePassword
                                       ? Icons.visibility_off


### PR DESCRIPTION
🎨 Palette: Add ARIA/semantic tooltips to visibility toggle buttons

💡 What: Added dynamic `tooltip` properties to the visibility toggle `IconButton`s for the API key and Password fields on the Server Settings page.
🎯 Why: Without tooltips, icon-only buttons lack semantic meaning for screen readers, and desktop users don't see descriptive hover text. This ensures both visual and assistive technology users understand the button's function and its current state.
♿ Accessibility: The added tooltips conditionally reflect the active state ('Show password' vs 'Hide password'), automatically updating the screen reader announcement when toggled.

---
*PR created automatically by Jules for task [4481515030222825512](https://jules.google.com/task/4481515030222825512) started by @Alchemist-Aloha*