### PR TITLE
🎨 Palette: [UX improvement] Add play button tooltip for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 ## 2024-05-24 - Added Tooltips to Close Buttons
 **Learning:** In a heavily reusable widget like `ListPageScaffold`, missing tooltips on interactive elements like search history removal or query clearing degrade accessibility across many screens. It's crucial to inspect nested builders (like `SearchAnchor`'s viewBuilder) for `IconButton` usage without tooltips.
 **Action:** When creating robust wrapper layouts, verify that dynamic icons (e.g., clearing inputs or managing overlays) map their semantic action to localized strings for tooltips to ensure broad screen reader support.
+## 2024-04-23 - Accessibility for non-standard IconButtons
+**Learning:** Even specialized `IconButton` variants like `IconButton.filledTonal` omit tooltips by default. When these are used for primary actions (like the large central play button on a video player), they lack an accessible name for screen readers, violating WCAG requirements.
+**Action:** Always verify that *all* forms of icon-only interactive widgets (e.g., `IconButton.filled`, `IconButton.filledTonal`, `IconButton.outlined`) include a `tooltip` or `semanticLabel` property.

--- a/lib/features/scenes/presentation/widgets/scene_video_player.dart
+++ b/lib/features/scenes/presentation/widgets/scene_video_player.dart
@@ -16,6 +16,7 @@ import '../../../../core/presentation/providers/keybinds_provider.dart';
 import '../../data/repositories/stream_resolver.dart';
 import '../../../../core/data/graphql/media_headers_provider.dart';
 import '../../../../core/utils/app_log_store.dart';
+import '../../../../core/utils/l10n_extensions.dart';
 import '../../../../core/utils/web_helpers.dart';
 import 'native_video_controls.dart';
 import 'scene_subtitle_overlay.dart';
@@ -309,6 +310,7 @@ class _SceneVideoPlayerState extends ConsumerState<SceneVideoPlayer> {
                 child: _isStarting
                     ? const CircularProgressIndicator()
                     : IconButton.filledTonal(
+                          tooltip: context.l10n.common_play,
                         style: IconButton.styleFrom(
                           backgroundColor: colorScheme.surfaceContainerHigh
                               .withValues(alpha: 0.92),


### PR DESCRIPTION
💡 **What:** Added a `tooltip` to the primary "Play" button in the scene video player.
🎯 **Why:** To ensure screen readers have an accessible name for the button and desktop users get a helpful hover text.
♿ **Accessibility:** Replaces an unlabeled interactive icon with a semantically labeled one using the app's localized string for "Play".

---
*PR created automatically by Jules for task [8995849158617459512](https://jules.google.com/task/8995849158617459512) started by @Alchemist-Aloha*