### PR TITLE
🎨 Palette: Improve accessibility and feedback of scene rating stars

### DIFF
--- a/lib/features/scenes/presentation/pages/scene_details_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_details_page.dart
@@ -535,8 +535,11 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
         for (var i = 1; i <= 5; i++)
-          GestureDetector(
-            onTap: () async {
+          IconButton(
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+            tooltip: '$i Star${i > 1 ? 's' : ''}',
+            onPressed: () async {
               final currentRating = scene.rating100 ?? 0;
               final newRating = (currentRating == i * 20) ? 0 : i * 20;
 
@@ -561,7 +564,7 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
                 }
               }
             },
-            child: Icon(
+            icon: Icon(
               (scene.rating100 ?? 0) >= i * 20 ? Icons.star : Icons.star_border,
               color: context.colors.ratingColor,
               size: 28,


### PR DESCRIPTION
💡 **What:** The `GestureDetector` wrappers on the individual star rating icons in `SceneDetailsPage` were converted to `IconButton`s.
🎯 **Why:** The previous implementation lacked screen reader labels, keyboard focus states, and visual interaction feedback (like hover states or ripple effects) which made interaction ambiguous for non-touch users.
📸 **Before/After:** The visual layout is identical, but hovering or focusing on the stars now shows a tooltip and ripple effect.
♿ **Accessibility:** Added `tooltip: '$i Star(s)'` to label each star individually, enabling screen readers to announce "1 Star, Button", "2 Stars, Button", etc., and added full keyboard navigability.

---
*PR created automatically by Jules for task [13385238718211162002](https://jules.google.com/task/13385238718211162002) started by @Alchemist-Aloha*