### PR TITLE
🎨 Palette: [UX improvement] Exclude raw images from semantics in Fullscreen viewer

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-19 - Localize tooltips
 **Learning:** Hardcoded strings in `tooltip` properties of interactive elements like `IconButton` break localization and make the app less accessible to international users, especially for those using screen readers. `IconButton` components use the `tooltip` property not only to display a popup on hover but also to provide the semantic label for accessibility purposes.
 **Action:** Always verify if a tooltip string can be linked to an existing localization key via `context.l10n`. If none exists, add one to `lib/l10n/app_en.arb` and generate the localization bindings using `flutter gen-l10n`. Never use hardcoded strings for tooltips or semantic labels.
+
+## 2024-05-18 - Fullscreen Raw Image Semantics
+**Learning:** Screen readers may redundantly announce "Image" or attempt to read the raw URL data for decorative/fullscreen raw image viewers like `ExtendedImage.network` if no semantic label is provided, trapping focus on unhelpful content.
+**Action:** Always add `excludeFromSemantics: true` to purely decorative or context-less fullscreen images (especially those fetching raw URLs) to prevent unhelpful screen reader announcements.

--- a/lib/features/images/presentation/pages/image_fullscreen_page.dart
+++ b/lib/features/images/presentation/pages/image_fullscreen_page.dart
@@ -1044,6 +1044,7 @@ class _ImageFullscreenPageState extends ConsumerState<ImageFullscreenPage> {
                             return RepaintBoundary(
                               child: ExtendedImage.network(
                                 imageUrl,
+                                excludeFromSemantics: true,
                                 headers: headers,
                                 fit: BoxFit.contain,
                                 mode: ExtendedImageMode.gesture,


### PR DESCRIPTION
💡 **What**: Added `excludeFromSemantics: true` to the `ExtendedImage.network` widget in `ImageFullscreenPage`.

🎯 **Why**: When users open the full-screen image viewer, screen readers would automatically focus the raw image viewer and read out "Image" or attempt to announce the underlying URL/paths. In a dedicated viewer context, the user already knows they are viewing an image, and the image data itself offers no semantic context without alt text. Excluding it from semantics prevents unhelpful noise and traps, allowing users to more easily navigate to actionable overlay buttons (like the close or favorite buttons).

♿ **Accessibility**: Reduces screen reader noise and improves focus management for users navigating via assistive technologies.

---
*PR created automatically by Jules for task [16038757059866594869](https://jules.google.com/task/16038757059866594869) started by @Alchemist-Aloha*