### PR TITLE
🎨 Palette: Add tooltip to server profile FAB

### DIFF
--- a/lib/features/setup/presentation/pages/settings/server_settings_page.dart
+++ b/lib/features/setup/presentation/pages/settings/server_settings_page.dart
@@ -112,6 +112,7 @@ class _ServerSettingsPageState extends ConsumerState<ServerSettingsPage> {
       title: '${l10n.settings_server} ${l10n.settings_title}',
       floatingActionButton: FloatingActionButton(
         onPressed: () => _showProfileDrawer(),
+        tooltip: l10n.settings_server_profile_add,
         child: const Icon(Icons.add),
       ),
       child: profiles.isEmpty


### PR DESCRIPTION
💡 **What:** Added a localized tooltip (`l10n.settings_server_profile_add`) to the `FloatingActionButton` on the `ServerSettingsPage`.
🎯 **Why:** To improve accessibility by providing a semantic label for screen readers and helpful context on hover for desktop/web users.
📸 **Before/After:** The FAB previously lacked context; now, it displays 'Add Profile' (localized) upon hover/focus.
♿ **Accessibility:** Provides a semantic label for the icon-only Add button.

---
*PR created automatically by Jules for task [4886173873969254309](https://jules.google.com/task/4886173873969254309) started by @Alchemist-Aloha*