### PR TITLE
🎨 Palette: [Add Tooltip to Server Settings FAB]

### DIFF
--- a/lib/features/setup/presentation/pages/settings/server_settings_page.dart
+++ b/lib/features/setup/presentation/pages/settings/server_settings_page.dart
@@ -111,6 +111,7 @@ class _ServerSettingsPageState extends ConsumerState<ServerSettingsPage> {
     return SettingsPageShell(
       title: '${l10n.settings_server} ${l10n.settings_title}',
       floatingActionButton: FloatingActionButton(
+        tooltip: l10n.settings_server_profile_add,
         onPressed: () => _showProfileDrawer(),
         child: const Icon(Icons.add),
       ),

--- a/test/features/setup/presentation/pages/settings/server_settings_page_test.dart
+++ b/test/features/setup/presentation/pages/settings/server_settings_page_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:stash_app_flutter/features/setup/presentation/pages/settings/server_settings_page.dart';
+
+import '../../../../../helpers/test_helpers.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  testWidgets('ServerSettingsPage renders add profile FAB with tooltip', (tester) async {
+    tester.view.physicalSize = const Size(1200, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await pumpTestWidget(
+      tester,
+      prefs: prefs,
+      child: const Scaffold(body: ServerSettingsPage()),
+    );
+    await tester.pumpAndSettle();
+
+    final fab = find.byType(FloatingActionButton);
+    expect(fab, findsOneWidget);
+
+    final widget = tester.widget<FloatingActionButton>(fab);
+    expect(widget.tooltip, isNotNull);
+    // The tooltip string comes from l10n.settings_server_profile_add, which should be 'Add Profile' in english
+    expect(widget.tooltip, 'Add Profile');
+  });
+}


### PR DESCRIPTION
**What:** Added `tooltip: l10n.settings_server_profile_add` to the `FloatingActionButton` on the `ServerSettingsPage` which only contained an `Icon(Icons.add)`. Also added a widget test to ensure the FAB tooltip is present and correctly localized.
**Why:** The Add Profile `FloatingActionButton` was an icon-only button without any label, which meant screen readers could not announce its purpose to the user, and desktop users wouldn't get a hover text explaining its function.
**Accessibility:** Improved accessibility by ensuring screen reader compatibility and providing descriptive hover tooltips.

---
*PR created automatically by Jules for task [3064087117138708354](https://jules.google.com/task/3064087117138708354) started by @Alchemist-Aloha*