### PR TITLE
🎨 Palette: [Add missing tooltip to stats floating panel close button]

### DIFF
--- a/lib/core/presentation/widgets/stats_floating_panel.dart
+++ b/lib/core/presentation/widgets/stats_floating_panel.dart
@@ -140,6 +140,7 @@ class StatsFloatingPanel extends ConsumerWidget {
           ),
           IconButton.filledTonal(
             icon: const Icon(Icons.close_rounded, size: 20),
+            tooltip: AppLocalizations.of(context)!.common_close,
             onPressed: () => Navigator.of(context).pop(),
           ),
         ],


### PR DESCRIPTION
💡 What: Added `tooltip: AppLocalizations.of(context)!.common_close` to the close `IconButton.filledTonal` in `lib/core/presentation/widgets/stats_floating_panel.dart`.
🎯 Why: A missing tooltip causes issues for screen readers since there's no semantic text describing the button's action. This improves overall UX and accessibility.
📸 Before/After: The close button in the stats floating panel now has a tooltip reading "Close" (localized).
♿ Accessibility: Provides a screen-reader accessible label and desktop hover hint for an icon-only button.

---
*PR created automatically by Jules for task [18075836654468471279](https://jules.google.com/task/18075836654468471279) started by @Alchemist-Aloha*