### PR TITLE
🎨 Palette: Improve text field keyboard navigation

### DIFF
--- a/lib/features/scenes/presentation/pages/scene_edit_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_edit_page.dart
@@ -500,6 +500,7 @@ class _SceneEditPageState extends ConsumerState<SceneEditPage> {
               ),
             TextField(
               controller: _titleController,
+              textInputAction: TextInputAction.next,
               decoration: InputDecoration(
                 labelText: context.l10n.common_title,
                 border: OutlineInputBorder(),
@@ -661,6 +662,8 @@ class _SceneEditPageState extends ConsumerState<SceneEditPage> {
                     Expanded(
                       child: TextField(
                         controller: controller,
+                        keyboardType: TextInputType.url,
+                        textInputAction: TextInputAction.done,
                         decoration: InputDecoration(
                           labelText: context.l10n.common_url,
                           border: OutlineInputBorder(),

--- a/lib/features/scenes/presentation/widgets/scrape_query_dialog.dart
+++ b/lib/features/scenes/presentation/widgets/scrape_query_dialog.dart
@@ -104,6 +104,8 @@ class _ScrapeQueryDialogState extends ConsumerState<ScrapeQueryDialog> {
           children: [
             TextField(
               controller: _urlController,
+              keyboardType: TextInputType.url,
+              textInputAction: TextInputAction.next,
               decoration: InputDecoration(
                 labelText: context.l10n.scrape_from_url,
                 hintText: context.l10n.common_hint_url,
@@ -126,6 +128,7 @@ class _ScrapeQueryDialogState extends ConsumerState<ScrapeQueryDialog> {
             const SizedBox(height: 16),
             TextField(
               controller: _queryController,
+              textInputAction: TextInputAction.done,
               decoration: InputDecoration(
                 labelText: context.l10n.common_search_placeholder,
                 border: const OutlineInputBorder(),


### PR DESCRIPTION
**What**: Added `textInputAction` and `keyboardType` properties to text fields in `scene_edit_page.dart` and `scrape_query_dialog.dart`.
**Why**: When navigating forms on mobile devices, standardizing input actions (like `next` or `done`) and setting explicit keyboard types (like URLs) improves input intuitiveness, ensures the correct virtual keyboard layout is shown, and avoids interrupting the form completion flow.
**Accessibility**: Improves keyboard navigation and semantic predictability.
**Before/After**: Virtual keyboards on mobile will now display ".com" keys for URLs and properly handle the Next/Done actions rather than simple newlines.

---
*PR created automatically by Jules for task [12856922626005596765](https://jules.google.com/task/12856922626005596765) started by @Alchemist-Aloha*