### PR TITLE
🎨 Palette: Localize hardcoded tooltips on icon buttons

### DIFF
--- a/lib/features/navigation/presentation/widgets/mini_player.dart
+++ b/lib/features/navigation/presentation/widgets/mini_player.dart
@@ -79,7 +79,7 @@ class MiniPlayer extends ConsumerWidget {
                 ),
               ),
               IconButton(
-                tooltip: isPlaying ? 'Pause' : 'Play',
+                tooltip: isPlaying ? context.l10n.common_pause : context.l10n.common_play,
                 onPressed: () =>
                     ref.read(playerStateProvider.notifier).togglePlayPause(),
                 icon: Icon(

--- a/lib/features/performers/presentation/pages/performer_details_page.dart
+++ b/lib/features/performers/presentation/pages/performer_details_page.dart
@@ -169,8 +169,8 @@ class PerformerDetailsPage extends ConsumerWidget {
                                     : Icons.favorite_border,
                               ),
                               tooltip: performer.favorite
-                                  ? 'Remove favorite'
-                                  : 'Add favorite',
+                                  ? context.l10n.common_remove_favorite
+                                  : context.l10n.common_add_favorite,
                               onPressed: () async {
                                 try {
                                   await ref

--- a/lib/features/scenes/presentation/widgets/native_video_controls.dart
+++ b/lib/features/scenes/presentation/widgets/native_video_controls.dart
@@ -607,7 +607,7 @@ class _NativeVideoControlsState extends ConsumerState<NativeVideoControls>
         mainAxisSize: MainAxisSize.min,
         children: [
           IconButton(
-            tooltip: isMuted ? 'Unmute' : 'Mute',
+            tooltip: isMuted ? context.l10n.common_unmute : context.l10n.common_mute,
             style: _controlButtonStyle(colorScheme),
             iconSize: 20,
             icon: Icon(iconData),

--- a/lib/features/scenes/presentation/widgets/video_controls/video_playback_controls.dart
+++ b/lib/features/scenes/presentation/widgets/video_controls/video_playback_controls.dart
@@ -113,7 +113,7 @@ class VideoPlaybackControls extends ConsumerWidget {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     IconButton(
-                      tooltip: isPlaying ? 'Pause' : 'Play',
+                      tooltip: isPlaying ? context.l10n.common_pause : context.l10n.common_play,
                       style: _controlButtonStyle(colorScheme),
                       iconSize: 20,
                       icon: Icon(


### PR DESCRIPTION
**💡 What:**
Replaced hardcoded tooltip strings with appropriate localized keys (`context.l10n...`) on `IconButton` widgets across `performer_details_page.dart`, `native_video_controls.dart`, `video_playback_controls.dart`, and `mini_player.dart`.

**🎯 Why:**
Hardcoded strings break internationalization and provide incorrect accessibility labels (ARIA equivalents) for non-English users using screen readers or hovering over icon buttons.

**📸 Before/After:**
*Before:* `tooltip: isPlaying ? 'Pause' : 'Play'`
*After:* `tooltip: isPlaying ? context.l10n.common_pause : context.l10n.common_play`

**♿ Accessibility:**
Improves screen reader support and tooltip accuracy for international users by dynamically loading localized labels.

---
*PR created automatically by Jules for task [10003905412237901803](https://jules.google.com/task/10003905412237901803) started by @Alchemist-Aloha*