### PR TITLE
🎨 Palette: Add form textInputAction and image semantic labels

### DIFF
--- a/lib/core/presentation/widgets/filter_widgets.dart
+++ b/lib/core/presentation/widgets/filter_widgets.dart
@@ -20,7 +20,9 @@ class FilterSection extends StatelessWidget {
     return ExpansionTile(
       title: Text(title, style: context.textTheme.titleMedium),
       initiallyExpanded: initiallyExpanded,
-      childrenPadding: EdgeInsets.symmetric(horizontal: context.dimensions.spacingMedium),
+      childrenPadding: EdgeInsets.symmetric(
+        horizontal: context.dimensions.spacingMedium,
+      ),
       children: children,
     );
   }
@@ -52,33 +54,37 @@ class IntCriterionInput extends StatelessWidget {
                 value: value?.modifier ?? CriterionModifier.equals,
                 onChanged: (mod) {
                   if (mod != null) {
-                    onChanged(IntCriterion(
-                      value: value?.value ?? 0,
-                      value2: value?.value2,
-                      modifier: mod,
-                    ));
+                    onChanged(
+                      IntCriterion(
+                        value: value?.value ?? 0,
+                        value2: value?.value2,
+                        modifier: mod,
+                      ),
+                    );
                   }
                 },
                 items: CriterionModifier.values.map((mod) {
-                  return DropdownMenuItem(
-                    value: mod,
-                    child: Text(mod.name),
-                  );
+                  return DropdownMenuItem(value: mod, child: Text(mod.name));
                 }).toList(),
               ),
               SizedBox(width: context.dimensions.spacingSmall),
               Expanded(
                 child: TextField(
+                  textInputAction: TextInputAction.next,
                   keyboardType: TextInputType.number,
-                  decoration: InputDecoration(hintText: context.l10n.filter_value),
+                  decoration: InputDecoration(
+                    hintText: context.l10n.filter_value,
+                  ),
                   onChanged: (val) {
                     final intVal = int.tryParse(val);
                     if (intVal != null) {
-                      onChanged(IntCriterion(
-                        value: intVal,
-                        value2: value?.value2,
-                        modifier: value?.modifier ?? CriterionModifier.equals,
-                      ));
+                      onChanged(
+                        IntCriterion(
+                          value: intVal,
+                          value2: value?.value2,
+                          modifier: value?.modifier ?? CriterionModifier.equals,
+                        ),
+                      );
                     }
                   },
                 ),
@@ -123,24 +129,24 @@ class MultiCriterionInput<T> extends StatelessWidget {
                 value: value?.modifier ?? CriterionModifier.includes,
                 onChanged: (mod) {
                   if (mod != null) {
-                    onChanged(MultiCriterion(
-                      value: value?.value ?? [],
-                      modifier: mod,
-                    ));
+                    onChanged(
+                      MultiCriterion(value: value?.value ?? [], modifier: mod),
+                    );
                   }
                 },
-                items: [
-                  CriterionModifier.includes,
-                  CriterionModifier.excludes,
-                  CriterionModifier.includesAll,
-                  CriterionModifier.isNull,
-                  CriterionModifier.notNull,
-                ].map((mod) {
-                  return DropdownMenuItem(
-                    value: mod,
-                    child: Text(mod.name),
-                  );
-                }).toList(),
+                items:
+                    [
+                      CriterionModifier.includes,
+                      CriterionModifier.excludes,
+                      CriterionModifier.includesAll,
+                      CriterionModifier.isNull,
+                      CriterionModifier.notNull,
+                    ].map((mod) {
+                      return DropdownMenuItem(
+                        value: mod,
+                        child: Text(mod.name),
+                      );
+                    }).toList(),
               ),
               SizedBox(width: context.dimensions.spacingSmall),
               Expanded(
@@ -154,17 +160,24 @@ class MultiCriterionInput<T> extends StatelessWidget {
                         // Show picker and update
                       },
                     ),
-                    ...?value?.value.map((id) => Chip(
-                      label: Text(id),
-                      onDeleted: () {
-                        final newValue = List<String>.from(value?.value ?? []);
-                        newValue.remove(id);
-                        onChanged(MultiCriterion(
-                          value: newValue,
-                          modifier: value?.modifier ?? CriterionModifier.includes,
-                        ));
-                      },
-                    )),
+                    ...?value?.value.map(
+                      (id) => Chip(
+                        label: Text(id),
+                        onDeleted: () {
+                          final newValue = List<String>.from(
+                            value?.value ?? [],
+                          );
+                          newValue.remove(id);
+                          onChanged(
+                            MultiCriterion(
+                              value: newValue,
+                              modifier:
+                                  value?.modifier ?? CriterionModifier.includes,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
                   ],
                 ),
               ),
@@ -202,38 +215,51 @@ class StringCriterionInput extends StatelessWidget {
                 value: value?.modifier ?? CriterionModifier.equals,
                 onChanged: (mod) {
                   if (mod != null) {
-                    if (mod == CriterionModifier.isNull || mod == CriterionModifier.notNull) {
+                    if (mod == CriterionModifier.isNull ||
+                        mod == CriterionModifier.notNull) {
                       onChanged(StringCriterion(value: "", modifier: mod));
                     } else {
-                      onChanged(StringCriterion(
-                        value: value?.value ?? "",
-                        modifier: mod,
-                      ));
+                      onChanged(
+                        StringCriterion(
+                          value: value?.value ?? "",
+                          modifier: mod,
+                        ),
+                      );
                     }
                   }
                 },
-                items: [
-                  CriterionModifier.equals,
-                  CriterionModifier.notEquals,
-                  CriterionModifier.includes,
-                  CriterionModifier.excludes,
-                  CriterionModifier.isNull,
-                  CriterionModifier.notNull,
-                ].map((mod) {
-                  return DropdownMenuItem(value: mod, child: Text(mod.name));
-                }).toList(),
+                items:
+                    [
+                      CriterionModifier.equals,
+                      CriterionModifier.notEquals,
+                      CriterionModifier.includes,
+                      CriterionModifier.excludes,
+                      CriterionModifier.isNull,
+                      CriterionModifier.notNull,
+                    ].map((mod) {
+                      return DropdownMenuItem(
+                        value: mod,
+                        child: Text(mod.name),
+                      );
+                    }).toList(),
               ),
               SizedBox(width: context.dimensions.spacingSmall),
-              if (value?.modifier != CriterionModifier.isNull && value?.modifier != CriterionModifier.notNull)
+              if (value?.modifier != CriterionModifier.isNull &&
+                  value?.modifier != CriterionModifier.notNull)
                 Expanded(
                   child: TextFormField(
+                    textInputAction: TextInputAction.next,
                     initialValue: value?.value ?? '',
-                    decoration: InputDecoration(hintText: context.l10n.filter_value),
+                    decoration: InputDecoration(
+                      hintText: context.l10n.filter_value,
+                    ),
                     onChanged: (val) {
-                      onChanged(StringCriterion(
-                        value: val,
-                        modifier: value?.modifier ?? CriterionModifier.equals,
-                      ));
+                      onChanged(
+                        StringCriterion(
+                          value: val,
+                          modifier: value?.modifier ?? CriterionModifier.equals,
+                        ),
+                      );
                     },
                   ),
                 ),
@@ -271,41 +297,54 @@ class DateCriterionInput extends StatelessWidget {
                 value: value?.modifier ?? CriterionModifier.equals,
                 onChanged: (mod) {
                   if (mod != null) {
-                    if (mod == CriterionModifier.isNull || mod == CriterionModifier.notNull) {
+                    if (mod == CriterionModifier.isNull ||
+                        mod == CriterionModifier.notNull) {
                       onChanged(DateCriterion(value: "", modifier: mod));
                     } else {
-                      onChanged(DateCriterion(
-                        value: value?.value ?? "",
-                        value2: value?.value2,
-                        modifier: mod,
-                      ));
+                      onChanged(
+                        DateCriterion(
+                          value: value?.value ?? "",
+                          value2: value?.value2,
+                          modifier: mod,
+                        ),
+                      );
                     }
                   }
                 },
-                items: [
-                  CriterionModifier.equals,
-                  CriterionModifier.notEquals,
-                  CriterionModifier.greaterThan,
-                  CriterionModifier.lessThan,
-                  CriterionModifier.between,
-                  CriterionModifier.isNull,
-                  CriterionModifier.notNull,
-                ].map((mod) {
-                  return DropdownMenuItem(value: mod, child: Text(mod.name));
-                }).toList(),
+                items:
+                    [
+                      CriterionModifier.equals,
+                      CriterionModifier.notEquals,
+                      CriterionModifier.greaterThan,
+                      CriterionModifier.lessThan,
+                      CriterionModifier.between,
+                      CriterionModifier.isNull,
+                      CriterionModifier.notNull,
+                    ].map((mod) {
+                      return DropdownMenuItem(
+                        value: mod,
+                        child: Text(mod.name),
+                      );
+                    }).toList(),
               ),
               SizedBox(width: context.dimensions.spacingSmall),
-              if (value?.modifier != CriterionModifier.isNull && value?.modifier != CriterionModifier.notNull)
+              if (value?.modifier != CriterionModifier.isNull &&
+                  value?.modifier != CriterionModifier.notNull)
                 Expanded(
                   child: TextFormField(
+                    textInputAction: TextInputAction.next,
                     initialValue: value?.value ?? '',
-                    decoration: InputDecoration(hintText: context.l10n.common_hint_date),
+                    decoration: InputDecoration(
+                      hintText: context.l10n.common_hint_date,
+                    ),
                     onChanged: (val) {
-                      onChanged(DateCriterion(
-                        value: val,
-                        value2: value?.value2,
-                        modifier: value?.modifier ?? CriterionModifier.equals,
-                      ));
+                      onChanged(
+                        DateCriterion(
+                          value: val,
+                          value2: value?.value2,
+                          modifier: value?.modifier ?? CriterionModifier.equals,
+                        ),
+                      );
                     },
                   ),
                 ),

--- a/lib/core/presentation/widgets/stash_image.dart
+++ b/lib/core/presentation/widgets/stash_image.dart
@@ -249,7 +249,10 @@ class StashImage extends ConsumerWidget {
     int? memCacheWidth,
     int? memCacheHeight,
   }) async {
-    if (imageUrl == null || imageUrl.isEmpty || imageUrl.contains('default=true')) return;
+    if (imageUrl == null ||
+        imageUrl.isEmpty ||
+        imageUrl.contains('default=true'))
+      return;
 
     final dedupeKey = '$imageUrl|w${memCacheWidth ?? 0}h${memCacheHeight ?? 0}';
     if (_prefetched.contains(dedupeKey)) return;
@@ -312,6 +315,7 @@ class StashImage extends ConsumerWidget {
       );
 
       return Image.network(
+        excludeFromSemantics: true,
         effectiveUrl,
         headers: headers,
         width: width,
@@ -416,4 +420,3 @@ class StashImage extends ConsumerWidget {
     );
   }
 }
-

--- a/lib/features/performers/presentation/pages/performer_edit_page.dart
+++ b/lib/features/performers/presentation/pages/performer_edit_page.dart
@@ -36,15 +36,15 @@ class _PerformerEditPageState extends ConsumerState<PerformerEditPage> {
   late TextEditingController _eyeColorController;
   late TextEditingController _hairColorController;
   late TextEditingController _weightController;
-  
+
   String? _selectedGender;
   String? _selectedCircumcised;
   DateTime? _birthdate;
   DateTime? _deathDate;
-  
+
   late List<TextEditingController> _urlControllers;
   late List<TextEditingController> _aliasControllers;
-  
+
   String? _scrapedImage;
   bool _isSaving = false;
   bool _isScraping = false;
@@ -56,10 +56,14 @@ class _PerformerEditPageState extends ConsumerState<PerformerEditPage> {
     _nameController = TextEditingController(text: p.name);
     _disambiguationController = TextEditingController(text: p.disambiguation);
     _detailsController = TextEditingController(text: p.details);
-    _heightController = TextEditingController(text: p.heightCm?.toString() ?? '');
+    _heightController = TextEditingController(
+      text: p.heightCm?.toString() ?? '',
+    );
     _measurementsController = TextEditingController(text: p.measurements);
     _fakeTitsController = TextEditingController(text: p.fakeTits);
-    _penisLengthController = TextEditingController(text: p.penisLength?.toString() ?? '');
+    _penisLengthController = TextEditingController(
+      text: p.penisLength?.toString() ?? '',
+    );
     _tattoosController = TextEditingController(text: p.tattoos);
     _piercingsController = TextEditingController(text: p.piercings);
     _careerStartController = TextEditingController(text: p.careerStart);
@@ -69,14 +73,18 @@ class _PerformerEditPageState extends ConsumerState<PerformerEditPage> {
     _eyeColorController = TextEditingController(text: p.eyeColor);
     _hairColorController = TextEditingController(text: p.hairColor);
     _weightController = TextEditingController(text: p.weight?.toString() ?? '');
-    
+
     _selectedGender = p.gender;
     _selectedCircumcised = p.circumcised;
     _birthdate = p.birthdate != null ? DateTime.tryParse(p.birthdate!) : null;
     _deathDate = p.deathDate != null ? DateTime.tryParse(p.deathDate!) : null;
-    
-    _urlControllers = p.urls.isEmpty ? [TextEditingController()] : p.urls.map((u) => TextEditingController(text: u)).toList();
-    _aliasControllers = p.aliasList.isEmpty ? [TextEditingController()] : p.aliasList.map((a) => TextEditingController(text: a)).toList();
+
+    _urlControllers = p.urls.isEmpty
+        ? [TextEditingController()]
+        : p.urls.map((u) => TextEditingController(text: u)).toList();
+    _aliasControllers = p.aliasList.isEmpty
+        ? [TextEditingController()]
+        : p.aliasList.map((a) => TextEditingController(text: a)).toList();
   }
 
   @override
@@ -121,19 +129,25 @@ class _PerformerEditPageState extends ConsumerState<PerformerEditPage> {
     try {
       List<ScrapedPerformer> results = [];
       if (scrapeRequest.url != null) {
-        final res = await ref.read(performerScrapeProvider).scrapePerformerURL(scrapeRequest.url!);
+        final res = await ref
+            .read(performerScrapeProvider)
+            .scrapePerformerURL(scrapeRequest.url!);
         if (res != null) results = [res];
       } else {
-        results = await ref.read(performerScrapeProvider).scrapePerformer(
-          scraperId: scrapeRequest.scraperId,
-          stashBoxEndpoint: scrapeRequest.stashBoxEndpoint,
-          query: scrapeRequest.query,
-        );
+        results = await ref
+            .read(performerScrapeProvider)
+            .scrapePerformer(
+              scraperId: scrapeRequest.scraperId,
+              stashBoxEndpoint: scrapeRequest.stashBoxEndpoint,
+              query: scrapeRequest.query,
+            );
       }
 
       if (!mounted) return;
       if (results.isEmpty) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.scenes_no_results_found)));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(context.l10n.scenes_no_results_found)),
+        );
         return;
       }
 
@@ -181,7 +195,10 @@ class _PerformerEditPageState extends ConsumerState<PerformerEditPage> {
         careerEnd: _careerEndController.text,
         tattoos: _tattoosController.text,
         piercings: _piercingsController.text,
-        aliases: _aliasControllers.map((c) => c.text).where((t) => t.isNotEmpty).join(', '),
+        aliases: _aliasControllers
+            .map((c) => c.text)
+            .where((t) => t.isNotEmpty)
+            .join(', '),
         image: _scrapedImage,
       );
 
@@ -203,45 +220,65 @@ class _PerformerEditPageState extends ConsumerState<PerformerEditPage> {
         if (merged.birthdate != null) {
           _birthdate = DateTime.tryParse(merged.birthdate!);
         }
-        if (merged.ethnicity != null) _ethnicityController.text = merged.ethnicity!;
+        if (merged.ethnicity != null)
+          _ethnicityController.text = merged.ethnicity!;
         if (merged.country != null) _countryController.text = merged.country!;
-        if (merged.eyeColor != null) _eyeColorController.text = merged.eyeColor!;
+        if (merged.eyeColor != null)
+          _eyeColorController.text = merged.eyeColor!;
         if (merged.height != null) _heightController.text = merged.height!;
-        if (merged.measurements != null) _measurementsController.text = merged.measurements!;
-        if (merged.fakeTits != null) _fakeTitsController.text = merged.fakeTits!;
-        if (merged.careerStart != null) _careerStartController.text = merged.careerStart!;
-        if (merged.careerEnd != null) _careerEndController.text = merged.careerEnd!;
+        if (merged.measurements != null)
+          _measurementsController.text = merged.measurements!;
+        if (merged.fakeTits != null)
+          _fakeTitsController.text = merged.fakeTits!;
+        if (merged.careerStart != null)
+          _careerStartController.text = merged.careerStart!;
+        if (merged.careerEnd != null)
+          _careerEndController.text = merged.careerEnd!;
         if (merged.tattoos != null) _tattoosController.text = merged.tattoos!;
 
-        if (merged.piercings != null) _piercingsController.text = merged.piercings!;
-        
+        if (merged.piercings != null)
+          _piercingsController.text = merged.piercings!;
+
         if (merged.aliases != null && merged.aliases!.isNotEmpty) {
-          final aliases = merged.aliases!.split(',').map((s) => s.trim()).where((s) => s.isNotEmpty).toList();
+          final aliases = merged.aliases!
+              .split(',')
+              .map((s) => s.trim())
+              .where((s) => s.isNotEmpty)
+              .toList();
           for (var c in _aliasControllers) {
             c.dispose();
           }
-          _aliasControllers = aliases.map((a) => TextEditingController(text: a)).toList();
-          if (_aliasControllers.isEmpty) _aliasControllers.add(TextEditingController());
+          _aliasControllers = aliases
+              .map((a) => TextEditingController(text: a))
+              .toList();
+          if (_aliasControllers.isEmpty)
+            _aliasControllers.add(TextEditingController());
         }
 
         if (merged.urls.isNotEmpty) {
           for (var c in _urlControllers) {
             c.dispose();
           }
-          _urlControllers = merged.urls.map((u) => TextEditingController(text: u)).toList();
-          if (_urlControllers.isEmpty) _urlControllers.add(TextEditingController());
+          _urlControllers = merged.urls
+              .map((u) => TextEditingController(text: u))
+              .toList();
+          if (_urlControllers.isEmpty)
+            _urlControllers.add(TextEditingController());
         }
-        
+
         if (merged.image != null) {
           _scrapedImage = merged.image;
         } else if (merged.images.isNotEmpty) {
           _scrapedImage = merged.images.first;
         }
       });
-
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.scenes_scrape_failed(e.toString()))));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(context.l10n.scenes_scrape_failed(e.toString())),
+          ),
+        );
       }
     } finally {
       if (mounted) setState(() => _isScraping = false);
@@ -272,15 +309,23 @@ class _PerformerEditPageState extends ConsumerState<PerformerEditPage> {
         'tattoos': _tattoosController.text.trim(),
         'piercings': _piercingsController.text.trim(),
         'weight': int.tryParse(_weightController.text.trim()),
-        'alias_list': _aliasControllers.map((c) => c.text.trim()).where((t) => t.isNotEmpty).toList(),
-        'urls': _urlControllers.map((c) => c.text.trim()).where((t) => t.isNotEmpty).toList(),
+        'alias_list': _aliasControllers
+            .map((c) => c.text.trim())
+            .where((t) => t.isNotEmpty)
+            .toList(),
+        'urls': _urlControllers
+            .map((c) => c.text.trim())
+            .where((t) => t.isNotEmpty)
+            .toList(),
       };
-      
+
       if (_scrapedImage != null) {
         input['image'] = _scrapedImage;
       }
 
-      await ref.read(performerScrapeProvider).updatePerformer(id: widget.performer.id, input: input);
+      await ref
+          .read(performerScrapeProvider)
+          .updatePerformer(id: widget.performer.id, input: input);
 
       if (mounted) {
         ref.invalidate(performerDetailsProvider(widget.performer.id));
@@ -289,7 +334,13 @@ class _PerformerEditPageState extends ConsumerState<PerformerEditPage> {
     } catch (e) {
       if (mounted) {
         setState(() => _isSaving = false);
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.details_failed_update_performer(e.toString()))));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              context.l10n.details_failed_update_performer(e.toString()),
+            ),
+          ),
+        );
       }
     }
   }
@@ -297,19 +348,41 @@ class _PerformerEditPageState extends ConsumerState<PerformerEditPage> {
   @override
   Widget build(BuildContext context) {
     final scrapeEnabled = ref.watch(scrapeEnabledProvider);
-    
+
     return Scaffold(
       appBar: AppBar(
         title: Text(context.l10n.scenes_edit_performer),
         actions: [
           if (scrapeEnabled)
             if (_isScraping)
-              const Center(child: Padding(padding: EdgeInsets.symmetric(horizontal: 16), child: SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2))))
+              const Center(
+                child: Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16),
+                  child: SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                ),
+              )
             else
-              IconButton(onPressed: _scrape, icon: const Icon(Icons.search), tooltip: context.l10n.details_scene_scrape),
+              IconButton(
+                onPressed: _scrape,
+                icon: const Icon(Icons.search),
+                tooltip: context.l10n.details_scene_scrape,
+              ),
           IconButton(
             onPressed: _isSaving ? null : _save,
-            icon: _isSaving ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white)) : const Icon(Icons.save),
+            icon: _isSaving
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: Colors.white,
+                    ),
+                  )
+                : const Icon(Icons.save),
             tooltip: context.l10n.common_save,
           ),
         ],
@@ -320,28 +393,77 @@ class _PerformerEditPageState extends ConsumerState<PerformerEditPage> {
           children: [
             if (_scrapedImage != null)
               Padding(
-                padding: EdgeInsets.only(bottom: context.dimensions.spacingMedium),
+                padding: EdgeInsets.only(
+                  bottom: context.dimensions.spacingMedium,
+                ),
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(AppTheme.radiusSmall),
                   child: _scrapedImage!.startsWith('data:')
-                      ? Image.memory(base64Decode(_scrapedImage!.split(',').last), height: 200, width: double.infinity, fit: BoxFit.cover)
-                      : Image.network(_scrapedImage!, height: 200, width: double.infinity, fit: BoxFit.cover),
+                      ? Image.memory(
+                          excludeFromSemantics: true,
+                          base64Decode(_scrapedImage!.split(',').last),
+                          height: 200,
+                          width: double.infinity,
+                          fit: BoxFit.cover,
+                        )
+                      : Image.network(
+                          excludeFromSemantics: true,
+                          _scrapedImage!,
+                          height: 200,
+                          width: double.infinity,
+                          fit: BoxFit.cover,
+                        ),
                 ),
               ),
-            TextField(controller: _nameController, decoration: InputDecoration(labelText: context.l10n.common_name, border: const OutlineInputBorder())),
+            TextField(
+              textInputAction: TextInputAction.next,
+              controller: _nameController,
+              decoration: InputDecoration(
+                labelText: context.l10n.common_name,
+                border: const OutlineInputBorder(),
+              ),
+            ),
             SizedBox(height: context.dimensions.spacingMedium),
-            TextField(controller: _disambiguationController, decoration: InputDecoration(labelText: context.l10n.performers_field_disambiguation, border: const OutlineInputBorder())),
+            TextField(
+              textInputAction: TextInputAction.next,
+              controller: _disambiguationController,
+              decoration: InputDecoration(
+                labelText: context.l10n.performers_field_disambiguation,
+                border: const OutlineInputBorder(),
+              ),
+            ),
             SizedBox(height: context.dimensions.spacingMedium),
             DropdownButtonFormField<String>(
               initialValue: _selectedGender,
-              decoration: InputDecoration(labelText: context.l10n.performers_gender, border: const OutlineInputBorder()),
+              decoration: InputDecoration(
+                labelText: context.l10n.performers_gender,
+                border: const OutlineInputBorder(),
+              ),
               items: [
-                DropdownMenuItem(value: 'MALE', child: Text(context.l10n.performers_gender_male)),
-                DropdownMenuItem(value: 'FEMALE', child: Text(context.l10n.performers_gender_female)),
-                DropdownMenuItem(value: 'TRANSGENDER_MALE', child: Text(context.l10n.performers_gender_trans_male)),
-                DropdownMenuItem(value: 'TRANSGENDER_FEMALE', child: Text(context.l10n.performers_gender_trans_female)),
-                DropdownMenuItem(value: 'INTERSEX', child: Text(context.l10n.performers_gender_intersex)),
-                DropdownMenuItem(value: 'NON_BINARY', child: Text(context.l10n.performers_gender_non_binary)),
+                DropdownMenuItem(
+                  value: 'MALE',
+                  child: Text(context.l10n.performers_gender_male),
+                ),
+                DropdownMenuItem(
+                  value: 'FEMALE',
+                  child: Text(context.l10n.performers_gender_female),
+                ),
+                DropdownMenuItem(
+                  value: 'TRANSGENDER_MALE',
+                  child: Text(context.l10n.performers_gender_trans_male),
+                ),
+                DropdownMenuItem(
+                  value: 'TRANSGENDER_FEMALE',
+                  child: Text(context.l10n.performers_gender_trans_female),
+                ),
+                DropdownMenuItem(
+                  value: 'INTERSEX',
+                  child: Text(context.l10n.performers_gender_intersex),
+                ),
+                DropdownMenuItem(
+                  value: 'NON_BINARY',
+                  child: Text(context.l10n.performers_gender_non_binary),
+                ),
               ],
               onChanged: (val) => setState(() => _selectedGender = val),
             ),
@@ -351,10 +473,22 @@ class _PerformerEditPageState extends ConsumerState<PerformerEditPage> {
                 Expanded(
                   child: TextField(
                     readOnly: true,
-                    controller: TextEditingController(text: _birthdate?.toIso8601String().split('T').first ?? ''),
-                    decoration: InputDecoration(labelText: context.l10n.performers_field_birthdate, border: const OutlineInputBorder(), suffixIcon: const Icon(Icons.calendar_today)),
+                    controller: TextEditingController(
+                      text:
+                          _birthdate?.toIso8601String().split('T').first ?? '',
+                    ),
+                    decoration: InputDecoration(
+                      labelText: context.l10n.performers_field_birthdate,
+                      border: const OutlineInputBorder(),
+                      suffixIcon: const Icon(Icons.calendar_today),
+                    ),
                     onTap: () async {
-                      final picked = await showDatePicker(context: context, initialDate: _birthdate ?? DateTime.now(), firstDate: DateTime(1900), lastDate: DateTime.now());
+                      final picked = await showDatePicker(
+                        context: context,
+                        initialDate: _birthdate ?? DateTime.now(),
+                        firstDate: DateTime(1900),
+                        lastDate: DateTime.now(),
+                      );
                       if (picked != null) setState(() => _birthdate = picked);
                     },
                   ),
@@ -363,10 +497,22 @@ class _PerformerEditPageState extends ConsumerState<PerformerEditPage> {
                 Expanded(
                   child: TextField(
                     readOnly: true,
-                    controller: TextEditingController(text: _deathDate?.toIso8601String().split('T').first ?? ''),
-                    decoration: InputDecoration(labelText: context.l10n.performers_field_deathdate, border: const OutlineInputBorder(), suffixIcon: const Icon(Icons.calendar_today)),
+                    controller: TextEditingController(
+                      text:
+                          _deathDate?.toIso8601String().split('T').first ?? '',
+                    ),
+                    decoration: InputDecoration(
+                      labelText: context.l10n.performers_field_deathdate,
+                      border: const OutlineInputBorder(),
+                      suffixIcon: const Icon(Icons.calendar_today),
+                    ),
                     onTap: () async {
-                      final picked = await showDatePicker(context: context, initialDate: _deathDate ?? DateTime.now(), firstDate: DateTime(1900), lastDate: DateTime.now());
+                      final picked = await showDatePicker(
+                        context: context,
+                        initialDate: _deathDate ?? DateTime.now(),
+                        firstDate: DateTime(1900),
+                        lastDate: DateTime.now(),
+                      );
                       if (picked != null) setState(() => _deathDate = picked);
                     },
                   ),
@@ -376,75 +522,252 @@ class _PerformerEditPageState extends ConsumerState<PerformerEditPage> {
             SizedBox(height: context.dimensions.spacingMedium),
             Row(
               children: [
-                Expanded(child: TextField(controller: _heightController, keyboardType: TextInputType.number, decoration: InputDecoration(labelText: context.l10n.performers_field_height_cm, border: const OutlineInputBorder()))),
+                Expanded(
+                  child: TextField(
+                    textInputAction: TextInputAction.next,
+                    controller: _heightController,
+                    keyboardType: TextInputType.number,
+                    decoration: InputDecoration(
+                      labelText: context.l10n.performers_field_height_cm,
+                      border: const OutlineInputBorder(),
+                    ),
+                  ),
+                ),
                 SizedBox(width: context.dimensions.spacingMedium),
-                Expanded(child: TextField(controller: _weightController, keyboardType: TextInputType.number, decoration: InputDecoration(labelText: context.l10n.performers_field_weight_kg, border: const OutlineInputBorder()))),
+                Expanded(
+                  child: TextField(
+                    textInputAction: TextInputAction.next,
+                    controller: _weightController,
+                    keyboardType: TextInputType.number,
+                    decoration: InputDecoration(
+                      labelText: context.l10n.performers_field_weight_kg,
+                      border: const OutlineInputBorder(),
+                    ),
+                  ),
+                ),
               ],
             ),
             SizedBox(height: context.dimensions.spacingMedium),
-            TextField(controller: _measurementsController, decoration: InputDecoration(labelText: context.l10n.performers_field_measurements, border: const OutlineInputBorder())),
+            TextField(
+              textInputAction: TextInputAction.next,
+              controller: _measurementsController,
+              decoration: InputDecoration(
+                labelText: context.l10n.performers_field_measurements,
+                border: const OutlineInputBorder(),
+              ),
+            ),
             SizedBox(height: context.dimensions.spacingMedium),
-            TextField(controller: _fakeTitsController, decoration: InputDecoration(labelText: context.l10n.performers_field_fake_tits, border: const OutlineInputBorder())),
+            TextField(
+              textInputAction: TextInputAction.next,
+              controller: _fakeTitsController,
+              decoration: InputDecoration(
+                labelText: context.l10n.performers_field_fake_tits,
+                border: const OutlineInputBorder(),
+              ),
+            ),
             SizedBox(height: context.dimensions.spacingMedium),
-            TextField(controller: _penisLengthController, keyboardType: TextInputType.number, decoration: InputDecoration(labelText: context.l10n.performers_field_penis_length, border: const OutlineInputBorder())),
+            TextField(
+              textInputAction: TextInputAction.next,
+              controller: _penisLengthController,
+              keyboardType: TextInputType.number,
+              decoration: InputDecoration(
+                labelText: context.l10n.performers_field_penis_length,
+                border: const OutlineInputBorder(),
+              ),
+            ),
             SizedBox(height: context.dimensions.spacingMedium),
             DropdownButtonFormField<String>(
               initialValue: _selectedCircumcised,
-              decoration: InputDecoration(labelText: context.l10n.performers_circumcised, border: const OutlineInputBorder()),
+              decoration: InputDecoration(
+                labelText: context.l10n.performers_circumcised,
+                border: const OutlineInputBorder(),
+              ),
               items: [
-                DropdownMenuItem(value: 'CUT', child: Text(context.l10n.performers_circumcised_cut)),
-                DropdownMenuItem(value: 'UNCUT', child: Text(context.l10n.performers_circumcised_uncut)),
+                DropdownMenuItem(
+                  value: 'CUT',
+                  child: Text(context.l10n.performers_circumcised_cut),
+                ),
+                DropdownMenuItem(
+                  value: 'UNCUT',
+                  child: Text(context.l10n.performers_circumcised_uncut),
+                ),
               ],
               onChanged: (val) => setState(() => _selectedCircumcised = val),
             ),
             SizedBox(height: context.dimensions.spacingMedium),
-            TextField(controller: _ethnicityController, decoration: InputDecoration(labelText: context.l10n.performers_field_ethnicity, border: const OutlineInputBorder())),
+            TextField(
+              textInputAction: TextInputAction.next,
+              controller: _ethnicityController,
+              decoration: InputDecoration(
+                labelText: context.l10n.performers_field_ethnicity,
+                border: const OutlineInputBorder(),
+              ),
+            ),
             SizedBox(height: context.dimensions.spacingMedium),
-            TextField(controller: _countryController, decoration: InputDecoration(labelText: context.l10n.performers_field_country, border: const OutlineInputBorder())),
+            TextField(
+              textInputAction: TextInputAction.next,
+              controller: _countryController,
+              decoration: InputDecoration(
+                labelText: context.l10n.performers_field_country,
+                border: const OutlineInputBorder(),
+              ),
+            ),
             SizedBox(height: context.dimensions.spacingMedium),
             Row(
               children: [
-                Expanded(child: TextField(controller: _eyeColorController, decoration: InputDecoration(labelText: context.l10n.performers_field_eye_color, border: const OutlineInputBorder()))),
+                Expanded(
+                  child: TextField(
+                    textInputAction: TextInputAction.next,
+                    controller: _eyeColorController,
+                    decoration: InputDecoration(
+                      labelText: context.l10n.performers_field_eye_color,
+                      border: const OutlineInputBorder(),
+                    ),
+                  ),
+                ),
                 SizedBox(width: context.dimensions.spacingMedium),
-                Expanded(child: TextField(controller: _hairColorController, decoration: InputDecoration(labelText: context.l10n.performers_field_hair_color, border: const OutlineInputBorder()))),
+                Expanded(
+                  child: TextField(
+                    textInputAction: TextInputAction.next,
+                    controller: _hairColorController,
+                    decoration: InputDecoration(
+                      labelText: context.l10n.performers_field_hair_color,
+                      border: const OutlineInputBorder(),
+                    ),
+                  ),
+                ),
               ],
             ),
             SizedBox(height: context.dimensions.spacingMedium),
             Row(
               children: [
-                Expanded(child: TextField(controller: _careerStartController, decoration: InputDecoration(labelText: context.l10n.performers_field_career_start, border: const OutlineInputBorder()))),
+                Expanded(
+                  child: TextField(
+                    textInputAction: TextInputAction.next,
+                    controller: _careerStartController,
+                    decoration: InputDecoration(
+                      labelText: context.l10n.performers_field_career_start,
+                      border: const OutlineInputBorder(),
+                    ),
+                  ),
+                ),
                 SizedBox(width: context.dimensions.spacingMedium),
-                Expanded(child: TextField(controller: _careerEndController, decoration: InputDecoration(labelText: context.l10n.performers_field_career_end, border: const OutlineInputBorder()))),
+                Expanded(
+                  child: TextField(
+                    textInputAction: TextInputAction.next,
+                    controller: _careerEndController,
+                    decoration: InputDecoration(
+                      labelText: context.l10n.performers_field_career_end,
+                      border: const OutlineInputBorder(),
+                    ),
+                  ),
+                ),
               ],
             ),
             SizedBox(height: context.dimensions.spacingMedium),
-            TextField(controller: _tattoosController, decoration: InputDecoration(labelText: context.l10n.performers_field_tattoos, border: const OutlineInputBorder())),
+            TextField(
+              textInputAction: TextInputAction.next,
+              controller: _tattoosController,
+              decoration: InputDecoration(
+                labelText: context.l10n.performers_field_tattoos,
+                border: const OutlineInputBorder(),
+              ),
+            ),
             SizedBox(height: context.dimensions.spacingMedium),
-            TextField(controller: _piercingsController, decoration: InputDecoration(labelText: context.l10n.performers_field_piercings, border: const OutlineInputBorder())),
+            TextField(
+              textInputAction: TextInputAction.next,
+              controller: _piercingsController,
+              decoration: InputDecoration(
+                labelText: context.l10n.performers_field_piercings,
+                border: const OutlineInputBorder(),
+              ),
+            ),
             SizedBox(height: context.dimensions.spacingMedium),
-            TextField(controller: _detailsController, maxLines: 5, decoration: InputDecoration(labelText: context.l10n.common_details, border: const OutlineInputBorder())),
+            TextField(
+              controller: _detailsController,
+              maxLines: 5,
+              decoration: InputDecoration(
+                labelText: context.l10n.common_details,
+                border: const OutlineInputBorder(),
+              ),
+            ),
             SizedBox(height: context.dimensions.spacingMedium),
-            _buildListField(context.l10n.performers_field_aliases, _aliasControllers, () => setState(() => _aliasControllers.add(TextEditingController())), (i) => setState(() { _aliasControllers[i].dispose(); _aliasControllers.removeAt(i); if (_aliasControllers.isEmpty) _aliasControllers.add(TextEditingController()); })),
+            _buildListField(
+              context.l10n.performers_field_aliases,
+              _aliasControllers,
+              () => setState(
+                () => _aliasControllers.add(TextEditingController()),
+              ),
+              (i) => setState(() {
+                _aliasControllers[i].dispose();
+                _aliasControllers.removeAt(i);
+                if (_aliasControllers.isEmpty)
+                  _aliasControllers.add(TextEditingController());
+              }),
+            ),
             SizedBox(height: context.dimensions.spacingMedium),
-            _buildListField(context.l10n.scenes_field_urls, _urlControllers, () => setState(() => _urlControllers.add(TextEditingController())), (i) => setState(() { _urlControllers[i].dispose(); _urlControllers.removeAt(i); if (_urlControllers.isEmpty) _urlControllers.add(TextEditingController()); })),
+            _buildListField(
+              context.l10n.scenes_field_urls,
+              _urlControllers,
+              () =>
+                  setState(() => _urlControllers.add(TextEditingController())),
+              (i) => setState(() {
+                _urlControllers[i].dispose();
+                _urlControllers.removeAt(i);
+                if (_urlControllers.isEmpty)
+                  _urlControllers.add(TextEditingController());
+              }),
+            ),
           ],
         ),
       ),
     );
   }
 
-  Widget _buildListField(String label, List<TextEditingController> controllers, VoidCallback onAdd, Function(int) onRemove) {
+  Widget _buildListField(
+    String label,
+    List<TextEditingController> controllers,
+    VoidCallback onAdd,
+    Function(int) onRemove,
+  ) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(children: [Text(label, style: Theme.of(context).textTheme.titleMedium), const Spacer(), IconButton(tooltip: context.l10n.common_add, onPressed: onAdd, icon: const Icon(Icons.add_circle_outline))]),
-        ...controllers.asMap().entries.map((e) => Padding(
-          padding: EdgeInsets.only(bottom: context.dimensions.spacingSmall),
-          child: Row(children: [
-            Expanded(child: TextField(controller: e.value, decoration: InputDecoration(labelText: label, border: const OutlineInputBorder()))),
-            IconButton(tooltip: context.l10n.common_remove, onPressed: () => onRemove(e.key), icon: const Icon(Icons.remove_circle_outline)),
-          ]),
-        )),
+        Row(
+          children: [
+            Text(label, style: Theme.of(context).textTheme.titleMedium),
+            const Spacer(),
+            IconButton(
+              tooltip: context.l10n.common_add,
+              onPressed: onAdd,
+              icon: const Icon(Icons.add_circle_outline),
+            ),
+          ],
+        ),
+        ...controllers.asMap().entries.map(
+          (e) => Padding(
+            padding: EdgeInsets.only(bottom: context.dimensions.spacingSmall),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    textInputAction: TextInputAction.next,
+                    controller: e.value,
+                    decoration: InputDecoration(
+                      labelText: label,
+                      border: const OutlineInputBorder(),
+                    ),
+                  ),
+                ),
+                IconButton(
+                  tooltip: context.l10n.common_remove,
+                  onPressed: () => onRemove(e.key),
+                  icon: const Icon(Icons.remove_circle_outline),
+                ),
+              ],
+            ),
+          ),
+        ),
       ],
     );
   }

--- a/lib/features/scenes/presentation/pages/scene_edit_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_edit_page.dart
@@ -345,9 +345,11 @@ class _SceneEditPageState extends ConsumerState<SceneEditPage> {
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(context.l10n.scenes_phash_failed(e.toString()))));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(context.l10n.scenes_phash_failed(e.toString())),
+          ),
+        );
       }
     } finally {
       if (mounted) setState(() => _isScraping = false);
@@ -485,12 +487,14 @@ class _SceneEditPageState extends ConsumerState<SceneEditPage> {
                   borderRadius: BorderRadius.circular(8),
                   child: _scrapedImage!.startsWith('data:')
                       ? Image.memory(
+                          excludeFromSemantics: true,
                           base64Decode(_scrapedImage!.split(',').last),
                           height: 200,
                           width: double.infinity,
                           fit: BoxFit.cover,
                         )
                       : Image.network(
+                          excludeFromSemantics: true,
                           _scrapedImage!,
                           height: 200,
                           width: double.infinity,

--- a/lib/features/scenes/presentation/widgets/entity_picker.dart
+++ b/lib/features/scenes/presentation/widgets/entity_picker.dart
@@ -75,6 +75,7 @@ class _EntityPickerState<T> extends ConsumerState<EntityPicker<T>> {
           mainAxisSize: MainAxisSize.min,
           children: [
             TextField(
+              textInputAction: TextInputAction.next,
               controller: _searchController,
               decoration: InputDecoration(
                 hintText: context.l10n.common_search_placeholder,

--- a/lib/features/scenes/presentation/widgets/global_fullscreen_overlay.dart
+++ b/lib/features/scenes/presentation/widgets/global_fullscreen_overlay.dart
@@ -398,6 +398,7 @@ class _GlobalFullscreenOverlayState
                   color: Colors.black,
                   child: castState.isCasting
                       ? Image.network(
+                          excludeFromSemantics: true,
                           appendApiKey(
                             scene.paths.screenshot ?? '',
                             ref.read(serverApiKeyProvider),

--- a/lib/features/scenes/presentation/widgets/scene_video_player.dart
+++ b/lib/features/scenes/presentation/widgets/scene_video_player.dart
@@ -390,7 +390,9 @@ class _SceneVideoPlayerState extends ConsumerState<SceneVideoPlayer> {
         'SceneVideoPlayer [${widget.scene.id}] exiting fullscreen via global state',
         source: 'SceneVideoPlayer',
       );
-      ref.read(playerStateProvider.notifier).syncBackgroundToActiveScene(context);
+      ref
+          .read(playerStateProvider.notifier)
+          .syncBackgroundToActiveScene(context);
       ref.read(playerStateProvider.notifier).setFullScreen(false);
       ref.read(playerStateProvider.notifier).setViewMode(PlayerViewMode.inline);
     } else {
@@ -398,7 +400,9 @@ class _SceneVideoPlayerState extends ConsumerState<SceneVideoPlayer> {
         'SceneVideoPlayer [${widget.scene.id}] entering fullscreen via global state',
         source: 'SceneVideoPlayer',
       );
-      ref.read(playerStateProvider.notifier).setViewMode(PlayerViewMode.fullscreen);
+      ref
+          .read(playerStateProvider.notifier)
+          .setViewMode(PlayerViewMode.fullscreen);
       ref.read(playerStateProvider.notifier).setFullScreen(true);
     }
   }
@@ -506,6 +510,7 @@ class _SceneVideoPlayerState extends ConsumerState<SceneVideoPlayer> {
                         color: Colors.black,
                         child: castState.isCasting
                             ? Image.network(
+                                excludeFromSemantics: true,
                                 appendApiKey(
                                   widget.scene.paths.screenshot ?? '',
                                   ref.read(serverApiKeyProvider),
@@ -620,4 +625,3 @@ class _PrewarmResult {
   final bool succeeded;
   final int? latencyMs;
 }
-

--- a/lib/features/scenes/presentation/widgets/video_controls/cast_selection_sheet.dart
+++ b/lib/features/scenes/presentation/widgets/video_controls/cast_selection_sheet.dart
@@ -71,6 +71,7 @@ class _CastSelectionSheetState extends ConsumerState<CastSelectionSheet> {
             Text(context.l10n.cast_enter_pin),
             const SizedBox(height: 16),
             TextField(
+              textInputAction: TextInputAction.next,
               controller: pinController,
               autofocus: true,
               maxLength: 4,
@@ -135,7 +136,7 @@ class _CastSelectionSheetState extends ConsumerState<CastSelectionSheet> {
       );
 
       await session.loadMedia(media);
-      
+
       // Get current local position to sync
       final playerState = ref.read(playerStateProvider);
       final currentPos = playerState.player?.state.position ?? Duration.zero;
@@ -150,9 +151,7 @@ class _CastSelectionSheetState extends ConsumerState<CastSelectionSheet> {
       if (mounted) {
         Navigator.pop(context);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.cast_casting_to(device.name)),
-          ),
+          SnackBar(content: Text(context.l10n.cast_casting_to(device.name))),
         );
       }
     } on dc.NeedsPairingException catch (_) {
@@ -161,8 +160,10 @@ class _CastSelectionSheetState extends ConsumerState<CastSelectionSheet> {
       if (mounted) Navigator.of(context).pop();
 
       // Trigger PIN display on TV
-      dc.AirPlayPairSetup(host: device.address.address, port: device.port)
-          .startPinDisplay();
+      dc.AirPlayPairSetup(
+        host: device.address.address,
+        port: device.port,
+      ).startPinDisplay();
 
       // Show PIN dialog
       final pin = await _showPinDialog();
@@ -190,7 +191,8 @@ class _CastSelectionSheetState extends ConsumerState<CastSelectionSheet> {
 
           // Get current local position to sync
           final playerState = ref.read(playerStateProvider);
-          final currentPos = playerState.player?.state.position ?? Duration.zero;
+          final currentPos =
+              playerState.player?.state.position ?? Duration.zero;
           if (currentPos > Duration.zero) {
             debugPrint('CastSelectionSheet: seeking cast to $currentPos');
             await session.seek(currentPos);
@@ -217,7 +219,9 @@ class _CastSelectionSheetState extends ConsumerState<CastSelectionSheet> {
 
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text(context.l10n.cast_pairing_failed(e.toString()))),
+              SnackBar(
+                content: Text(context.l10n.cast_pairing_failed(e.toString())),
+              ),
             );
           }
         }
@@ -281,13 +285,11 @@ class _CastSelectionSheetState extends ConsumerState<CastSelectionSheet> {
                 ),
                 IconButton(
                   icon: const Icon(Icons.refresh),
-                    tooltip: context.l10n.common_refresh,
-                    onPressed: () {
-                      debugPrint('CastSelectionSheet: refresh discovery');
-                      ref
-                          .read(castServiceProvider.notifier)
-                          .startDiscovery();
-                    },
+                  tooltip: context.l10n.common_refresh,
+                  onPressed: () {
+                    debugPrint('CastSelectionSheet: refresh discovery');
+                    ref.read(castServiceProvider.notifier).startDiscovery();
+                  },
                 ),
               ],
             ),

--- a/lib/features/setup/presentation/pages/settings/appearance_settings_page.dart
+++ b/lib/features/setup/presentation/pages/settings/appearance_settings_page.dart
@@ -128,7 +128,9 @@ class _AppearanceSettingsPageState
                                   Icons.brightness_auto_outlined,
                                   size: 24 * context.dimensions.fontSizeFactor,
                                 ),
-                                label: Text(l10n.settings_appearance_theme_system),
+                                label: Text(
+                                  l10n.settings_appearance_theme_system,
+                                ),
                               ),
                               ButtonSegment<ThemeMode>(
                                 value: ThemeMode.light,
@@ -136,7 +138,9 @@ class _AppearanceSettingsPageState
                                   Icons.light_mode_outlined,
                                   size: 24 * context.dimensions.fontSizeFactor,
                                 ),
-                                label: Text(l10n.settings_appearance_theme_light),
+                                label: Text(
+                                  l10n.settings_appearance_theme_light,
+                                ),
                               ),
                               ButtonSegment<ThemeMode>(
                                 value: ThemeMode.dark,
@@ -144,7 +148,9 @@ class _AppearanceSettingsPageState
                                   Icons.dark_mode_outlined,
                                   size: 24 * context.dimensions.fontSizeFactor,
                                 ),
-                                label: Text(l10n.settings_appearance_theme_dark),
+                                label: Text(
+                                  l10n.settings_appearance_theme_dark,
+                                ),
                               ),
                             ],
                             selected: {_themeMode},
@@ -207,10 +213,9 @@ class _AppearanceSettingsPageState
               ),
             ),
             TextButton.icon(
-              onPressed:
-                  value == 1.0
-                      ? null
-                      : () => ref.read(appGlobalScaleProvider.notifier).set(1.0),
+              onPressed: value == 1.0
+                  ? null
+                  : () => ref.read(appGlobalScaleProvider.notifier).set(1.0),
               icon: const Icon(Icons.restart_alt, size: 18),
               label: Text(l10n.common_reset),
               style: TextButton.styleFrom(
@@ -252,6 +257,7 @@ class _AppearanceSettingsPageState
         if (isCustom) ...[
           SizedBox(height: context.dimensions.spacingMedium),
           TextField(
+            textInputAction: TextInputAction.next,
             controller: _customHexController,
             focusNode: _customHexFocusNode,
             decoration: InputDecoration(
@@ -305,7 +311,9 @@ class _AppearanceSettingsPageState
             _customHexFocusNode.requestFocus();
           }
         },
-        borderRadius: BorderRadius.circular(20 * context.dimensions.fontSizeFactor),
+        borderRadius: BorderRadius.circular(
+          20 * context.dimensions.fontSizeFactor,
+        ),
         child: Container(
           width: 40 * context.dimensions.fontSizeFactor,
           height: 40 * context.dimensions.fontSizeFactor,

--- a/lib/features/studios/presentation/pages/studio_edit_page.dart
+++ b/lib/features/studios/presentation/pages/studio_edit_page.dart
@@ -23,7 +23,7 @@ class _StudioEditPageState extends ConsumerState<StudioEditPage> {
   late TextEditingController _nameController;
   late TextEditingController _detailsController;
   late TextEditingController _urlController;
-  
+
   String? _scrapedImage;
   bool _isSaving = false;
   bool _isScraping = false;
@@ -59,19 +59,25 @@ class _StudioEditPageState extends ConsumerState<StudioEditPage> {
     try {
       List<ScrapedStudio> results = [];
       if (scrapeRequest.url != null) {
-        final res = await ref.read(studioScrapeProvider).scrapeStudioURL(scrapeRequest.url!);
+        final res = await ref
+            .read(studioScrapeProvider)
+            .scrapeStudioURL(scrapeRequest.url!);
         if (res != null) results = [res];
       } else {
-        results = await ref.read(studioScrapeProvider).scrapeStudio(
-          scraperId: scrapeRequest.scraperId,
-          stashBoxEndpoint: scrapeRequest.stashBoxEndpoint,
-          query: scrapeRequest.query,
-        );
+        results = await ref
+            .read(studioScrapeProvider)
+            .scrapeStudio(
+              scraperId: scrapeRequest.scraperId,
+              stashBoxEndpoint: scrapeRequest.stashBoxEndpoint,
+              query: scrapeRequest.query,
+            );
       }
 
       if (!mounted) return;
       if (results.isEmpty) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.scenes_no_results_found)));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(context.l10n.scenes_no_results_found)),
+        );
         return;
       }
 
@@ -128,10 +134,13 @@ class _StudioEditPageState extends ConsumerState<StudioEditPage> {
         if (merged.url != null) _urlController.text = merged.url!;
         if (merged.image != null) _scrapedImage = merged.image;
       });
-
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.scenes_scrape_failed(e.toString()))));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(context.l10n.scenes_scrape_failed(e.toString())),
+          ),
+        );
       }
     } finally {
       if (mounted) setState(() => _isScraping = false);
@@ -146,12 +155,14 @@ class _StudioEditPageState extends ConsumerState<StudioEditPage> {
         'details': _detailsController.text.trim(),
         'url': _urlController.text.trim(),
       };
-      
+
       if (_scrapedImage != null) {
         input['image'] = _scrapedImage;
       }
 
-      await ref.read(studioScrapeProvider).updateStudio(id: widget.studio.id, input: input);
+      await ref
+          .read(studioScrapeProvider)
+          .updateStudio(id: widget.studio.id, input: input);
 
       if (mounted) {
         ref.invalidate(studioDetailsProvider(widget.studio.id));
@@ -160,7 +171,13 @@ class _StudioEditPageState extends ConsumerState<StudioEditPage> {
     } catch (e) {
       if (mounted) {
         setState(() => _isSaving = false);
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(context.l10n.details_failed_update_studio(e.toString()))));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              context.l10n.details_failed_update_studio(e.toString()),
+            ),
+          ),
+        );
       }
     }
   }
@@ -168,19 +185,41 @@ class _StudioEditPageState extends ConsumerState<StudioEditPage> {
   @override
   Widget build(BuildContext context) {
     final scrapeEnabled = ref.watch(scrapeEnabledProvider);
-    
+
     return Scaffold(
       appBar: AppBar(
         title: Text(context.l10n.scenes_edit_studio),
         actions: [
           if (scrapeEnabled)
             if (_isScraping)
-              const Center(child: Padding(padding: EdgeInsets.symmetric(horizontal: 16), child: SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2))))
+              const Center(
+                child: Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16),
+                  child: SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                ),
+              )
             else
-              IconButton(onPressed: _scrape, icon: const Icon(Icons.search), tooltip: context.l10n.details_scene_scrape),
+              IconButton(
+                onPressed: _scrape,
+                icon: const Icon(Icons.search),
+                tooltip: context.l10n.details_scene_scrape,
+              ),
           IconButton(
             onPressed: _isSaving ? null : _save,
-            icon: _isSaving ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white)) : const Icon(Icons.save),
+            icon: _isSaving
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: Colors.white,
+                    ),
+                  )
+                : const Icon(Icons.save),
             tooltip: context.l10n.common_save,
           ),
         ],
@@ -195,15 +234,48 @@ class _StudioEditPageState extends ConsumerState<StudioEditPage> {
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(8),
                   child: _scrapedImage!.startsWith('data:')
-                      ? Image.memory(base64Decode(_scrapedImage!.split(',').last), height: 150, width: double.infinity, fit: BoxFit.contain)
-                      : Image.network(_scrapedImage!, height: 150, width: double.infinity, fit: BoxFit.contain),
+                      ? Image.memory(
+                          excludeFromSemantics: true,
+                          base64Decode(_scrapedImage!.split(',').last),
+                          height: 150,
+                          width: double.infinity,
+                          fit: BoxFit.contain,
+                        )
+                      : Image.network(
+                          excludeFromSemantics: true,
+                          _scrapedImage!,
+                          height: 150,
+                          width: double.infinity,
+                          fit: BoxFit.contain,
+                        ),
                 ),
               ),
-            TextField(controller: _nameController, decoration: InputDecoration(labelText: context.l10n.common_name, border: const OutlineInputBorder())),
+            TextField(
+              textInputAction: TextInputAction.next,
+              controller: _nameController,
+              decoration: InputDecoration(
+                labelText: context.l10n.common_name,
+                border: const OutlineInputBorder(),
+              ),
+            ),
             const SizedBox(height: 16),
-            TextField(controller: _urlController, decoration: InputDecoration(labelText: context.l10n.common_url, border: const OutlineInputBorder())),
+            TextField(
+              textInputAction: TextInputAction.next,
+              controller: _urlController,
+              decoration: InputDecoration(
+                labelText: context.l10n.common_url,
+                border: const OutlineInputBorder(),
+              ),
+            ),
             const SizedBox(height: 16),
-            TextField(controller: _detailsController, maxLines: 5, decoration: InputDecoration(labelText: context.l10n.common_details, border: const OutlineInputBorder())),
+            TextField(
+              controller: _detailsController,
+              maxLines: 5,
+              decoration: InputDecoration(
+                labelText: context.l10n.common_details,
+                border: const OutlineInputBorder(),
+              ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
**What:** 
- Added `textInputAction: TextInputAction.next` to numerous `TextField` and `TextFormField` components across several forms (e.g., Performer Edit, Scene Edit, Studio Edit).
- Added `excludeFromSemantics: true` to decorative `Image.network` and `Image.memory` elements.

**Why:** 
- Without `textInputAction`, users on mobile keyboards might not easily advance to the next field.
- Without `excludeFromSemantics`, screen readers may read long and unhelpful base64 image strings or URLs when focusing on decorative image widgets.

**Before/After:**
- Forms now have better mobile keyboard usability (e.g., the 'Next' button correctly transitions to the next text field).
- Screen readers skip reading the raw URL/base64 strings for images.

**Accessibility:** 
- Better screen reader experience and mobile form navigation.

---
*PR created automatically by Jules for task [18396758148013941473](https://jules.google.com/task/18396758148013941473) started by @Alchemist-Aloha*