### PR TITLE
⚡ Bolt: Optimize ServerProfileDrawer rebuilds using viewInsetsOf

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2024-06-25 - [O(N^2) Scroll Stutter via itemBuilder lookups]
 **Learning:** Performing an `O(N)` list scan like `indexWhere` inside a Flutter `itemBuilder` callback causes massive O(N^2) scaling issues when the user scrolls through long lists. Similarly, evaluating fallbacks like `images ?? []` repeatedly causes needless GC pressure.
 **Action:** Always pre-compute a lookup map (like `{for (var i=0; i<list.length; i++) list[i].id: i}`) in the parent `build` method before passing data to `itemBuilder`, ensuring O(1) lookups during the render phase. Hoist all possible allocations out of the builder.
+## 2024-07-25 - [MediaQuery.of(context) Over-Rebuilding]
+**Learning:** Using `MediaQuery.of(context).viewInsets` binds the widget to the entire `MediaQueryData` object, triggering an unnecessary rebuild whenever any unrelated property changes (like screen size or orientation).
+**Action:** Always use granular MediaQuery methods like `MediaQuery.viewInsetsOf(context)` to isolate dependencies to only the properties the widget actually uses.

--- a/lib/features/setup/presentation/widgets/server_profile_drawer.dart
+++ b/lib/features/setup/presentation/widgets/server_profile_drawer.dart
@@ -211,7 +211,9 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
     
     return Container(
       padding: EdgeInsets.only(
-        bottom: MediaQuery.of(context).viewInsets.bottom,
+        // Using MediaQuery.viewInsetsOf(context) instead of MediaQuery.of(context).viewInsets
+        // to prevent unnecessary rebuilds when other MediaQuery properties change.
+        bottom: MediaQuery.viewInsetsOf(context).bottom,
       ),
       child: SingleChildScrollView(
         child: Padding(


### PR DESCRIPTION
💡 What: Changed `MediaQuery.of(context).viewInsets.bottom` to `MediaQuery.viewInsetsOf(context).bottom` in `ServerProfileDrawer`.
🎯 Why: `MediaQuery.of(context)` causes the widget to rebuild whenever *any* property of `MediaQueryData` changes (like screen size, orientation, text scale factor). Using `viewInsetsOf` scopes the dependency so the widget only rebuilds when the keyboard appearance actually changes.
📊 Impact: Reduces unnecessary widget rebuilds during generic app-wide layout or accessibility changes.
🔬 Measurement: Verify by triggering keyboard appearance and observing standard behavior without unnecessary redraws on other media query updates.

---
*PR created automatically by Jules for task [598229622743211267](https://jules.google.com/task/598229622743211267) started by @Alchemist-Aloha*