### PR TITLE
🎨 Palette: Add missing tooltip to SceneInfoPage close button

### DIFF
--- a/lib/features/scenes/presentation/pages/scene_info_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_info_page.dart
@@ -36,6 +36,7 @@ class SceneInfoPage extends ConsumerWidget {
                   ),
                 ),
                 IconButton(
+                  tooltip: context.l10n.common_close,
                   icon: const Icon(Icons.close),
                   onPressed: () => Navigator.of(context).pop(),
                 ),


### PR DESCRIPTION
💡 What: Added missing `tooltip` to the `IconButton` used to close the `SceneInfoPage` bottom sheet/dialog.
🎯 Why: Makes the UI more accessible for screen readers and improves the desktop experience by providing hover text.
📸 Before/After: Visual text added on hover over the close icon.
♿ Accessibility: The button is now properly labeled with "Close" (localized via `common_close`) instead of being an unlabeled icon-only button.

---
*PR created automatically by Jules for task [3485470144847707923](https://jules.google.com/task/3485470144847707923) started by @Alchemist-Aloha*