### PR TITLE
⚡ Bolt: Hoist GoRouter lookups out of List/Grid itemBuilders

### DIFF
--- a/lib/features/performers/presentation/pages/performer_media_grid_page.dart
+++ b/lib/features/performers/presentation/pages/performer_media_grid_page.dart
@@ -26,6 +26,13 @@ class PerformerMediaGridPage extends ConsumerWidget {
     final isGridView = ref.watch(performerMediaGridLayoutProvider);
     final gridColumns = ref.watch(performerGridColumnsProvider);
 
+    // ⚡ Bolt: Hoist router lookup out of the itemBuilder loop.
+    // Why: Looking up GoRouter.of(context) inside itemBuilder executes an O(1) inherited widget lookup per list item.
+    // Impact: Prevents N router lookups and route uri parsing on every scroll frame, reducing GC pressure.
+    final router = GoRouter.of(context);
+    final currentPath = router.routeInformationProvider.value.uri.path;
+    final isAtRoot = currentPath.endsWith('/media');
+
     return ListPageScaffold<Scene>(
       title: context.l10n.performers_media_title,
       searchHint: context.l10n.common_search_placeholder,
@@ -46,10 +53,6 @@ class PerformerMediaGridPage extends ConsumerWidget {
       useMasonry: isGridView,
       padding: isGridView ? GridUtils.defaultPadding : EdgeInsets.zero,
       itemBuilder: (context, item, memCacheWidth, memCacheHeight) {
-        final router = GoRouter.of(context);
-        final currentPath = router.routeInformationProvider.value.uri.path;
-        final isAtRoot = currentPath.endsWith('/media');
-
         return SceneCard(
           scene: item,
           isGrid: isGridView,

--- a/lib/features/scenes/presentation/pages/scenes_page.dart
+++ b/lib/features/scenes/presentation/pages/scenes_page.dart
@@ -444,6 +444,13 @@ class _ScenesPageState extends ConsumerState<ScenesPage> {
       for (var i = 0; i < scenes.length; i++) scenes[i].id: i,
     };
 
+    // ⚡ Bolt: Hoist router lookup out of the itemBuilder loop.
+    // Why: Looking up GoRouter.of(context) inside itemBuilder executes an O(1) inherited widget lookup per list item.
+    // Impact: Prevents N router lookups and route uri parsing on every scroll frame, reducing GC pressure.
+    final router = GoRouter.of(context);
+    final currentPath = router.routeInformationProvider.value.uri.path;
+    final isAtRoot = currentPath == '/scenes';
+
     return ListPageScaffold<Scene>(
       title: context.l10n.appTitle,
       searchHint: context.l10n.scenes_search_hint,
@@ -527,9 +534,6 @@ class _ScenesPageState extends ConsumerState<ScenesPage> {
       padding: isGridView ? GridUtils.defaultPadding : EdgeInsets.zero,
       itemBuilder: (context, scene, memCacheWidth, memCacheHeight) {
         final index = sceneIndexMap[scene.id] ?? -1;
-        final router = GoRouter.of(context);
-        final currentPath = router.routeInformationProvider.value.uri.path;
-        final isAtRoot = currentPath == '/scenes';
 
         return SceneCard(
           scene: scene,

--- a/lib/features/scenes/presentation/widgets/tiktok_scenes_view.dart
+++ b/lib/features/scenes/presentation/widgets/tiktok_scenes_view.dart
@@ -318,6 +318,13 @@ class _TiktokScenesViewState extends ConsumerState<TiktokScenesView> {
           });
         }
 
+        // ⚡ Bolt: Hoist router lookup out of the itemBuilder loop.
+        // Why: Looking up GoRouter.of(context) inside itemBuilder executes an O(1) inherited widget lookup per list item.
+        // Impact: Prevents N router lookups and route uri parsing on every scroll frame, reducing GC pressure.
+        final router = GoRouter.of(context);
+        final currentPath = router.routeInformationProvider.value.uri.path;
+        final isAtRoot = currentPath == '/scenes';
+
         return NotificationListener<ScrollNotification>(
           onNotification: (notification) {
             if (notification is ScrollEndNotification) {
@@ -364,11 +371,6 @@ class _TiktokScenesViewState extends ConsumerState<TiktokScenesView> {
               } else {
                 controller = _controllers[scene.id];
               }
-
-              final router = GoRouter.of(context);
-              final currentPath =
-                  router.routeInformationProvider.value.uri.path;
-              final isAtRoot = currentPath == '/scenes';
 
               return TiktokSceneItem(
                 scene: scene,
@@ -673,7 +675,9 @@ class _TiktokSceneItemState extends ConsumerState<TiktokSceneItem> {
         // Navigate to details THEN set global fullscreen state
         context.go('/scenes/scene/${widget.scene.id}');
         ref.read(playerStateProvider.notifier).setFullScreen(true);
-        ref.read(playerStateProvider.notifier).setViewMode(PlayerViewMode.fullscreen);
+        ref
+            .read(playerStateProvider.notifier)
+            .setViewMode(PlayerViewMode.fullscreen);
       }
     }
   }

--- a/lib/features/studios/presentation/pages/studio_media_grid_page.dart
+++ b/lib/features/studios/presentation/pages/studio_media_grid_page.dart
@@ -26,6 +26,13 @@ class StudioMediaGridPage extends ConsumerWidget {
     final isGridView = ref.watch(studioMediaGridLayoutProvider);
     final gridColumns = ref.watch(studioGridColumnsProvider);
 
+    // ⚡ Bolt: Hoist router lookup out of the itemBuilder loop.
+    // Why: Looking up GoRouter.of(context) inside itemBuilder executes an O(1) inherited widget lookup per list item.
+    // Impact: Prevents N router lookups and route uri parsing on every scroll frame, reducing GC pressure.
+    final router = GoRouter.of(context);
+    final currentPath = router.routeInformationProvider.value.uri.path;
+    final isAtRoot = currentPath.endsWith('/media');
+
     return ListPageScaffold<Scene>(
       title: context.l10n.studios_media_title,
       searchHint: context.l10n.common_search_placeholder,
@@ -44,10 +51,6 @@ class StudioMediaGridPage extends ConsumerWidget {
       useMasonry: isGridView,
       padding: isGridView ? GridUtils.defaultPadding : EdgeInsets.zero,
       itemBuilder: (context, item, memCacheWidth, memCacheHeight) {
-        final router = GoRouter.of(context);
-        final currentPath = router.routeInformationProvider.value.uri.path;
-        final isAtRoot = currentPath.endsWith('/media');
-
         return SceneCard(
           scene: item,
           isGrid: isGridView,

--- a/lib/features/tags/presentation/pages/tag_media_grid_page.dart
+++ b/lib/features/tags/presentation/pages/tag_media_grid_page.dart
@@ -26,6 +26,13 @@ class TagMediaGridPage extends ConsumerWidget {
     final isGridView = ref.watch(tagMediaGridLayoutProvider);
     final gridColumns = ref.watch(tagGridColumnsProvider);
 
+    // ⚡ Bolt: Hoist router lookup out of the itemBuilder loop.
+    // Why: Looking up GoRouter.of(context) inside itemBuilder executes an O(1) inherited widget lookup per list item.
+    // Impact: Prevents N router lookups and route uri parsing on every scroll frame, reducing GC pressure.
+    final router = GoRouter.of(context);
+    final currentPath = router.routeInformationProvider.value.uri.path;
+    final isAtRoot = currentPath.endsWith('/media');
+
     return ListPageScaffold<Scene>(
       title: context
           .l10n
@@ -45,10 +52,6 @@ class TagMediaGridPage extends ConsumerWidget {
       useMasonry: isGridView,
       padding: isGridView ? GridUtils.defaultPadding : EdgeInsets.zero,
       itemBuilder: (context, item, memCacheWidth, memCacheHeight) {
-        final router = GoRouter.of(context);
-        final currentPath = router.routeInformationProvider.value.uri.path;
-        final isAtRoot = currentPath.endsWith('/media');
-
         return SceneCard(
           scene: item,
           isGrid: isGridView,


### PR DESCRIPTION
⚡ Bolt: Hoist GoRouter lookups out of List/Grid itemBuilders

What:
Moved `GoRouter.of(context)` lookups and route URI path parsing out of `itemBuilder` methods and into the parent `build` method across five scrolling views (`ScenesPage`, `TiktokScenesView`, `PerformerMediaGridPage`, `StudioMediaGridPage`, `TagMediaGridPage`).

Why:
Looking up inherited widgets (like `GoRouter.of(context)`) inside an `itemBuilder` executes an $O(1)$ context walk for every single item that scrolls onto the screen. Worse, parsing the `routeInformationProvider.value.uri.path` string allocates new memory constantly during high-velocity scrolling. By hoisting this static information, we compute it once per page build instead of once per list item.

Impact:
Prevents $N$ unnecessary inherited widget context lookups and string allocations per scroll frame, directly reducing Garbage Collection (GC) pressure and minimizing the risk of frame drops during fast scrolling of large media grids.

Measurement:
Run a Flutter DevTools profile session while aggressively scrolling the Scenes list. The CPU flame chart will show a reduction in `GoRouter.of` calls originating from the Sliver list builder logic.

---
*PR created automatically by Jules for task [15796344242167451062](https://jules.google.com/task/15796344242167451062) started by @Alchemist-Aloha*