### PR TITLE
feat(l10n): Replace hardcoded strings with localization keys

### DIFF
--- a/lib/features/images/presentation/pages/image_fullscreen_page.dart
+++ b/lib/features/images/presentation/pages/image_fullscreen_page.dart
@@ -222,9 +222,9 @@ class _ImageFullscreenPageState extends ConsumerState<ImageFullscreenPage> {
 
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text('Saving image...'),
-        duration: Duration(seconds: 1),
+      SnackBar(
+        content: Text(context.l10n.saving_image),
+        duration: const Duration(seconds: 1),
       ),
     );
 
@@ -303,7 +303,7 @@ class _ImageFullscreenPageState extends ConsumerState<ImageFullscreenPage> {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: const Text('Saved to StashFlow album'),
+            content: Text(context.l10n.saved_to_album),
             // action: SnackBarAction(
             //   label: 'View',
             //   onPressed: () => Gal.open(),
@@ -321,14 +321,14 @@ class _ImageFullscreenPageState extends ConsumerState<ImageFullscreenPage> {
       debugPrint('GalException final failure: ${e.type.name}');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Gallery Error: $message')),
+          SnackBar(content: Text(context.l10n.gallery_error(message))),
         );
       }
     } catch (e) {
       debugPrint('Save error: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to save: ${e.toString()}')),
+          SnackBar(content: Text(context.l10n.failed_to_save(e.toString()))),
         );
       }
     }

--- a/lib/features/scenes/presentation/pages/scene_details_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_details_page.dart
@@ -111,9 +111,9 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
   Future<void> _saveVideoToGallery(Scene scene) async {
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text('Saving to gallery...'),
-        duration: Duration(seconds: 1),
+      SnackBar(
+        content: Text(context.l10n.saving_video),
+        duration: const Duration(seconds: 1),
       ),
     );
 
@@ -187,7 +187,7 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Saved to StashFlow album')),
+          SnackBar(content: Text(context.l10n.saved_to_album)),
         );
       }
     } on GalException catch (e) {
@@ -200,13 +200,13 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
       };
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Gallery Error: $message')),
+          SnackBar(content: Text(context.l10n.gallery_error(message))),
         );
       }
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to save: ${e.toString()}')),
+          SnackBar(content: Text(context.l10n.failed_to_save(e.toString()))),
         );
       }
     }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -811,5 +811,24 @@
   "common_pt": "{value} pt",
   "common_percent": "{value}%",
   "settings_playback_direct_play": "Direkt-Wiedergabe bei Szenen-Navigation",
-  "settings_playback_direct_play_subtitle": "Bei der Navigation von einer anderen spielenden Szene wird die neue Szene direkt abgespielt"
+  "settings_playback_direct_play_subtitle": "Bei der Navigation von einer anderen spielenden Szene wird die neue Szene direkt abgespielt",
+  "saving_video": "In Galerie speichern...",
+  "saved_to_album": "Im StashFlow-Album gespeichert",
+  "gallery_error": "Galeriefehler: {message}",
+  "failed_to_save": "Speichern fehlgeschlagen: {error}",
+  "saving_image": "Bild speichern...",
+  "@gallery_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "@failed_to_save": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -881,6 +881,23 @@
       }
     }
   },
-  "settings_playback_direct_play": "Direct-play on scene navigation",
-  "settings_playback_direct_play_subtitle": "When navigating from another playing scene, directly play the new scene"
+  "saving_video": "Saving to gallery...",
+  "saved_to_album": "Saved to StashFlow album",
+  "gallery_error": "Gallery Error: {message}",
+  "@gallery_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "failed_to_save": "Failed to save: {error}",
+  "@failed_to_save": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "saving_image": "Saving image..."
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -790,5 +790,24 @@
   "common_pt": "{value} pt",
   "common_percent": "{value}%",
   "settings_playback_direct_play": "Reproducción directa al navegar por escenas",
-  "settings_playback_direct_play_subtitle": "Al navegar desde otra escena en reproducción, reproducir directamente la nueva escena"
+  "settings_playback_direct_play_subtitle": "Al navegar desde otra escena en reproducción, reproducir directamente la nueva escena",
+  "saving_video": "Guardando en galería...",
+  "saved_to_album": "Guardado en álbum de StashFlow",
+  "gallery_error": "Error de galería: {message}",
+  "failed_to_save": "Error al guardar: {error}",
+  "saving_image": "Guardando imagen...",
+  "@gallery_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "@failed_to_save": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -790,5 +790,24 @@
   "common_pt": "{value} pt",
   "common_percent": "{value}%",
   "settings_playback_direct_play": "Lecture directe lors de la navigation entre scènes",
-  "settings_playback_direct_play_subtitle": "Lors de la navigation depuis une autre scène en cours de lecture, lire directement la nouvelle scène"
+  "settings_playback_direct_play_subtitle": "Lors de la navigation depuis une autre scène en cours de lecture, lire directement la nouvelle scène",
+  "saving_video": "Enregistrement dans la galerie...",
+  "saved_to_album": "Enregistré dans l'album StashFlow",
+  "gallery_error": "Erreur de galerie: {message}",
+  "failed_to_save": "Échec de l'enregistrement: {error}",
+  "saving_image": "Enregistrement de l'image...",
+  "@gallery_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "@failed_to_save": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -795,5 +795,24 @@
   "common_pt": "{value} pt",
   "common_percent": "{value}%",
   "settings_playback_direct_play": "Riproduzione diretta alla navigazione della scena",
-  "settings_playback_direct_play_subtitle": "Quando si naviga da un'altra scena in riproduzione, riproduce direttamente la nuova scena"
+  "settings_playback_direct_play_subtitle": "Quando si naviga da un'altra scena in riproduzione, riproduce direttamente la nuova scena",
+  "saving_video": "Salvataggio in galleria...",
+  "saved_to_album": "Salvato nell'album StashFlow",
+  "gallery_error": "Errore galleria: {message}",
+  "failed_to_save": "Impossibile salvare: {error}",
+  "saving_image": "Salvataggio immagine...",
+  "@gallery_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "@failed_to_save": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -790,5 +790,24 @@
   "common_pt": "{value} pt",
   "common_percent": "{value}%",
   "settings_playback_direct_play": "シーン移動時に直接再生",
-  "settings_playback_direct_play_subtitle": "他の再生中シーンから移動した際、新しいシーンを直接再生します"
+  "settings_playback_direct_play_subtitle": "他の再生中シーンから移動した際、新しいシーンを直接再生します",
+  "saving_video": "ギャラリーに保存中...",
+  "saved_to_album": "StashFlowアルバムに保存しました",
+  "gallery_error": "ギャラリーエラー: {message}",
+  "failed_to_save": "保存に失敗しました: {error}",
+  "saving_image": "画像を保存中...",
+  "@gallery_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "@failed_to_save": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -790,5 +790,24 @@
   "common_pt": "{value} pt",
   "common_percent": "{value}%",
   "settings_playback_direct_play": "장면 이동 시 즉시 재생",
-  "settings_playback_direct_play_subtitle": "다른 재생 중인 장면에서 이동할 때 새 장면을 즉시 재생합니다"
+  "settings_playback_direct_play_subtitle": "다른 재생 중인 장면에서 이동할 때 새 장면을 즉시 재생합니다",
+  "saving_video": "갤러리에 저장 중...",
+  "saved_to_album": "StashFlow 앨범에 저장됨",
+  "gallery_error": "갤러리 오류: {message}",
+  "failed_to_save": "저장 실패: {error}",
+  "saving_image": "이미지 저장 중...",
+  "@gallery_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "@failed_to_save": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4229,6 +4229,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{value}%'**
   String common_percent(int value);
+
+  /// No description provided for @saving_video.
+  ///
+  /// In en, this message translates to:
+  /// **'Saving to gallery...'**
+  String get saving_video;
+
+  /// No description provided for @saved_to_album.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved to StashFlow album'**
+  String get saved_to_album;
+
+  /// No description provided for @gallery_error.
+  ///
+  /// In en, this message translates to:
+  /// **'Gallery Error: {message}'**
+  String gallery_error(String message);
+
+  /// No description provided for @failed_to_save.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to save: {error}'**
+  String failed_to_save(String error);
+
+  /// No description provided for @saving_image.
+  ///
+  /// In en, this message translates to:
+  /// **'Saving image...'**
+  String get saving_image;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2281,4 +2281,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String common_percent(int value) {
     return '$value%';
   }
+
+  @override
+  String get saving_video => 'In Galerie speichern...';
+
+  @override
+  String get saved_to_album => 'Im StashFlow-Album gespeichert';
+
+  @override
+  String gallery_error(String message) {
+    return 'Galeriefehler: $message';
+  }
+
+  @override
+  String failed_to_save(String error) {
+    return 'Speichern fehlgeschlagen: $error';
+  }
+
+  @override
+  String get saving_image => 'Bild speichern...';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2245,4 +2245,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String common_percent(int value) {
     return '$value%';
   }
+
+  @override
+  String get saving_video => 'Saving to gallery...';
+
+  @override
+  String get saved_to_album => 'Saved to StashFlow album';
+
+  @override
+  String gallery_error(String message) {
+    return 'Gallery Error: $message';
+  }
+
+  @override
+  String failed_to_save(String error) {
+    return 'Failed to save: $error';
+  }
+
+  @override
+  String get saving_image => 'Saving image...';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2304,4 +2304,23 @@ class AppLocalizationsEs extends AppLocalizations {
   String common_percent(int value) {
     return '$value%';
   }
+
+  @override
+  String get saving_video => 'Guardando en galería...';
+
+  @override
+  String get saved_to_album => 'Guardado en álbum de StashFlow';
+
+  @override
+  String gallery_error(String message) {
+    return 'Error de galería: $message';
+  }
+
+  @override
+  String failed_to_save(String error) {
+    return 'Error al guardar: $error';
+  }
+
+  @override
+  String get saving_image => 'Guardando imagen...';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2294,4 +2294,23 @@ class AppLocalizationsFr extends AppLocalizations {
   String common_percent(int value) {
     return '$value%';
   }
+
+  @override
+  String get saving_video => 'Enregistrement dans la galerie...';
+
+  @override
+  String get saved_to_album => 'Enregistré dans l\'album StashFlow';
+
+  @override
+  String gallery_error(String message) {
+    return 'Erreur de galerie: $message';
+  }
+
+  @override
+  String failed_to_save(String error) {
+    return 'Échec de l\'enregistrement: $error';
+  }
+
+  @override
+  String get saving_image => 'Enregistrement de l\'image...';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2298,4 +2298,23 @@ class AppLocalizationsIt extends AppLocalizations {
   String common_percent(int value) {
     return '$value%';
   }
+
+  @override
+  String get saving_video => 'Salvataggio in galleria...';
+
+  @override
+  String get saved_to_album => 'Salvato nell\'album StashFlow';
+
+  @override
+  String gallery_error(String message) {
+    return 'Errore galleria: $message';
+  }
+
+  @override
+  String failed_to_save(String error) {
+    return 'Impossibile salvare: $error';
+  }
+
+  @override
+  String get saving_image => 'Salvataggio immagine...';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2198,4 +2198,23 @@ class AppLocalizationsJa extends AppLocalizations {
   String common_percent(int value) {
     return '$value%';
   }
+
+  @override
+  String get saving_video => 'ギャラリーに保存中...';
+
+  @override
+  String get saved_to_album => 'StashFlowアルバムに保存しました';
+
+  @override
+  String gallery_error(String message) {
+    return 'ギャラリーエラー: $message';
+  }
+
+  @override
+  String failed_to_save(String error) {
+    return '保存に失敗しました: $error';
+  }
+
+  @override
+  String get saving_image => '画像を保存中...';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2198,4 +2198,23 @@ class AppLocalizationsKo extends AppLocalizations {
   String common_percent(int value) {
     return '$value%';
   }
+
+  @override
+  String get saving_video => '갤러리에 저장 중...';
+
+  @override
+  String get saved_to_album => 'StashFlow 앨범에 저장됨';
+
+  @override
+  String gallery_error(String message) {
+    return '갤러리 오류: $message';
+  }
+
+  @override
+  String failed_to_save(String error) {
+    return '저장 실패: $error';
+  }
+
+  @override
+  String get saving_image => '이미지 저장 중...';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2274,4 +2274,23 @@ class AppLocalizationsRu extends AppLocalizations {
   String common_percent(int value) {
     return '$value%';
   }
+
+  @override
+  String get saving_video => 'Сохранение в галерею...';
+
+  @override
+  String get saved_to_album => 'Сохранено в альбом StashFlow';
+
+  @override
+  String gallery_error(String message) {
+    return 'Ошибка галереи: $message';
+  }
+
+  @override
+  String failed_to_save(String error) {
+    return 'Не удалось сохранить: $error';
+  }
+
+  @override
+  String get saving_image => 'Сохранение изображения...';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2176,6 +2176,25 @@ class AppLocalizationsZh extends AppLocalizations {
   String common_percent(int value) {
     return '$value%';
   }
+
+  @override
+  String get saving_video => '正在保存到相册...';
+
+  @override
+  String get saved_to_album => '已保存到 StashFlow 相册';
+
+  @override
+  String gallery_error(String message) {
+    return '相册错误: $message';
+  }
+
+  @override
+  String failed_to_save(String error) {
+    return '保存失败: $error';
+  }
+
+  @override
+  String get saving_image => '正在保存图片...';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -4313,6 +4332,25 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String common_percent(int value) {
     return '$value%';
   }
+
+  @override
+  String get saving_video => '正在保存到相册...';
+
+  @override
+  String get saved_to_album => '已保存到 StashFlow 相册';
+
+  @override
+  String gallery_error(String message) {
+    return '相册错误: $message';
+  }
+
+  @override
+  String failed_to_save(String error) {
+    return '保存失败: $error';
+  }
+
+  @override
+  String get saving_image => '正在保存图片...';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -6454,4 +6492,23 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String common_percent(int value) {
     return '$value%';
   }
+
+  @override
+  String get saving_video => '正在儲存到相簿...';
+
+  @override
+  String get saved_to_album => '已儲存到 StashFlow 相簿';
+
+  @override
+  String gallery_error(String message) {
+    return '相簿錯誤: $message';
+  }
+
+  @override
+  String failed_to_save(String error) {
+    return '儲存失敗: $error';
+  }
+
+  @override
+  String get saving_image => '正在儲存圖片...';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -790,5 +790,24 @@
   "common_pt": "{value} пт",
   "common_percent": "{value}%",
   "settings_playback_direct_play": "Прямое воспроизведение при навигации по сценам",
-  "settings_playback_direct_play_subtitle": "При переходе из другой воспроизводящейся сцены, сразу включать новую сцену"
+  "settings_playback_direct_play_subtitle": "При переходе из другой воспроизводящейся сцены, сразу включать новую сцену",
+  "saving_video": "Сохранение в галерею...",
+  "saved_to_album": "Сохранено в альбом StashFlow",
+  "gallery_error": "Ошибка галереи: {message}",
+  "failed_to_save": "Не удалось сохранить: {error}",
+  "saving_image": "Сохранение изображения...",
+  "@gallery_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "@failed_to_save": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -790,5 +790,24 @@
   "common_pt": "{value} 点",
   "common_percent": "{value}%",
   "settings_playback_direct_play": "切换场景时直接播放",
-  "settings_playback_direct_play_subtitle": "从另一个正在播放的场景切换过来时，直接播放新场景"
+  "settings_playback_direct_play_subtitle": "从另一个正在播放的场景切换过来时，直接播放新场景",
+  "saving_video": "正在保存到相册...",
+  "saved_to_album": "已保存到 StashFlow 相册",
+  "gallery_error": "相册错误: {message}",
+  "failed_to_save": "保存失败: {error}",
+  "saving_image": "正在保存图片...",
+  "@gallery_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "@failed_to_save": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -790,5 +790,24 @@
   "common_pt": "{value} 点",
   "common_percent": "{value}%",
   "settings_playback_direct_play": "切换场景时直接播放",
-  "settings_playback_direct_play_subtitle": "从另一个正在播放的场景切换过来时，直接播放新场景"
+  "settings_playback_direct_play_subtitle": "从另一个正在播放的场景切换过来时，直接播放新场景",
+  "saving_video": "正在保存到相册...",
+  "saved_to_album": "已保存到 StashFlow 相册",
+  "gallery_error": "相册错误: {message}",
+  "failed_to_save": "保存失败: {error}",
+  "saving_image": "正在保存图片...",
+  "@gallery_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "@failed_to_save": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -790,5 +790,24 @@
   "common_pt": "{value} 點",
   "common_percent": "{value}%",
   "settings_playback_direct_play": "切換場景時直接播放",
-  "settings_playback_direct_play_subtitle": "從另一個正在播放的場景切換過來時，直接播放新場景"
+  "settings_playback_direct_play_subtitle": "從另一個正在播放的場景切換過來時，直接播放新場景",
+  "saving_video": "正在儲存到相簿...",
+  "saved_to_album": "已儲存到 StashFlow 相簿",
+  "gallery_error": "相簿錯誤: {message}",
+  "failed_to_save": "儲存失敗: {error}",
+  "saving_image": "正在儲存圖片...",
+  "@gallery_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "@failed_to_save": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Replaced hardcoded strings (`Saving to gallery...`, `Saved to StashFlow album`, `Gallery Error: {message}`, `Failed to save: {error}`, `Saving image...`) with localized equivalents using `context.l10n.<key>`.
Updated the `.arb` files for all supported languages with correct translations for the new keys.
Regenerated the Dart localization files via `flutter gen-l10n`.

---
*PR created automatically by Jules for task [12474829280656081211](https://jules.google.com/task/12474829280656081211) started by @Alchemist-Aloha*