### PR TITLE
🎨 Palette: Localize tooltips for IconButtons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-02-28 - Tooltips for Dynamic State Toggles
 **Learning:** In Flutter, adding a `tooltip` to an `IconButton` automatically sets its semantic accessibility label for screen readers. For dynamic state toggles like password visibility (`_obscurePassword`), the tooltip must conditionally update its text (e.g., 'Show password' vs 'Hide password') to maintain accurate screen reader announcements matching the visual state.
 **Action:** When adding or reviewing tooltips on toggle buttons, always ensure the tooltip text dynamically reflects the active state rather than using a static label.
+## 2024-05-19 - Localized Icon Tooltips
+**Learning:** Hardcoded strings in Flutter tooltips bypass localization mechanisms and result in inconsistent accessibility labeling for screen readers. In `stash_app_flutter`, `IconButton.tooltip` maps to ARIA labels.
+**Action:** Always verify `tooltip` strings use `context.l10n.[key]` rather than literal strings, and proactively sweep UI files (e.g., list pages and details pages) for typoed or hardcoded tooltips to maintain semantic a11y.

--- a/lib/features/galleries/presentation/pages/galleries_page.dart
+++ b/lib/features/galleries/presentation/pages/galleries_page.dart
@@ -370,7 +370,7 @@ class _GalleriesPageState extends ConsumerState<GalleriesPage> {
         Stack(
           children: [
             IconButton(
-              tooltip: 'Filter List',
+              tooltip: context.l10n.common_filter,
               icon: const Icon(Icons.filter_list),
               onPressed: _showFilterPanel,
             ),

--- a/lib/features/images/presentation/pages/images_page.dart
+++ b/lib/features/images/presentation/pages/images_page.dart
@@ -375,7 +375,7 @@ class _ImagesPageState extends ConsumerState<ImagesPage> {
         Stack(
           children: [
             IconButton(
-              tooltip: 'Filter List',
+              tooltip: context.l10n.common_filter,
               icon: const Icon(Icons.filter_list),
               onPressed: _showFilterPanel,
             ),

--- a/lib/features/performers/presentation/pages/performer_details_page.dart
+++ b/lib/features/performers/presentation/pages/performer_details_page.dart
@@ -75,7 +75,7 @@ class PerformerDetailsPage extends ConsumerWidget {
           if (scrapeEnabled)
             performerAsync.maybeWhen(
               data: (performer) => IconButton(
-                tooltip: 'Editd',
+                tooltip: context.l10n.common_edit,
                 icon: const Icon(Icons.edit_outlined),
                 onPressed: () => context.push(
                   '/performers/performer/${performer.id}/edit',

--- a/lib/features/scenes/presentation/pages/scene_details_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_details_page.dart
@@ -194,7 +194,7 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
           if (scrapeEnabled)
             sceneAsync.maybeWhen(
               data: (scene) => IconButton(
-                tooltip: 'Editd',
+                tooltip: context.l10n.common_edit,
                 icon: const Icon(Icons.edit_outlined),
                 onPressed: () => context.push(
                   '/scenes/scene/${scene.id}/edit',

--- a/lib/features/scenes/presentation/pages/scenes_page.dart
+++ b/lib/features/scenes/presentation/pages/scenes_page.dart
@@ -481,7 +481,7 @@ class _ScenesPageState extends ConsumerState<ScenesPage> {
         Stack(
           children: [
             IconButton(
-              tooltip: 'Filter List',
+              tooltip: context.l10n.common_filter,
               icon: const Icon(Icons.filter_list),
               onPressed: _showFilterPanel,
             ),

--- a/lib/features/studios/presentation/pages/studio_details_page.dart
+++ b/lib/features/studios/presentation/pages/studio_details_page.dart
@@ -55,7 +55,7 @@ class StudioDetailsPage extends ConsumerWidget {
           if (scrapeEnabled)
             studioAsync.maybeWhen(
               data: (studio) => IconButton(
-                tooltip: 'Editd',
+                tooltip: context.l10n.common_edit,
                 icon: const Icon(Icons.edit_outlined),
                 onPressed: () => context.push(
                   '/studios/studio/${studio.id}/edit',


### PR DESCRIPTION
💡 **What:** Fixed typoed and hardcoded tooltips for IconButtons across several pages. Replaced "Editd" with `context.l10n.common_edit` and "Filter List" with `context.l10n.common_filter`.
🎯 **Why:** Hardcoded strings bypass the app's localization mechanisms, leading to inconsistent experiences for users in different languages.
📸 **Before/After:** N/A (Visuals remain same in English, but localized properly elsewhere, and tooltip typo is fixed)
♿ **Accessibility:** `IconButton` tooltips serve as semantic labels for screen readers. Using proper localization ensures screen reader users receive accurately translated and correctly spelled ARIA-equivalent labels.

---
*PR created automatically by Jules for task [10582405025476016056](https://jules.google.com/task/10582405025476016056) started by @Alchemist-Aloha*