### PR TITLE
⚡ Bolt: [Hoist Router Layout Lookups from itemBuilder]

### DIFF
--- a/lib/features/scenes/presentation/widgets/tiktok_scenes_view.dart
+++ b/lib/features/scenes/presentation/widgets/tiktok_scenes_view.dart
@@ -335,6 +335,14 @@ class _TiktokScenesViewState extends ConsumerState<TiktokScenesView> {
     final scenesAsync = ref.watch(sceneListProvider);
     final playerState = ref.watch(playerStateProvider);
 
+    // ⚡ Bolt: Hoist routing layout variables out of the itemBuilder loop.
+    // Why: Looking up the router via InheritedWidget causes redundant O(1) traversals
+    // on every rendered list item during scroll.
+    // Impact: Avoids GC pressure and reduces scroll stuttering.
+    final router = GoRouter.of(context);
+    final currentPath = router.routeInformationProvider.value.uri.path;
+    final isAtRoot = currentPath == '/scenes';
+
     return scenesAsync.when(
       data: (scenes) {
         if (scenes.isEmpty) {
@@ -394,11 +402,6 @@ class _TiktokScenesViewState extends ConsumerState<TiktokScenesView> {
               } else {
                 controller = _controllers[scene.id];
               }
-
-              final router = GoRouter.of(context);
-              final currentPath =
-                  router.routeInformationProvider.value.uri.path;
-              final isAtRoot = currentPath == '/scenes';
 
               return TiktokSceneItem(
                 scene: scene,


### PR DESCRIPTION
What: Moved `GoRouter.of(context)`, `routeInformationProvider.value.uri.path`, and `isAtRoot` variable calculations out of the `itemBuilder` callback and into the parent `build` method in `tiktok_scenes_view.dart`.

Why: Looking up InheritedWidgets and traversing deeply nested properties inside an `itemBuilder` executes redundantly on every single rendered list item during a scroll event. This causes unnecessary garbage collection pressure and layout computation overhead.

Impact: Reduces router layout lookups and path string matching from O(N) to O(1) per page render, avoiding scroll stuttering and reducing CPU cycles during fast scrolling through the TikTok view.

Measurement: Profile the `tiktok_scenes_view` page scroll performance in Flutter DevTools to observe reduced `build` times for list items.

---
*PR created automatically by Jules for task [18128277807799990424](https://jules.google.com/task/18128277807799990424) started by @Alchemist-Aloha*