### PR TITLE
Replace hardcoded text with l10n keys

### DIFF
--- a/l10n_untranslated.json
+++ b/l10n_untranslated.json
@@ -1,59 +1,99 @@
 {
   "de": [
+    "common_token",
+    "common_yes",
+    "common_no",
+    "common_clear_history",
     "nPlays",
     "settings_appearance_font_size",
     "settings_appearance_font_size_subtitle"
   ],
 
   "es": [
+    "common_token",
+    "common_yes",
+    "common_no",
+    "common_clear_history",
     "nPlays",
     "settings_appearance_font_size",
     "settings_appearance_font_size_subtitle"
   ],
 
   "fr": [
+    "common_token",
+    "common_yes",
+    "common_no",
+    "common_clear_history",
     "nPlays",
     "settings_appearance_font_size",
     "settings_appearance_font_size_subtitle"
   ],
 
   "it": [
+    "common_token",
+    "common_yes",
+    "common_no",
+    "common_clear_history",
     "nPlays",
     "settings_appearance_font_size",
     "settings_appearance_font_size_subtitle"
   ],
 
   "ja": [
+    "common_token",
+    "common_yes",
+    "common_no",
+    "common_clear_history",
     "nPlays",
     "settings_appearance_font_size",
     "settings_appearance_font_size_subtitle"
   ],
 
   "ko": [
+    "common_token",
+    "common_yes",
+    "common_no",
+    "common_clear_history",
     "nPlays",
     "settings_appearance_font_size",
     "settings_appearance_font_size_subtitle"
   ],
 
   "ru": [
+    "common_token",
+    "common_yes",
+    "common_no",
+    "common_clear_history",
     "nPlays",
     "settings_appearance_font_size",
     "settings_appearance_font_size_subtitle"
   ],
 
   "zh": [
+    "common_token",
+    "common_yes",
+    "common_no",
+    "common_clear_history",
     "nPlays",
     "settings_appearance_font_size",
     "settings_appearance_font_size_subtitle"
   ],
 
   "zh_Hans": [
+    "common_token",
+    "common_yes",
+    "common_no",
+    "common_clear_history",
     "nPlays",
     "settings_appearance_font_size",
     "settings_appearance_font_size_subtitle"
   ],
 
   "zh_Hant": [
+    "common_token",
+    "common_yes",
+    "common_no",
+    "common_clear_history",
     "nPlays",
     "settings_appearance_font_size",
     "settings_appearance_font_size_subtitle"

--- a/lib/core/presentation/widgets/filter_widgets.dart
+++ b/lib/core/presentation/widgets/filter_widgets.dart
@@ -1,3 +1,4 @@
+import 'package:stash_app_flutter/core/utils/l10n_extensions.dart';
 import 'package:flutter/material.dart';
 import '../theme/app_theme.dart';
 import '../../domain/entities/criterion.dart';
@@ -69,7 +70,7 @@ class IntCriterionInput extends StatelessWidget {
               Expanded(
                 child: TextField(
                   keyboardType: TextInputType.number,
-                  decoration: const InputDecoration(hintText: 'Value'),
+                  decoration: InputDecoration(hintText: context.l10n.filter_value),
                   onChanged: (val) {
                     final intVal = int.tryParse(val);
                     if (intVal != null) {
@@ -227,7 +228,7 @@ class StringCriterionInput extends StatelessWidget {
                 Expanded(
                   child: TextFormField(
                     initialValue: value?.value ?? '',
-                    decoration: const InputDecoration(hintText: 'Value'),
+                    decoration: InputDecoration(hintText: context.l10n.filter_value),
                     onChanged: (val) {
                       onChanged(StringCriterion(
                         value: val,
@@ -298,7 +299,7 @@ class DateCriterionInput extends StatelessWidget {
                 Expanded(
                   child: TextFormField(
                     initialValue: value?.value ?? '',
-                    decoration: const InputDecoration(hintText: 'YYYY-MM-DD'),
+                    decoration: InputDecoration(hintText: 'YYYY-MM-DD'),
                     onChanged: (val) {
                       onChanged(DateCriterion(
                         value: val,

--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -514,7 +514,7 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                                                   )
                                                   .clearAll();
                                             },
-                                            child: const Text('Clear History'),
+                                            child: Text(context.l10n.common_clear_history),
                                           ),
                                         ],
                                       ),

--- a/lib/features/galleries/presentation/widgets/gallery_filter_panel.dart
+++ b/lib/features/galleries/presentation/widgets/gallery_filter_panel.dart
@@ -310,7 +310,7 @@ class _GalleryFilterPanelState extends ConsumerState<GalleryFilterPanel> {
             for (var stars = 0; stars <= 5; stars++)
               ChoiceChip(
                 label: stars == 0
-                    ? const Text('Any')
+                    ? Text(context.l10n.common_any)
                     : Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
@@ -374,21 +374,21 @@ class _GalleryFilterPanelState extends ConsumerState<GalleryFilterPanel> {
           spacing: context.dimensions.spacingSmall,
           children: [
             ChoiceChip(
-              label: const Text('Any'),
+              label: Text(context.l10n.common_any),
               selected: value == null,
               onSelected: (selected) {
                 if (selected) onChanged(null);
               },
             ),
             ChoiceChip(
-              label: const Text('Yes'),
+              label: Text(context.l10n.common_yes),
               selected: value == true,
               onSelected: (selected) {
                 if (selected) onChanged(true);
               },
             ),
             ChoiceChip(
-              label: const Text('No'),
+              label: Text(context.l10n.common_no),
               selected: value == false,
               onSelected: (selected) {
                 if (selected) onChanged(false);

--- a/lib/features/images/presentation/widgets/image_filter_panel.dart
+++ b/lib/features/images/presentation/widgets/image_filter_panel.dart
@@ -285,7 +285,7 @@ class _ImageFilterPanelState extends ConsumerState<ImageFilterPanel> {
             for (var stars = 0; stars <= 5; stars++)
               ChoiceChip(
                 label: stars == 0
-                    ? const Text('Any')
+                    ? Text(context.l10n.common_any)
                     : Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
@@ -354,21 +354,21 @@ class _ImageFilterPanelState extends ConsumerState<ImageFilterPanel> {
           spacing: context.dimensions.spacingSmall,
           children: [
             ChoiceChip(
-              label: const Text('Any'),
+              label: Text(context.l10n.common_any),
               selected: value == null,
               onSelected: (selected) {
                 if (selected) onChanged(null);
               },
             ),
             ChoiceChip(
-              label: const Text('Yes'),
+              label: Text(context.l10n.common_yes),
               selected: value == true,
               onSelected: (selected) {
                 if (selected) onChanged(true);
               },
             ),
             ChoiceChip(
-              label: const Text('No'),
+              label: Text(context.l10n.common_no),
               selected: value == false,
               onSelected: (selected) {
                 if (selected) onChanged(false);

--- a/lib/features/performers/presentation/widgets/performer_filter_panel.dart
+++ b/lib/features/performers/presentation/widgets/performer_filter_panel.dart
@@ -246,7 +246,7 @@ class _PerformerFilterPanelState extends ConsumerState<PerformerFilterPanel> {
             for (var stars = 0; stars <= 5; stars++)
               ChoiceChip(
                 label: stars == 0
-                    ? const Text('Any')
+                    ? Text(context.l10n.common_any)
                     : Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
@@ -437,21 +437,21 @@ class _PerformerFilterPanelState extends ConsumerState<PerformerFilterPanel> {
           spacing: context.dimensions.spacingSmall,
           children: [
             ChoiceChip(
-              label: const Text('Any'),
+              label: Text(context.l10n.common_any),
               selected: value == null,
               onSelected: (selected) {
                 if (selected) onChanged(null);
               },
             ),
             ChoiceChip(
-              label: const Text('Yes'),
+              label: Text(context.l10n.common_yes),
               selected: value == true,
               onSelected: (selected) {
                 if (selected) onChanged(true);
               },
             ),
             ChoiceChip(
-              label: const Text('No'),
+              label: Text(context.l10n.common_no),
               selected: value == false,
               onSelected: (selected) {
                 if (selected) onChanged(false);

--- a/lib/features/scenes/presentation/widgets/scene_filter_panel.dart
+++ b/lib/features/scenes/presentation/widgets/scene_filter_panel.dart
@@ -537,7 +537,7 @@ class _SceneFilterPanelState extends ConsumerState<SceneFilterPanel> {
             for (var stars = 0; stars <= 5; stars++)
               ChoiceChip(
                 label: stars == 0
-                    ? const Text('Any')
+                    ? Text(context.l10n.common_any)
                     : Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
@@ -611,21 +611,21 @@ class _SceneFilterPanelState extends ConsumerState<SceneFilterPanel> {
           spacing: context.dimensions.spacingSmall,
           children: [
             ChoiceChip(
-              label: const Text('Any'),
+              label: Text(context.l10n.common_any),
               selected: value == null,
               onSelected: (selected) {
                 if (selected) onChanged(null);
               },
             ),
             ChoiceChip(
-              label: const Text('Yes'),
+              label: Text(context.l10n.common_yes),
               selected: value == true,
               onSelected: (selected) {
                 if (selected) onChanged(true);
               },
             ),
             ChoiceChip(
-              label: const Text('No'),
+              label: Text(context.l10n.common_no),
               selected: value == false,
               onSelected: (selected) {
                 if (selected) onChanged(false);

--- a/lib/features/setup/presentation/widgets/server_profile_drawer.dart
+++ b/lib/features/setup/presentation/widgets/server_profile_drawer.dart
@@ -394,7 +394,7 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
       return TextFormField(
         controller: _apiKeyController,
         decoration: InputDecoration(
-          labelText: _authMode == AuthMode.apiKey ? l10n.settings_server_auth_apikey : 'Token',
+          labelText: _authMode == AuthMode.apiKey ? l10n.settings_server_auth_apikey : l10n.common_token,
           border: const OutlineInputBorder(),
           suffixIcon: IconButton(
             icon: Icon(_obscureApiKey ? Icons.visibility : Icons.visibility_off),

--- a/lib/features/studios/presentation/widgets/studio_filter_panel.dart
+++ b/lib/features/studios/presentation/widgets/studio_filter_panel.dart
@@ -286,7 +286,7 @@ class _StudioFilterPanelState extends ConsumerState<StudioFilterPanel> {
             for (var stars = 0; stars <= 5; stars++)
               ChoiceChip(
                 label: stars == 0
-                    ? const Text('Any')
+                    ? Text(context.l10n.common_any)
                     : Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
@@ -359,21 +359,21 @@ class _StudioFilterPanelState extends ConsumerState<StudioFilterPanel> {
           spacing: context.dimensions.spacingSmall,
           children: [
             ChoiceChip(
-              label: const Text('Any'),
+              label: Text(context.l10n.common_any),
               selected: value == null,
               onSelected: (selected) {
                 if (selected) onChanged(null);
               },
             ),
             ChoiceChip(
-              label: const Text('Yes'),
+              label: Text(context.l10n.common_yes),
               selected: value == true,
               onSelected: (selected) {
                 if (selected) onChanged(true);
               },
             ),
             ChoiceChip(
-              label: const Text('No'),
+              label: Text(context.l10n.common_no),
               selected: value == false,
               onSelected: (selected) {
                 if (selected) onChanged(false);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,6 +1,11 @@
 {
   "@@locale": "en",
   "appTitle": "StashFlow",
+  "common_token": "Token",
+  "filter_value": "Value",
+  "common_yes": "Yes",
+  "common_no": "No",
+  "common_clear_history": "Clear History",
   "nav_scenes": "Scenes",
   "nav_performers": "Performers",
   "nav_studios": "Studios",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -120,6 +120,36 @@ abstract class AppLocalizations {
   /// **'StashFlow'**
   String get appTitle;
 
+  /// No description provided for @common_token.
+  ///
+  /// In en, this message translates to:
+  /// **'Token'**
+  String get common_token;
+
+  /// No description provided for @filter_value.
+  ///
+  /// In en, this message translates to:
+  /// **'Value'**
+  String get filter_value;
+
+  /// No description provided for @common_yes.
+  ///
+  /// In en, this message translates to:
+  /// **'Yes'**
+  String get common_yes;
+
+  /// No description provided for @common_no.
+  ///
+  /// In en, this message translates to:
+  /// **'No'**
+  String get common_no;
+
+  /// No description provided for @common_clear_history.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear History'**
+  String get common_clear_history;
+
   /// No description provided for @nav_scenes.
   ///
   /// In en, this message translates to:
@@ -1445,12 +1475,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Modifier'**
   String get filter_modifier;
-
-  /// No description provided for @filter_value.
-  ///
-  /// In en, this message translates to:
-  /// **'Value'**
-  String get filter_value;
 
   /// No description provided for @filter_equals.
   ///

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -12,6 +12,21 @@ class AppLocalizationsDe extends AppLocalizations {
   String get appTitle => 'StashFlow';
 
   @override
+  String get common_token => 'Token';
+
+  @override
+  String get filter_value => 'Wert';
+
+  @override
+  String get common_yes => 'Yes';
+
+  @override
+  String get common_no => 'No';
+
+  @override
+  String get common_clear_history => 'Clear History';
+
+  @override
   String get nav_scenes => 'Szenen';
 
   @override
@@ -737,9 +752,6 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get filter_modifier => 'Modifikator';
-
-  @override
-  String get filter_value => 'Wert';
 
   @override
   String get filter_equals => 'Gleich';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -12,6 +12,21 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appTitle => 'StashFlow';
 
   @override
+  String get common_token => 'Token';
+
+  @override
+  String get filter_value => 'Value';
+
+  @override
+  String get common_yes => 'Yes';
+
+  @override
+  String get common_no => 'No';
+
+  @override
+  String get common_clear_history => 'Clear History';
+
+  @override
   String get nav_scenes => 'Scenes';
 
   @override
@@ -729,9 +744,6 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get filter_modifier => 'Modifier';
-
-  @override
-  String get filter_value => 'Value';
 
   @override
   String get filter_equals => 'Equals';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -12,6 +12,21 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appTitle => 'StashFlow';
 
   @override
+  String get common_token => 'Token';
+
+  @override
+  String get filter_value => 'Valor';
+
+  @override
+  String get common_yes => 'Yes';
+
+  @override
+  String get common_no => 'No';
+
+  @override
+  String get common_clear_history => 'Clear History';
+
+  @override
   String get nav_scenes => 'Escenas';
 
   @override
@@ -739,9 +754,6 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get filter_modifier => 'Modificador';
-
-  @override
-  String get filter_value => 'Valor';
 
   @override
   String get filter_equals => 'Igual';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -12,6 +12,21 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appTitle => 'StashFlow';
 
   @override
+  String get common_token => 'Token';
+
+  @override
+  String get filter_value => 'Valeur';
+
+  @override
+  String get common_yes => 'Yes';
+
+  @override
+  String get common_no => 'No';
+
+  @override
+  String get common_clear_history => 'Clear History';
+
+  @override
   String get nav_scenes => 'Scènes';
 
   @override
@@ -737,9 +752,6 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get filter_modifier => 'Modificateur';
-
-  @override
-  String get filter_value => 'Valeur';
 
   @override
   String get filter_equals => 'Égal';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -12,6 +12,21 @@ class AppLocalizationsIt extends AppLocalizations {
   String get appTitle => 'StashFlow';
 
   @override
+  String get common_token => 'Token';
+
+  @override
+  String get filter_value => 'Valore';
+
+  @override
+  String get common_yes => 'Yes';
+
+  @override
+  String get common_no => 'No';
+
+  @override
+  String get common_clear_history => 'Clear History';
+
+  @override
   String get nav_scenes => 'Scene';
 
   @override
@@ -739,9 +754,6 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get filter_modifier => 'Modificatore';
-
-  @override
-  String get filter_value => 'Valore';
 
   @override
   String get filter_equals => 'Uguale';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -12,6 +12,21 @@ class AppLocalizationsJa extends AppLocalizations {
   String get appTitle => 'StashFlow';
 
   @override
+  String get common_token => 'Token';
+
+  @override
+  String get filter_value => '値';
+
+  @override
+  String get common_yes => 'Yes';
+
+  @override
+  String get common_no => 'No';
+
+  @override
+  String get common_clear_history => 'Clear History';
+
+  @override
   String get nav_scenes => 'シーン';
 
   @override
@@ -727,9 +742,6 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get filter_modifier => '修飾子';
-
-  @override
-  String get filter_value => '値';
 
   @override
   String get filter_equals => '等しい';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -12,6 +12,21 @@ class AppLocalizationsKo extends AppLocalizations {
   String get appTitle => 'StashFlow';
 
   @override
+  String get common_token => 'Token';
+
+  @override
+  String get filter_value => '값';
+
+  @override
+  String get common_yes => 'Yes';
+
+  @override
+  String get common_no => 'No';
+
+  @override
+  String get common_clear_history => 'Clear History';
+
+  @override
   String get nav_scenes => '장면';
 
   @override
@@ -725,9 +740,6 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get filter_modifier => '수정자';
-
-  @override
-  String get filter_value => '값';
 
   @override
   String get filter_equals => '같음';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -12,6 +12,21 @@ class AppLocalizationsRu extends AppLocalizations {
   String get appTitle => 'StashFlow';
 
   @override
+  String get common_token => 'Token';
+
+  @override
+  String get filter_value => 'Значение';
+
+  @override
+  String get common_yes => 'Yes';
+
+  @override
+  String get common_no => 'No';
+
+  @override
+  String get common_clear_history => 'Clear History';
+
+  @override
   String get nav_scenes => 'Сцены';
 
   @override
@@ -734,9 +749,6 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get filter_modifier => 'Модификатор';
-
-  @override
-  String get filter_value => 'Значение';
 
   @override
   String get filter_equals => 'Равно';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -12,6 +12,21 @@ class AppLocalizationsZh extends AppLocalizations {
   String get appTitle => 'StashFlow';
 
   @override
+  String get common_token => 'Token';
+
+  @override
+  String get filter_value => '值';
+
+  @override
+  String get common_yes => 'Yes';
+
+  @override
+  String get common_no => 'No';
+
+  @override
+  String get common_clear_history => 'Clear History';
+
+  @override
   String get nav_scenes => '场景';
 
   @override
@@ -725,9 +740,6 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get filter_modifier => '修饰符';
-
-  @override
-  String get filter_value => '值';
 
   @override
   String get filter_equals => '等于';
@@ -1676,6 +1688,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get appTitle => 'StashFlow';
 
   @override
+  String get filter_value => '值';
+
+  @override
   String get nav_scenes => '场景';
 
   @override
@@ -2372,9 +2387,6 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get filter_modifier => '修饰符';
-
-  @override
-  String get filter_value => '值';
 
   @override
   String get filter_equals => '等于';
@@ -3316,6 +3328,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get appTitle => 'StashFlow';
 
   @override
+  String get filter_value => '值';
+
+  @override
   String get nav_scenes => '場景';
 
   @override
@@ -4014,9 +4029,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get filter_modifier => '修饰符';
-
-  @override
-  String get filter_value => '值';
 
   @override
   String get filter_equals => '等于';


### PR DESCRIPTION
What: Replaced several hardcoded strings across UI widgets with generated localization keys.
Why: To conform with the project's localization standards and ensure these strings can be translated.
Impact: Several panels, lists, and filter views are now localized properly.
Measurement: `flutter analyze` and tests pass successfully with the generated localization files.

---
*PR created automatically by Jules for task [1277622288740235499](https://jules.google.com/task/1277622288740235499) started by @Alchemist-Aloha*