### PR TITLE
⚡ Bolt: Hoist layout calculations from images page itemBuilder

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -6,3 +6,6 @@
 ## 2024-05-29 - [Hoist Invariant Layout Calculations from itemBuilder]
 **Learning:** Performing invariant layout calculations (e.g., `MediaQuery.sizeOf(context)` or creating grid delegates) inside Flutter's `ListView.builder` or `GridView.builder` `itemBuilder` callbacks is an O(N) operation that applies significant GC pressure during scrolling.
 **Action:** Always hoist invariant variables and layout calculations out of `itemBuilder` loops up to the `build` method.
+## 2024-05-30 - [Hoist Invariant Calculations from SliverMasonryGrid itemBuilder]
+**Learning:** Just like with ListView.builder, performing invariant calculations like MediaQuery.sizeOf(context) inside SliverMasonryGrid.count's itemBuilder causes an O(N) performance bottleneck during fast scroll events due to continuous redundant math operations and inherited widget lookups.
+**Action:** Always hoist invariant layout variables out of the itemBuilder and into the parent build method to ensure O(1) performance.

--- a/lib/features/images/presentation/pages/images_page.dart
+++ b/lib/features/images/presentation/pages/images_page.dart
@@ -272,6 +272,11 @@ class _ImagesPageState extends ConsumerState<ImagesPage> {
 
     final randomNavigationEnabled = ref.watch(randomNavigationEnabledProvider);
 
+    // Hoist invariant layout calculations out of the itemBuilder loop
+    // to prevent O(N) redundant calculations during scroll events.
+    final screenWidth = MediaQuery.sizeOf(context).width;
+    final memCacheWidth = (screenWidth / crossAxisCount * 1.5).toInt();
+
     return ListPageScaffold<entity.Image>(
       title: 'Images',
       imageUrlBuilder: (img) => img.paths.thumbnail,
@@ -374,10 +379,6 @@ class _ImagesPageState extends ConsumerState<ImagesPage> {
               itemBuilder: (context, index) {
                 final items = imagesAsync.value ?? [];
                 if (index >= items.length) return const SizedBox.shrink();
-
-                final screenWidth = MediaQuery.sizeOf(context).width;
-                final memCacheWidth = (screenWidth / crossAxisCount * 1.5)
-                    .toInt();
 
                 return RepaintBoundary(
                   child: ImageCard(


### PR DESCRIPTION
- **What:** Hoisted `MediaQuery.sizeOf(context)` and `memCacheWidth` calculations out of the `SliverMasonryGrid.count` `itemBuilder` and into the parent `build` method within `lib/features/images/presentation/pages/images_page.dart`.
- **Why:** The `itemBuilder` callback is executed repeatedly for every visible item during scroll events. Recalculating invariant properties like screen width inside this loop causes an O(N) performance bottleneck via continuous redundant math operations and inherited widget lookups, causing GC pressure and potential frame drops.
- **Impact:** Transforms layout calculation complexity within the scroll area from O(N) to O(1), directly reducing GC pressure and frame render time during fast scrolls.
- **Measurement:** Run the Flutter performance profiler while scrolling rapidly through the Images page on a device with a large image count; observe reduced CPU time spent in layout calculation.

---
*PR created automatically by Jules for task [12822960733452386949](https://jules.google.com/task/12822960733452386949) started by @Alchemist-Aloha*