### PR TITLE
⚡ Bolt: Optimize CastSelectionSheet padding query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,7 @@
 ## 2024-07-25 - [MediaQuery.of(context) Over-Rebuilding]
 **Learning:** Using `MediaQuery.of(context).viewInsets` binds the widget to the entire `MediaQueryData` object, triggering an unnecessary rebuild whenever any unrelated property changes (like screen size or orientation).
 **Action:** Always use granular MediaQuery methods like `MediaQuery.viewInsetsOf(context)` to isolate dependencies to only the properties the widget actually uses.
+
+## 2024-08-01 - [MediaQuery.of(context) Over-Rebuilding in Padding]
+**Learning:** Using `MediaQuery.of(context).padding.bottom` binds the widget to the entire `MediaQueryData` object, triggering an unnecessary rebuild whenever any unrelated property changes (like text scale factor, orientation, screen size).
+**Action:** Always use granular MediaQuery methods like `MediaQuery.paddingOf(context).bottom` to isolate dependencies to only the properties the widget actually uses.

--- a/lib/features/scenes/presentation/widgets/video_controls/cast_selection_sheet.dart
+++ b/lib/features/scenes/presentation/widgets/video_controls/cast_selection_sheet.dart
@@ -258,7 +258,7 @@ class _CastSelectionSheetState extends ConsumerState<CastSelectionSheet> {
 
     return Container(
       padding: EdgeInsets.only(
-        bottom: MediaQuery.of(context).padding.bottom + AppTheme.spacingMedium,
+        bottom: MediaQuery.paddingOf(context).bottom + AppTheme.spacingMedium,
       ),
       decoration: BoxDecoration(
         color: context.colors.surface,


### PR DESCRIPTION
💡 **What**: Refactored `CastSelectionSheet` to use `MediaQuery.paddingOf(context).bottom` instead of `MediaQuery.of(context).padding.bottom`.

🎯 **Why**: Using `MediaQuery.of(context)` subscribes the widget to the entire `MediaQueryData` object. This causes the widget to needlessly rebuild whenever *any* unrelated property changes, such as the device orientation, text scale factor, or the keyboard sliding up (`viewInsets`).

📊 **Impact**: Prevents unnecessary rebuilds of the `CastSelectionSheet` whenever global UI metrics change, saving rendering cycles and minimizing frame drops, especially during keyboard appearance/disappearance or orientation changes.

🔬 **Measurement**: Inspect the widget tree rebuild counts during a text scale change or when toggling the keyboard; the rebuild count for `CastSelectionSheet` should remain 0 when padding does not change. Run the `flutter test` suite to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [1725491168705086239](https://jules.google.com/task/1725491168705086239) started by @Alchemist-Aloha*