### PR TITLE
⚡ Bolt: [performance improvement] Replace MediaQuery.of(context).size with MediaQuery.sizeOf(context)

### DIFF
--- a/lib/features/galleries/presentation/pages/galleries_page.dart
+++ b/lib/features/galleries/presentation/pages/galleries_page.dart
@@ -185,7 +185,7 @@ class _GalleriesPageState extends ConsumerState<GalleriesPage> {
                     Flexible(
                       child: ConstrainedBox(
                         constraints: BoxConstraints(
-                          maxHeight: MediaQuery.of(context).size.height * 0.35,
+                          maxHeight: MediaQuery.sizeOf(context).height * 0.35,
                         ),
                         child: Scrollbar(
                           thumbVisibility: true,

--- a/lib/features/images/presentation/pages/images_page.dart
+++ b/lib/features/images/presentation/pages/images_page.dart
@@ -189,7 +189,7 @@ class _ImagesPageState extends ConsumerState<ImagesPage> {
                     Flexible(
                       child: ConstrainedBox(
                         constraints: BoxConstraints(
-                          maxHeight: MediaQuery.of(context).size.height * 0.35,
+                          maxHeight: MediaQuery.sizeOf(context).height * 0.35,
                         ),
                         child: Scrollbar(
                           thumbVisibility: true,

--- a/lib/features/performers/presentation/pages/performers_page.dart
+++ b/lib/features/performers/presentation/pages/performers_page.dart
@@ -234,7 +234,7 @@ class _PerformersPageState extends ConsumerState<PerformersPage> {
                 Flexible(
                   child: ConstrainedBox(
                     constraints: BoxConstraints(
-                      maxHeight: MediaQuery.of(context).size.height * 0.35,
+                      maxHeight: MediaQuery.sizeOf(context).height * 0.35,
                     ),
                     child: Scrollbar(
                       thumbVisibility: true,

--- a/lib/features/scenes/presentation/pages/scenes_page.dart
+++ b/lib/features/scenes/presentation/pages/scenes_page.dart
@@ -278,7 +278,7 @@ class _ScenesPageState extends ConsumerState<ScenesPage> {
                     Flexible(
                       child: ConstrainedBox(
                         constraints: BoxConstraints(
-                          maxHeight: MediaQuery.of(context).size.height * 0.35,
+                          maxHeight: MediaQuery.sizeOf(context).height * 0.35,
                         ),
                         child: Scrollbar(
                           thumbVisibility: true,
@@ -441,7 +441,7 @@ class _ScenesPageState extends ConsumerState<ScenesPage> {
         if (!isGrid) return 640;
         final padding = AppTheme.spacingSmall * 2;
         final crossAxisCount = _getGridColumnCount(context);
-        final availableWidth = MediaQuery.of(context).size.width - padding;
+        final availableWidth = MediaQuery.sizeOf(context).width - padding;
         final itemWidth =
             (availableWidth - (AppTheme.spacingSmall * (crossAxisCount - 1))) /
             crossAxisCount;

--- a/lib/features/scenes/presentation/widgets/entity_picker.dart
+++ b/lib/features/scenes/presentation/widgets/entity_picker.dart
@@ -68,7 +68,7 @@ class _EntityPickerState<T> extends ConsumerState<EntityPicker<T>> {
       contentPadding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
       content: SizedBox(
         width: double.maxFinite,
-        height: MediaQuery.of(context).size.height * 0.6,
+        height: MediaQuery.sizeOf(context).height * 0.6,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/features/studios/presentation/pages/studios_page.dart
+++ b/lib/features/studios/presentation/pages/studios_page.dart
@@ -165,7 +165,7 @@ class _StudiosPageState extends ConsumerState<StudiosPage> {
                 Flexible(
                   child: ConstrainedBox(
                     constraints: BoxConstraints(
-                      maxHeight: MediaQuery.of(context).size.height * 0.35,
+                      maxHeight: MediaQuery.sizeOf(context).height * 0.35,
                     ),
                     child: Scrollbar(
                       thumbVisibility: true,

--- a/lib/features/tags/presentation/pages/tags_page.dart
+++ b/lib/features/tags/presentation/pages/tags_page.dart
@@ -164,7 +164,7 @@ class _TagsPageState extends ConsumerState<TagsPage> {
                 Flexible(
                   child: ConstrainedBox(
                     constraints: BoxConstraints(
-                      maxHeight: MediaQuery.of(context).size.height * 0.35,
+                      maxHeight: MediaQuery.sizeOf(context).height * 0.35,
                     ),
                     child: Scrollbar(
                       thumbVisibility: true,


### PR DESCRIPTION
💡 What: Replaces `MediaQuery.of(context).size` with `MediaQuery.sizeOf(context)` across several presentation pages.
🎯 Why: `MediaQuery.of(context)` causes the widget to rebuild whenever *any* property of `MediaQueryData` changes (e.g., keyboard appearing, text scale factor changing). `MediaQuery.sizeOf(context)` narrows the dependency so the widget only rebuilds when the screen size actually changes.
📊 Impact: Reduces unnecessary widget rebuilds, particularly when the keyboard opens or closes, improving UI responsiveness.
🔬 Measurement: Verify by checking Flutter performance overlay and observing widget rebuild counts in Dart DevTools when triggering view insets changes (e.g. opening the keyboard).

---
*PR created automatically by Jules for task [10671466351645775605](https://jules.google.com/task/10671466351645775605) started by @Alchemist-Aloha*