### PR TITLE
⚡ Bolt: Use MediaQuery.sizeOf() to prevent unnecessary rebuilds

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-30 - [Hoist Invariant Calculations from SliverMasonryGrid itemBuilder]
 **Learning:** Just like with ListView.builder, performing invariant calculations like MediaQuery.sizeOf(context) inside SliverMasonryGrid.count's itemBuilder causes an O(N) performance bottleneck during fast scroll events due to continuous redundant math operations and inherited widget lookups.
 **Action:** Always hoist invariant layout variables out of the itemBuilder and into the parent build method to ensure O(1) performance.
+
+## 2024-06-03 - [Use MediaQuery.sizeOf over MediaQuery.of]
+**Learning:** Using `MediaQuery.of(context).size` inside a widget `build` method binds that widget to the entire `MediaQueryData` object. This causes the widget to rebuild whenever *any* property of `MediaQueryData` changes (like `viewInsets` when a keyboard appears, or text scaling), even if the screen `size` itself hasn't changed.
+**Action:** Always use specific getters like `MediaQuery.sizeOf(context)`, `MediaQuery.paddingOf(context)`, etc., to restrict dependencies strictly to the needed properties and avoid unnecessary rebuilds.

--- a/lib/features/galleries/presentation/pages/galleries_page.dart
+++ b/lib/features/galleries/presentation/pages/galleries_page.dart
@@ -185,7 +185,8 @@ class _GalleriesPageState extends ConsumerState<GalleriesPage> {
                     Flexible(
                       child: ConstrainedBox(
                         constraints: BoxConstraints(
-                          maxHeight: MediaQuery.of(context).size.height * 0.35,
+                          // Use sizeOf to prevent unnecessary rebuilds on other MediaQuery changes
+                          maxHeight: MediaQuery.sizeOf(context).height * 0.35,
                         ),
                         child: Scrollbar(
                           thumbVisibility: true,

--- a/lib/features/images/presentation/pages/images_page.dart
+++ b/lib/features/images/presentation/pages/images_page.dart
@@ -189,7 +189,8 @@ class _ImagesPageState extends ConsumerState<ImagesPage> {
                     Flexible(
                       child: ConstrainedBox(
                         constraints: BoxConstraints(
-                          maxHeight: MediaQuery.of(context).size.height * 0.35,
+                          // Use sizeOf to prevent unnecessary rebuilds on other MediaQuery changes
+                          maxHeight: MediaQuery.sizeOf(context).height * 0.35,
                         ),
                         child: Scrollbar(
                           thumbVisibility: true,

--- a/lib/features/performers/presentation/pages/performers_page.dart
+++ b/lib/features/performers/presentation/pages/performers_page.dart
@@ -234,7 +234,8 @@ class _PerformersPageState extends ConsumerState<PerformersPage> {
                 Flexible(
                   child: ConstrainedBox(
                     constraints: BoxConstraints(
-                      maxHeight: MediaQuery.of(context).size.height * 0.35,
+                      // Use sizeOf to prevent unnecessary rebuilds on other MediaQuery changes
+                      maxHeight: MediaQuery.sizeOf(context).height * 0.35,
                     ),
                     child: Scrollbar(
                       thumbVisibility: true,

--- a/lib/features/scenes/presentation/pages/scenes_page.dart
+++ b/lib/features/scenes/presentation/pages/scenes_page.dart
@@ -278,7 +278,8 @@ class _ScenesPageState extends ConsumerState<ScenesPage> {
                     Flexible(
                       child: ConstrainedBox(
                         constraints: BoxConstraints(
-                          maxHeight: MediaQuery.of(context).size.height * 0.35,
+                          // Use sizeOf to prevent unnecessary rebuilds on other MediaQuery changes
+                          maxHeight: MediaQuery.sizeOf(context).height * 0.35,
                         ),
                         child: Scrollbar(
                           thumbVisibility: true,
@@ -441,7 +442,8 @@ class _ScenesPageState extends ConsumerState<ScenesPage> {
         if (!isGrid) return 640;
         final padding = AppTheme.spacingSmall * 2;
         final crossAxisCount = _getGridColumnCount(context);
-        final availableWidth = MediaQuery.of(context).size.width - padding;
+        // Use sizeOf to prevent unnecessary rebuilds on other MediaQuery changes
+        final availableWidth = MediaQuery.sizeOf(context).width - padding;
         final itemWidth =
             (availableWidth - (AppTheme.spacingSmall * (crossAxisCount - 1))) /
             crossAxisCount;

--- a/lib/features/scenes/presentation/widgets/entity_picker.dart
+++ b/lib/features/scenes/presentation/widgets/entity_picker.dart
@@ -68,7 +68,8 @@ class _EntityPickerState<T> extends ConsumerState<EntityPicker<T>> {
       contentPadding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
       content: SizedBox(
         width: double.maxFinite,
-        height: MediaQuery.of(context).size.height * 0.6,
+        // Use sizeOf to prevent unnecessary rebuilds on other MediaQuery changes
+        height: MediaQuery.sizeOf(context).height * 0.6,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/features/studios/presentation/pages/studios_page.dart
+++ b/lib/features/studios/presentation/pages/studios_page.dart
@@ -165,7 +165,8 @@ class _StudiosPageState extends ConsumerState<StudiosPage> {
                 Flexible(
                   child: ConstrainedBox(
                     constraints: BoxConstraints(
-                      maxHeight: MediaQuery.of(context).size.height * 0.35,
+                      // Use sizeOf to prevent unnecessary rebuilds on other MediaQuery changes
+                      maxHeight: MediaQuery.sizeOf(context).height * 0.35,
                     ),
                     child: Scrollbar(
                       thumbVisibility: true,

--- a/lib/features/tags/presentation/pages/tags_page.dart
+++ b/lib/features/tags/presentation/pages/tags_page.dart
@@ -164,7 +164,8 @@ class _TagsPageState extends ConsumerState<TagsPage> {
                 Flexible(
                   child: ConstrainedBox(
                     constraints: BoxConstraints(
-                      maxHeight: MediaQuery.of(context).size.height * 0.35,
+                      // Use sizeOf to prevent unnecessary rebuilds on other MediaQuery changes
+                      maxHeight: MediaQuery.sizeOf(context).height * 0.35,
                     ),
                     child: Scrollbar(
                       thumbVisibility: true,


### PR DESCRIPTION
💡 **What:** Replaced `MediaQuery.of(context).size` with `MediaQuery.sizeOf(context)` in multiple list/grid pages and picker dialogs.

🎯 **Why:** `MediaQuery.of(context)` registers a dependency on the entire `MediaQueryData` object. This causes widgets to rebuild unnecessarily whenever *any* unrelated property changes (such as `viewInsets` when a keyboard appears, or text scaling factors). Using `MediaQuery.sizeOf(context)` correctly narrows the dependency down to just the size.

📊 **Impact:** Reduces unnecessary UI re-renders, especially during keyboard interactions or platform-level changes, leading to smoother UI performance.

🔬 **Measurement:** Verify by placing a `print` statement in the `build` method of `EntityPicker` or `ScenesPage` and toggling the keyboard. The print should not trigger with the updated code.

---
*PR created automatically by Jules for task [6361592815456748352](https://jules.google.com/task/6361592815456748352) started by @Alchemist-Aloha*