### PR TITLE
🎨 Palette: Add tooltip to password visibility toggles

### DIFF
--- a/lib/features/setup/presentation/widgets/server_profile_drawer.dart
+++ b/lib/features/setup/presentation/widgets/server_profile_drawer.dart
@@ -391,6 +391,7 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
           border: const OutlineInputBorder(),
           suffixIcon: IconButton(
             icon: Icon(_obscureApiKey ? Icons.visibility : Icons.visibility_off),
+            tooltip: _obscureApiKey ? l10n.common_show : l10n.common_hide,
             onPressed: () => setState(() => _obscureApiKey = !_obscureApiKey),
           ),
         ),
@@ -414,6 +415,7 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
               border: const OutlineInputBorder(),
               suffixIcon: IconButton(
                 icon: Icon(_obscurePassword ? Icons.visibility : Icons.visibility_off),
+                tooltip: _obscurePassword ? l10n.common_show : l10n.common_hide,
                 onPressed: () => setState(() => _obscurePassword = !_obscurePassword),
               ),
             ),


### PR DESCRIPTION
💡 What: Added `tooltip` attributes to the "obscure text" toggle buttons in `ServerProfileDrawer` for API Key and Password inputs.
🎯 Why: Without tooltips, icon-only buttons lack an accessible label for screen readers. Adding this makes the form significantly more accessible.
📸 Before/After: Visual presentation remains the same. Desktop users now see "Show" or "Hide" on hover, and screen readers will announce the button action.
♿ Accessibility: Uses existing localized `l10n.common_show` and `l10n.common_hide` to announce the intent of the toggle button based on current state.

---
*PR created automatically by Jules for task [1454219192666383559](https://jules.google.com/task/1454219192666383559) started by @Alchemist-Aloha*