### PR TITLE
refactor(l10n): Extract hardcoded text to l10n and translate keys

### DIFF
--- a/lib/features/galleries/presentation/widgets/gallery_filter_panel.dart
+++ b/lib/features/galleries/presentation/widgets/gallery_filter_panel.dart
@@ -316,7 +316,7 @@ class _GalleryFilterPanelState extends ConsumerState<GalleryFilterPanel> {
                     : Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Text('$stars'),
+                          Text(context.l10n.common_stars(stars)),
                           SizedBox(width: context.dimensions.spacingSmall / 2),
                           Icon(
                             Icons.star,

--- a/lib/features/images/presentation/widgets/image_filter_panel.dart
+++ b/lib/features/images/presentation/widgets/image_filter_panel.dart
@@ -291,7 +291,7 @@ class _ImageFilterPanelState extends ConsumerState<ImageFilterPanel> {
                     : Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Text('$stars'),
+                          Text(context.l10n.common_stars(stars)),
                           SizedBox(width: context.dimensions.spacingSmall / 2),
                           Icon(
                             Icons.star,

--- a/lib/features/performers/presentation/widgets/performer_filter_panel.dart
+++ b/lib/features/performers/presentation/widgets/performer_filter_panel.dart
@@ -250,7 +250,7 @@ class _PerformerFilterPanelState extends ConsumerState<PerformerFilterPanel> {
                     : Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Text('$stars'),
+                          Text(context.l10n.common_stars(stars)),
                           SizedBox(width: context.dimensions.spacingSmall / 2),
                           Icon(
                             Icons.star,

--- a/lib/features/scenes/presentation/pages/scene_details_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_details_page.dart
@@ -582,7 +582,7 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
           IconButton(
             padding: EdgeInsets.zero,
             constraints: const BoxConstraints(),
-            tooltip: '$i Star${i > 1 ? 's' : ''}',
+            tooltip: context.l10n.common_stars(i),
             onPressed: () async {
               final currentRating = scene.rating100 ?? 0;
               final newRating = (currentRating == i * 20) ? 0 : i * 20;

--- a/lib/features/scenes/presentation/pages/scene_info_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_info_page.dart
@@ -125,7 +125,7 @@ class _SceneInfoPageState extends ConsumerState<SceneInfoPage> {
                   dense: true,
                   contentPadding: EdgeInsets.zero,
                   title: Text(scene.studioName!),
-                  subtitle: scene.studioId != null ? Text('ID: ${scene.studioId}') : null,
+                  subtitle: scene.studioId != null ? Text(context.l10n.common_id(scene.studioId!)) : null,
                   trailing: const Icon(Icons.chevron_right_rounded),
                   onTap: scene.studioId != null && scene.studioId!.trim().isNotEmpty
                       ? () => _closeAndNavigate('/studios/studio/${scene.studioId}')

--- a/lib/features/scenes/presentation/widgets/scene_filter_panel.dart
+++ b/lib/features/scenes/presentation/widgets/scene_filter_panel.dart
@@ -543,7 +543,7 @@ class _SceneFilterPanelState extends ConsumerState<SceneFilterPanel> {
                     : Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Text('$stars'),
+                          Text(context.l10n.common_stars(stars)),
                           SizedBox(width: context.dimensions.spacingSmall / 2),
                           Icon(
                             Icons.star,

--- a/lib/features/studios/presentation/widgets/studio_filter_panel.dart
+++ b/lib/features/studios/presentation/widgets/studio_filter_panel.dart
@@ -290,7 +290,7 @@ class _StudioFilterPanelState extends ConsumerState<StudioFilterPanel> {
                     : Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Text('$stars'),
+                          Text(context.l10n.common_stars(stars)),
                           SizedBox(width: context.dimensions.spacingSmall / 2),
                           Icon(
                             Icons.star,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -874,5 +874,6 @@
   "performer_filters": "Darstellerfilter",
   "update_available": "Eine neue Version von StashFlow ({version}) ist verfügbar.",
   "details_failed_update_favorite": "Favorit konnte nicht aktualisiert werden: {error}",
-  "details_failed_load_galleries": "Fehler beim Laden der Galerien: {error}"
+  "details_failed_load_galleries": "Fehler beim Laden der Galerien: {error}",
+  "common_stars": "{count, plural, =1{1 Stern} other{{count} Sterne}}"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -952,5 +952,20 @@
         "type": "String"
       }
     }
+  },
+  "common_stars": "{count, plural, =1{1 Star} other{{count} Stars}}",
+  "@common_stars": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@common_id": {
+    "placeholders": {
+      "id": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -853,5 +853,6 @@
   "performer_filters": "Filtros de artistas",
   "update_available": "Una nueva versión de StashFlow ({version}) está disponible.",
   "details_failed_update_favorite": "Error al actualizar favorito: {error}",
-  "details_failed_load_galleries": "Error al cargar galerías: {error}"
+  "details_failed_load_galleries": "Error al cargar galerías: {error}",
+  "common_stars": "{count, plural, =1{1 Estrella} other{{count} estrellas}}"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -853,5 +853,6 @@
   "performer_filters": "Filtres d'artistes",
   "update_available": "Une nouvelle version de StashFlow ({version}) est disponible.",
   "details_failed_update_favorite": "Échec de la mise à jour du favori: {error}",
-  "details_failed_load_galleries": "Échec du chargement des galeries: {error}"
+  "details_failed_load_galleries": "Échec du chargement des galeries: {error}",
+  "common_stars": "{count, plural, =1{1 Étoile} other{{count} Étoiles}}"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -858,5 +858,6 @@
   "performer_filters": "Filtri artisti",
   "update_available": "Una nuova versione di StashFlow ({version}) è disponibile.",
   "details_failed_update_favorite": "Impossibile aggiornare il preferito: {error}",
-  "details_failed_load_galleries": "Impossibile caricare le gallerie: {error}"
+  "details_failed_load_galleries": "Impossibile caricare le gallerie: {error}",
+  "common_stars": "{count, plural, =1{1 Stella} other{{count} Stelle}}"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -853,5 +853,6 @@
   "performer_filters": "出演者フィルター",
   "update_available": "StashFlowの新しいバージョン ({version}) が利用可能です。",
   "details_failed_update_favorite": "お気に入りの更新に失敗しました: {error}",
-  "details_failed_load_galleries": "ギャラリーの読み込みに失敗しました: {error}"
+  "details_failed_load_galleries": "ギャラリーの読み込みに失敗しました: {error}",
+  "common_stars": "{count, plural, =1{1 星} other{{count} スター}}"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -853,5 +853,6 @@
   "performer_filters": "출연자 필터",
   "update_available": "StashFlow의 새 버전 ({version})을(를) 사용할 수 있습니다.",
   "details_failed_update_favorite": "즐겨찾기 업데이트 실패: {error}",
-  "details_failed_load_galleries": "갤러리 로드 실패: {error}"
+  "details_failed_load_galleries": "갤러리 로드 실패: {error}",
+  "common_stars": "{count, plural, =1{1 별} other{{count} 별}}"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -640,7 +640,7 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'ID: {id}'**
-  String common_id(Object id);
+  String common_id(String id);
 
   /// No description provided for @common_search_placeholder.
   ///
@@ -4367,6 +4367,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Failed to load galleries: {error}'**
   String details_failed_load_galleries(String error);
+
+  /// No description provided for @common_stars.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 Star} other{{count} Stars}}'**
+  String common_stars(int count);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -322,7 +322,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get common_no_media_available => 'keine Medien verfügbar';
 
   @override
-  String common_id(Object id) {
+  String common_id(String id) {
     return 'ID: $id';
   }
 
@@ -2370,5 +2370,16 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String details_failed_load_galleries(String error) {
     return 'Fehler beim Laden der Galerien: $error';
+  }
+
+  @override
+  String common_stars(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Sterne',
+      one: '1 Stern',
+    );
+    return '$_temp0';
   }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -316,7 +316,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get common_no_media_available => 'No media available';
 
   @override
-  String common_id(Object id) {
+  String common_id(String id) {
     return 'ID: $id';
   }
 
@@ -2331,5 +2331,16 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String details_failed_load_galleries(String error) {
     return 'Failed to load galleries: $error';
+  }
+
+  @override
+  String common_stars(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Stars',
+      one: '1 Star',
+    );
+    return '$_temp0';
   }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -324,7 +324,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get common_no_media_available => 'sin medios disponibles';
 
   @override
-  String common_id(Object id) {
+  String common_id(String id) {
     return 'ID: $id';
   }
 
@@ -2393,5 +2393,16 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String details_failed_load_galleries(String error) {
     return 'Error al cargar galerías: $error';
+  }
+
+  @override
+  String common_stars(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count estrellas',
+      one: '1 Estrella',
+    );
+    return '$_temp0';
   }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -322,7 +322,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get common_no_media_available => 'aucun média disponible';
 
   @override
-  String common_id(Object id) {
+  String common_id(String id) {
     return 'ID : $id';
   }
 
@@ -2383,5 +2383,16 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String details_failed_load_galleries(String error) {
     return 'Échec du chargement des galeries: $error';
+  }
+
+  @override
+  String common_stars(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Étoiles',
+      one: '1 Étoile',
+    );
+    return '$_temp0';
   }
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -324,7 +324,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get common_no_media_available => 'nessun media disponibile';
 
   @override
-  String common_id(Object id) {
+  String common_id(String id) {
     return 'ID: $id';
   }
 
@@ -2387,5 +2387,16 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String details_failed_load_galleries(String error) {
     return 'Impossibile caricare le gallerie: $error';
+  }
+
+  @override
+  String common_stars(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Stelle',
+      one: '1 Stella',
+    );
+    return '$_temp0';
   }
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -314,7 +314,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get common_no_media_available => 'メディアなし';
 
   @override
-  String common_id(Object id) {
+  String common_id(String id) {
     return 'ID: $id';
   }
 
@@ -2283,5 +2283,16 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String details_failed_load_galleries(String error) {
     return 'ギャラリーの読み込みに失敗しました: $error';
+  }
+
+  @override
+  String common_stars(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count スター',
+      one: '1 星',
+    );
+    return '$_temp0';
   }
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -312,7 +312,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get common_no_media_available => '미디어 없음';
 
   @override
-  String common_id(Object id) {
+  String common_id(String id) {
     return 'ID: $id';
   }
 
@@ -2283,5 +2283,16 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String details_failed_load_galleries(String error) {
     return '갤러리 로드 실패: $error';
+  }
+
+  @override
+  String common_stars(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 별',
+      one: '1 별',
+    );
+    return '$_temp0';
   }
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -320,7 +320,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get common_no_media_available => 'нет доступных медиа';
 
   @override
-  String common_id(Object id) {
+  String common_id(String id) {
     return 'ID: $id';
   }
 
@@ -2363,5 +2363,16 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String details_failed_load_galleries(String error) {
     return 'Не удалось загрузить галереи: $error';
+  }
+
+  @override
+  String common_stars(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Звезды',
+      one: '1 Звезда',
+    );
+    return '$_temp0';
   }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -312,7 +312,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get common_no_media_available => '无可用媒体';
 
   @override
-  String common_id(Object id) {
+  String common_id(String id) {
     return 'ID：$id';
   }
 
@@ -2261,6 +2261,17 @@ class AppLocalizationsZh extends AppLocalizations {
   String details_failed_load_galleries(String error) {
     return '加载图库失败: $error';
   }
+
+  @override
+  String common_stars(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 星星',
+      one: '1 星星',
+    );
+    return '$_temp0';
+  }
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -2571,7 +2582,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get common_no_media_available => '无可用媒体';
 
   @override
-  String common_id(Object id) {
+  String common_id(String id) {
     return 'ID：$id';
   }
 
@@ -4520,6 +4531,17 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String details_failed_load_galleries(String error) {
     return '加载图库失败: $error';
   }
+
+  @override
+  String common_stars(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 星星',
+      one: '1 星星',
+    );
+    return '$_temp0';
+  }
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -4832,7 +4854,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get common_no_media_available => '無可用媒體';
 
   @override
-  String common_id(Object id) {
+  String common_id(String id) {
     return 'ID：$id';
   }
 
@@ -6782,5 +6804,16 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   @override
   String details_failed_load_galleries(String error) {
     return '載入圖庫失敗: $error';
+  }
+
+  @override
+  String common_stars(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 星星',
+      one: '1 星星',
+    );
+    return '$_temp0';
   }
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -853,5 +853,6 @@
   "performer_filters": "Фильтры исполнителей",
   "update_available": "Доступна новая версия StashFlow ({version}).",
   "details_failed_update_favorite": "Не удалось обновить избранное: {error}",
-  "details_failed_load_galleries": "Не удалось загрузить галереи: {error}"
+  "details_failed_load_galleries": "Не удалось загрузить галереи: {error}",
+  "common_stars": "{count, plural, =1{1 Звезда} other{{count} Звезды}}"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -853,5 +853,6 @@
   "performer_filters": "演员筛选",
   "update_available": "StashFlow的更新版本 ({version}) 已经发布。",
   "details_failed_update_favorite": "更新收藏失败: {error}",
-  "details_failed_load_galleries": "加载图库失败: {error}"
+  "details_failed_load_galleries": "加载图库失败: {error}",
+  "common_stars": "{count, plural, =1{1 星星} other{{count} 星星}}"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -839,5 +839,6 @@
   "details_failed_update_favorite": "更新收藏失败: {error}",
   "details_failed_load_galleries": "加载图库失败: {error}",
   "common_select": "选择 {label}",
-  "common_saved_to": "保存至 {path}"
+  "common_saved_to": "保存至 {path}",
+  "common_stars": "{count, plural, =1{1 星星} other{{count} 星星}}"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -839,5 +839,6 @@
   "details_failed_update_favorite": "更新收藏失敗: {error}",
   "details_failed_load_galleries": "載入圖庫失敗: {error}",
   "common_select": "選擇 {label}",
-  "common_saved_to": "儲存至 {path}"
+  "common_saved_to": "儲存至 {path}",
+  "common_stars": "{count, plural, =1{1 星星} other{{count} 星星}}"
 }


### PR DESCRIPTION
This PR refactors multiple hardcoded strings across the project to use localization keys, ensuring proper internationalization.

Changes made:
- Identified hardcoded strings for "Stars" in various filter panels (`GalleryFilterPanel`, `ImageFilterPanel`, `PerformerFilterPanel`, `SceneFilterPanel`, `StudioFilterPanel`) and `SceneDetailsPage`.
- Identified a hardcoded "ID" string in `SceneInfoPage`.
- Extracted these strings into `app_en.arb` by adding a new `common_stars` key utilizing ICU pluralization and fixing the existing `@common_id` placeholder.
- Translated the new `common_stars` key for all supported language locales (`de`, `es`, `fr`, `it`, `ja`, `ko`, `ru`, `zh`, `zh_Hans`, `zh_Hant`) using an automated translation script.
- Regenerated the localization classes by running `flutter gen-l10n`.
- Replaced the hardcoded strings in the UI components with their respective `context.l10n` accessors.

---
*PR created automatically by Jules for task [6164778365508740468](https://jules.google.com/task/6164778365508740468) started by @Alchemist-Aloha*