### PR TITLE
⚡ Bolt: Hoist RegExp compilations to prevent redundant processing

### DIFF
--- a/lib/core/utils/vtt_service.dart
+++ b/lib/core/utils/vtt_service.dart
@@ -13,6 +13,11 @@ final vttServiceProvider = Provider<VttService>((ref) {
 class VttService {
   VttService({this.apiKey});
 
+  static final _spriteRegExp = RegExp(
+    r'^([^#]*)#xywh=(\d+),(\d+),(\d+),(\d+)$',
+    caseSensitive: false,
+  );
+
   final String? apiKey;
   final Map<String, List<SpriteInfo>> _cache = {};
 
@@ -68,11 +73,6 @@ class VttService {
     final List<SpriteInfo> sprites = [];
     final lines = vttBody.split('\n');
 
-    final spriteRegExp = RegExp(
-      r'^([^#]*)#xywh=(\d+),(\d+),(\d+),(\d+)$',
-      caseSensitive: false,
-    );
-
     // Robust VTT parser for Stash sprite format
     for (int i = 0; i < lines.length; i++) {
       final line = lines[i].trim();
@@ -94,7 +94,7 @@ class VttService {
           }
 
           if (spriteLine != null) {
-            final match = spriteRegExp.firstMatch(spriteLine);
+            final match = _spriteRegExp.firstMatch(spriteLine);
             if (match != null) {
               final spriteFile = match.group(1) ?? '';
               final x = double.parse(match.group(2)!);

--- a/lib/features/galleries/domain/entities/gallery.dart
+++ b/lib/features/galleries/domain/entities/gallery.dart
@@ -10,6 +10,8 @@ class Gallery {
   final int? coverWidth;
   final int? coverHeight;
 
+  static final _separatorRegExp = RegExp(r'[_\.]+');
+
   const Gallery({
     required this.id,
     required this.title,
@@ -41,7 +43,7 @@ class Gallery {
       if (filename.isNotEmpty) {
         final dotIndex = filename.lastIndexOf('.');
         final stem = dotIndex > 0 ? filename.substring(0, dotIndex) : filename;
-        final cleaned = stem.replaceAll(RegExp(r'[_\.]+'), ' ').trim();
+        final cleaned = stem.replaceAll(_separatorRegExp, ' ').trim();
         if (cleaned.isNotEmpty) return cleaned;
       }
     }

--- a/lib/features/scenes/data/utils/scrape_normalizer.dart
+++ b/lib/features/scenes/data/utils/scrape_normalizer.dart
@@ -6,6 +6,8 @@ String? _normalizeDate(DateTime? date) {
   return date.toIso8601String().split('T').first;
 }
 
+final _dateRegExp = RegExp(r'^\d{4}-\d{2}-\d{2}$');
+
 String? _cleanUrl(String? url) {
   if (url == null) return null;
   final trimmed = url.trim();
@@ -72,7 +74,7 @@ void validateSceneUpdateInput(Map<String, dynamic> input) {
 
   if (input.containsKey('date')) {
     final d = input['date'];
-    if (d is! String || !RegExp(r'^\d{4}-\d{2}-\d{2}$').hasMatch(d)) {
+    if (d is! String || !_dateRegExp.hasMatch(d)) {
       throw ArgumentError('Invalid date format (expected YYYY-MM-DD): $d');
     }
   }

--- a/lib/features/scenes/domain/entities/scene_title_utils.dart
+++ b/lib/features/scenes/domain/entities/scene_title_utils.dart
@@ -22,6 +22,8 @@ String buildSceneDisplayTitle({
   return (fromPath == null || fromPath.isEmpty) ? fallback : fromPath;
 }
 
+final _separatorRegExp = RegExp(r'[_\.]+');
+
 String? getFilestem(String? rawPath) {
   if (rawPath == null || rawPath.trim().isEmpty) return null;
 
@@ -41,7 +43,7 @@ String? getFilestem(String? rawPath) {
   final decoded = _safeDecodeComponent(lastSegment);
   final dotIndex = decoded.lastIndexOf('.');
   final withoutExt = dotIndex > 0 ? decoded.substring(0, dotIndex) : decoded;
-  final cleaned = withoutExt.replaceAll(RegExp(r'[_\.]+'), ' ').trim();
+  final cleaned = withoutExt.replaceAll(_separatorRegExp, ' ').trim();
   if (cleaned.isEmpty) return null;
 
   final lower = cleaned.toLowerCase();


### PR DESCRIPTION
💡 What: Extracted dynamic `RegExp` instantiations in multiple locations (`scene_title_utils.dart`, `gallery.dart`, `vtt_service.dart`, `scrape_normalizer.dart`) into top-level or `static final` variables.

🎯 Why: In Dart, compiling a regular expression is an expensive operation. Previously, these regexes were being recompiled every time a scene title was evaluated, a date was validated, or a VTT file was parsed. Hoisting them ensures they are compiled exactly once.

📊 Impact: Reduces CPU cycles and Garbage Collection pressure by avoiding redundant regex recompilations during critical paths, particularly when parsing scraped data or rendering lists of scenes and galleries.

🔬 Measurement: Use the Flutter DevTools performance profiler during list scrolling or data ingestion. The time spent compiling regular expressions in these specific paths will be eliminated.

---
*PR created automatically by Jules for task [3274024568103432398](https://jules.google.com/task/3274024568103432398) started by @Alchemist-Aloha*