### PR TITLE
chore: replace hardcoded text with l10n keys

### DIFF
--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -661,7 +661,7 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                     SizedBox(width: context.dimensions.spacingSmall),
                     Expanded(
                       child: Text(
-                        'Searching for: "$_currentQuery"',
+                        context.l10n.common_searching_for(_currentQuery ?? ''),
                         style: context.textTheme.bodyMedium?.copyWith(
                           fontWeight: FontWeight.bold,
                         ),

--- a/lib/features/scenes/presentation/widgets/player_surface.dart
+++ b/lib/features/scenes/presentation/widgets/player_surface.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:stash_app_flutter/core/utils/l10n_extensions.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 import 'package:vector_math/vector_math_64.dart' show Vector3;
@@ -207,7 +208,7 @@ class _PlayerSurfaceState extends ConsumerState<PlayerSurface> {
                         ),
                         const SizedBox(height: 8),
                         Text(
-                          'Casting to ${castState.activeSession?.device.name ?? 'Device'}',
+                          context.l10n.cast_casting_to(castState.activeSession?.device.name ?? context.l10n.cast_device),
                           style: const TextStyle(
                             color: Colors.white,
                             fontWeight: FontWeight.bold,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -894,5 +894,11 @@
   "scene_info_sprite": "Sprite",
   "scene_info_technical": "Technisch",
   "scene_studio_id": "ID: {id}",
-  "scene_rating_stars": "{count, plural, =1{1 Stern} other{{count} Sterne}}"
+  "scene_rating_stars": "{count, plural, =1{1 Stern} other{{count} Sterne}}",
+  "settings_playback_resume_position": "Von der letzten Spielposition aus fortfahren",
+  "settings_playback_resume_position_subtitle": "Wenn Sie ein Video öffnen, wird es automatisch an der Stelle fortgesetzt, an der Sie aufgehört haben",
+  "main_startup_failed": "StashFlow konnte nicht gestartet werden",
+  "main_startup_failed_desc": "Ein Startdienst ist fehlgeschlagen, bevor die App die Initialisierung abschließen konnte.Starten Sie die App neu, nachdem Sie die Diagnose überprüft haben.",
+  "common_searching_for": "Suche nach: „{query}“",
+  "cast_device": "Gerät"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -988,5 +988,16 @@
         "type": "int"
       }
     }
-  }
+  },
+  "main_startup_failed": "StashFlow failed to start",
+  "main_startup_failed_desc": "A startup service failed before the app could finish initializing. Restart the app after checking diagnostics.",
+  "common_searching_for": "Searching for: \"{query}\"",
+  "@common_searching_for": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "cast_device": "Device"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -873,5 +873,11 @@
   "scene_info_sprite": "Duende",
   "scene_studio_id": "Identificación: {id}",
   "scene_rating_stars": "{count, plural, =1{1 estrella} other{{count} estrellas}}",
-  "scene_info_technical": "Técnico"
+  "scene_info_technical": "Técnico",
+  "settings_playback_resume_position": "Reanudar desde la última posición de juego",
+  "settings_playback_resume_position_subtitle": "Al abrir un vídeo, se reanuda automáticamente desde donde lo dejaste.",
+  "main_startup_failed": "StashFlow no pudo iniciarse",
+  "main_startup_failed_desc": "Un servicio de inicio falló antes de que la aplicación pudiera terminar de inicializarse.Reinicie la aplicación después de verificar los diagnósticos.",
+  "common_searching_for": "Buscando: \"{query}\"",
+  "cast_device": "Dispositivo"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -873,5 +873,11 @@
   "scene_info_sprite": "Lutin",
   "scene_info_technical": "Technique",
   "scene_studio_id": "Identifiant : {id}",
-  "scene_rating_stars": "{count, plural, =1{1 étoile} other{{count} Étoiles}}"
+  "scene_rating_stars": "{count, plural, =1{1 étoile} other{{count} Étoiles}}",
+  "settings_playback_resume_position": "Reprendre à partir de la dernière position de jeu",
+  "settings_playback_resume_position_subtitle": "Lors de l'ouverture d'une vidéo, reprenez automatiquement là où vous vous étiez arrêté",
+  "main_startup_failed": "StashFlow n'a pas réussi à démarrer",
+  "main_startup_failed_desc": "Un service de démarrage a échoué avant que l'application puisse terminer son initialisation.Redémarrez l'application après avoir vérifié les diagnostics.",
+  "common_searching_for": "Recherche de : \"{query}\"",
+  "cast_device": "Appareil"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -878,5 +878,11 @@
   "scene_info_sprite": "Folletto",
   "scene_studio_id": "ID: {id}",
   "scene_rating_stars": "{count, plural, =1{1 stella} other{{count} Stelle}}",
-  "scene_info_technical": "Tecnico"
+  "scene_info_technical": "Tecnico",
+  "settings_playback_resume_position": "Riprendi dall'ultima posizione di gioco",
+  "settings_playback_resume_position_subtitle": "Quando apri un video, riprendi automaticamente da dove avevi interrotto",
+  "main_startup_failed": "Impossibile avviare StashFlow",
+  "main_startup_failed_desc": "Un servizio di avvio non è riuscito prima che l'app potesse completare l'inizializzazione.Riavvia l'app dopo aver controllato la diagnostica.",
+  "common_searching_for": "Cercando: \"{query}\"",
+  "cast_device": "Dispositivo"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -873,5 +873,11 @@
   "scene_info_sprite": "スプライト",
   "scene_info_technical": "テクニカル",
   "scene_studio_id": "ID: {id}",
-  "scene_rating_stars": "{count, plural, =1{1 つ星} other{{count} スター}}"
+  "scene_rating_stars": "{count, plural, =1{1 つ星} other{{count} スター}}",
+  "settings_playback_resume_position": "最後に再生した位置から再開",
+  "settings_playback_resume_position_subtitle": "ビデオを開くと、中断したところから自動的に再開します",
+  "main_startup_failed": "StashFlow の開始に失敗しました",
+  "main_startup_failed_desc": "アプリの初期化が完了する前に、スタートアップ サービスが失敗しました。診断を確認した後、アプリを再起動します。",
+  "common_searching_for": "検索中:「{query}」",
+  "cast_device": "デバイス"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -873,5 +873,11 @@
   "scene_info_sprite": "요정",
   "scene_info_technical": "인위적인",
   "scene_studio_id": "ID: {id}",
-  "scene_rating_stars": "{count, plural, =1{별 1개} other{{count} 별}}"
+  "scene_rating_stars": "{count, plural, =1{별 1개} other{{count} 별}}",
+  "settings_playback_resume_position": "마지막 재생 위치에서 다시 시작",
+  "settings_playback_resume_position_subtitle": "비디오를 열 때 중단한 부분부터 자동으로 다시 시작",
+  "main_startup_failed": "StashFlow를 시작하지 못했습니다.",
+  "main_startup_failed_desc": "앱 초기화가 완료되기 전에 시작 서비스가 실패했습니다.진단을 확인한 후 앱을 다시 시작하세요.",
+  "common_searching_for": "검색 중: \"{query}\"",
+  "cast_device": "장치"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4499,6 +4499,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =1{1 Star} other{{count} Stars}}'**
   String scene_rating_stars(int count);
+
+  /// No description provided for @main_startup_failed.
+  ///
+  /// In en, this message translates to:
+  /// **'StashFlow failed to start'**
+  String get main_startup_failed;
+
+  /// No description provided for @main_startup_failed_desc.
+  ///
+  /// In en, this message translates to:
+  /// **'A startup service failed before the app could finish initializing. Restart the app after checking diagnostics.'**
+  String get main_startup_failed_desc;
+
+  /// No description provided for @common_searching_for.
+  ///
+  /// In en, this message translates to:
+  /// **'Searching for: \"{query}\"'**
+  String common_searching_for(String query);
+
+  /// No description provided for @cast_device.
+  ///
+  /// In en, this message translates to:
+  /// **'Device'**
+  String get cast_device;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1365,11 +1365,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settings_playback_resume_position =>
-      'Resume from last playing position';
+      'Von der letzten Spielposition aus fortfahren';
 
   @override
   String get settings_playback_resume_position_subtitle =>
-      'When opening a video, automatically resume from where you left off';
+      'Wenn Sie ein Video öffnen, wird es automatisch an der Stelle fortgesetzt, an der Sie aufgehört haben';
 
   @override
   String get settings_playback_end_behavior => 'Endeverhalten abspielen';
@@ -2449,4 +2449,19 @@ class AppLocalizationsDe extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get main_startup_failed => 'StashFlow konnte nicht gestartet werden';
+
+  @override
+  String get main_startup_failed_desc =>
+      'Ein Startdienst ist fehlgeschlagen, bevor die App die Initialisierung abschließen konnte.Starten Sie die App neu, nachdem Sie die Diagnose überprüft haben.';
+
+  @override
+  String common_searching_for(String query) {
+    return 'Suche nach: „$query“';
+  }
+
+  @override
+  String get cast_device => 'Gerät';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2410,4 +2410,19 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get main_startup_failed => 'StashFlow failed to start';
+
+  @override
+  String get main_startup_failed_desc =>
+      'A startup service failed before the app could finish initializing. Restart the app after checking diagnostics.';
+
+  @override
+  String common_searching_for(String query) {
+    return 'Searching for: \"$query\"';
+  }
+
+  @override
+  String get cast_device => 'Device';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1378,11 +1378,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settings_playback_resume_position =>
-      'Resume from last playing position';
+      'Reanudar desde la última posición de juego';
 
   @override
   String get settings_playback_resume_position_subtitle =>
-      'When opening a video, automatically resume from where you left off';
+      'Al abrir un vídeo, se reanuda automáticamente desde donde lo dejaste.';
 
   @override
   String get settings_playback_end_behavior =>
@@ -2472,4 +2472,19 @@ class AppLocalizationsEs extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get main_startup_failed => 'StashFlow no pudo iniciarse';
+
+  @override
+  String get main_startup_failed_desc =>
+      'Un servicio de inicio falló antes de que la aplicación pudiera terminar de inicializarse.Reinicie la aplicación después de verificar los diagnósticos.';
+
+  @override
+  String common_searching_for(String query) {
+    return 'Buscando: \"$query\"';
+  }
+
+  @override
+  String get cast_device => 'Dispositivo';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1370,11 +1370,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settings_playback_resume_position =>
-      'Resume from last playing position';
+      'Reprendre à partir de la dernière position de jeu';
 
   @override
   String get settings_playback_resume_position_subtitle =>
-      'When opening a video, automatically resume from where you left off';
+      'Lors de l\'ouverture d\'une vidéo, reprenez automatiquement là où vous vous étiez arrêté';
 
   @override
   String get settings_playback_end_behavior => 'Comportement de fin de lecture';
@@ -2462,4 +2462,19 @@ class AppLocalizationsFr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get main_startup_failed => 'StashFlow n\'a pas réussi à démarrer';
+
+  @override
+  String get main_startup_failed_desc =>
+      'Un service de démarrage a échoué avant que l\'application puisse terminer son initialisation.Redémarrez l\'application après avoir vérifié les diagnostics.';
+
+  @override
+  String common_searching_for(String query) {
+    return 'Recherche de : \"$query\"';
+  }
+
+  @override
+  String get cast_device => 'Appareil';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1374,11 +1374,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settings_playback_resume_position =>
-      'Resume from last playing position';
+      'Riprendi dall\'ultima posizione di gioco';
 
   @override
   String get settings_playback_resume_position_subtitle =>
-      'When opening a video, automatically resume from where you left off';
+      'Quando apri un video, riprendi automaticamente da dove avevi interrotto';
 
   @override
   String get settings_playback_end_behavior =>
@@ -2466,4 +2466,19 @@ class AppLocalizationsIt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get main_startup_failed => 'Impossibile avviare StashFlow';
+
+  @override
+  String get main_startup_failed_desc =>
+      'Un servizio di avvio non è riuscito prima che l\'app potesse completare l\'inizializzazione.Riavvia l\'app dopo aver controllato la diagnostica.';
+
+  @override
+  String common_searching_for(String query) {
+    return 'Cercando: \"$query\"';
+  }
+
+  @override
+  String get cast_device => 'Dispositivo';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1319,12 +1319,11 @@ class AppLocalizationsJa extends AppLocalizations {
       'フィードモードでシーンを再生するとき、動画の長さの0%から90%の間のランダムな位置から開始します';
 
   @override
-  String get settings_playback_resume_position =>
-      'Resume from last playing position';
+  String get settings_playback_resume_position => '最後に再生した位置から再開';
 
   @override
   String get settings_playback_resume_position_subtitle =>
-      'When opening a video, automatically resume from where you left off';
+      'ビデオを開くと、中断したところから自動的に再開します';
 
   @override
   String get settings_playback_end_behavior => '再生終了時の動作';
@@ -2362,4 +2361,19 @@ class AppLocalizationsJa extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get main_startup_failed => 'StashFlow の開始に失敗しました';
+
+  @override
+  String get main_startup_failed_desc =>
+      'アプリの初期化が完了する前に、スタートアップ サービスが失敗しました。診断を確認した後、アプリを再起動します。';
+
+  @override
+  String common_searching_for(String query) {
+    return '検索中:「$query」';
+  }
+
+  @override
+  String get cast_device => 'デバイス';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1317,12 +1317,11 @@ class AppLocalizationsKo extends AppLocalizations {
       '피드 모드에서 장면을 재생할 때 비디오 길이의 0%에서 90% 사이의 임의의 위치에서 시작합니다';
 
   @override
-  String get settings_playback_resume_position =>
-      'Resume from last playing position';
+  String get settings_playback_resume_position => '마지막 재생 위치에서 다시 시작';
 
   @override
   String get settings_playback_resume_position_subtitle =>
-      'When opening a video, automatically resume from where you left off';
+      '비디오를 열 때 중단한 부분부터 자동으로 다시 시작';
 
   @override
   String get settings_playback_end_behavior => '재생 종료 동작';
@@ -2362,4 +2361,19 @@ class AppLocalizationsKo extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get main_startup_failed => 'StashFlow를 시작하지 못했습니다.';
+
+  @override
+  String get main_startup_failed_desc =>
+      '앱 초기화가 완료되기 전에 시작 서비스가 실패했습니다.진단을 확인한 후 앱을 다시 시작하세요.';
+
+  @override
+  String common_searching_for(String query) {
+    return '검색 중: \"$query\"';
+  }
+
+  @override
+  String get cast_device => '장치';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1358,11 +1358,11 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get settings_playback_resume_position =>
-      'Resume from last playing position';
+      'Возобновить с последней игровой позиции';
 
   @override
   String get settings_playback_resume_position_subtitle =>
-      'When opening a video, automatically resume from where you left off';
+      'При открытии видео автоматически возобновляется с того места, на котором вы остановились.';
 
   @override
   String get settings_playback_end_behavior => 'Поведение в конце игры';
@@ -2442,4 +2442,19 @@ class AppLocalizationsRu extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get main_startup_failed => 'StashFlow не удалось запустить';
+
+  @override
+  String get main_startup_failed_desc =>
+      'Служба запуска завершилась сбоем до того, как приложение смогло завершить инициализацию.Перезапустите приложение после проверки диагностики.';
+
+  @override
+  String common_searching_for(String query) {
+    return 'Поиск: \"$query\"';
+  }
+
+  @override
+  String get cast_device => 'Устройство';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1305,12 +1305,11 @@ class AppLocalizationsZh extends AppLocalizations {
       '在Feed模式下播放场景时，从视频长度的0%到90%之间的随机位置开始播放';
 
   @override
-  String get settings_playback_resume_position =>
-      'Resume from last playing position';
+  String get settings_playback_resume_position => '从上次播放位置恢复';
 
   @override
   String get settings_playback_resume_position_subtitle =>
-      'When opening a video, automatically resume from where you left off';
+      '打开视频时，自动从上次中断的地方继续播放';
 
   @override
   String get settings_playback_end_behavior => '播放结束行为';
@@ -2339,6 +2338,20 @@ class AppLocalizationsZh extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get main_startup_failed => 'StashFlow 启动失败';
+
+  @override
+  String get main_startup_failed_desc => '在应用程序完成初始化之前启动服务失败。检查诊断后重新启动应用程序。';
+
+  @override
+  String common_searching_for(String query) {
+    return '正在搜索：“$query”';
+  }
+
+  @override
+  String get cast_device => '设备';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -3642,6 +3655,13 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
       '在Feed模式下播放场景时，从视频长度的0%到90%之间的随机位置开始播放';
 
   @override
+  String get settings_playback_resume_position => '从上次播放位置恢复';
+
+  @override
+  String get settings_playback_resume_position_subtitle =>
+      '打开视频时，自动从上次中断的地方继续播放';
+
+  @override
   String get settings_playback_end_behavior => '播放结束行为';
 
   @override
@@ -4668,6 +4688,20 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
     );
     return '$_temp0';
   }
+
+  @override
+  String get main_startup_failed => 'StashFlow 启动失败';
+
+  @override
+  String get main_startup_failed_desc => '在应用程序完成初始化之前启动服务失败。检查诊断后重新启动应用程序。';
+
+  @override
+  String common_searching_for(String query) {
+    return '正在搜索：“$query”';
+  }
+
+  @override
+  String get cast_device => '设备';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -5974,6 +6008,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
       '在Feed模式下播放場景時，從影片長度的0%到90%之間的隨機位置開始播放';
 
   @override
+  String get settings_playback_resume_position => '從上次播放位置恢復';
+
+  @override
+  String get settings_playback_resume_position_subtitle =>
+      '打開影片時，自動從上次中斷的地方繼續播放';
+
+  @override
   String get settings_playback_end_behavior => '播放結束行為';
 
   @override
@@ -7001,4 +7042,18 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
     );
     return '$_temp0';
   }
+
+  @override
+  String get main_startup_failed => 'StashFlow 啟動失敗';
+
+  @override
+  String get main_startup_failed_desc => '在應用程式完成初始化之前啟動服務失敗。檢查診斷後重新啟動應用程式。';
+
+  @override
+  String common_searching_for(String query) {
+    return '正在搜尋：“$query”';
+  }
+
+  @override
+  String get cast_device => '裝置';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -873,5 +873,11 @@
   "scene_info_sprite": "Спрайт",
   "scene_info_technical": "Технический",
   "scene_studio_id": "Идентификатор: {id}",
-  "scene_rating_stars": "{count, plural, =1{1 звезда} other{{count} Звезды}}"
+  "scene_rating_stars": "{count, plural, =1{1 звезда} other{{count} Звезды}}",
+  "settings_playback_resume_position": "Возобновить с последней игровой позиции",
+  "settings_playback_resume_position_subtitle": "При открытии видео автоматически возобновляется с того места, на котором вы остановились.",
+  "main_startup_failed": "StashFlow не удалось запустить",
+  "main_startup_failed_desc": "Служба запуска завершилась сбоем до того, как приложение смогло завершить инициализацию.Перезапустите приложение после проверки диагностики.",
+  "common_searching_for": "Поиск: \"{query}\"",
+  "cast_device": "Устройство"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -873,5 +873,11 @@
   "scene_info_sprite": "雪碧",
   "scene_info_technical": "技术的",
   "scene_studio_id": "ID：{id}",
-  "scene_rating_stars": "{count, plural, =1{1 星} other{{count} 星星}}"
+  "scene_rating_stars": "{count, plural, =1{1 星} other{{count} 星星}}",
+  "settings_playback_resume_position": "从上次播放位置恢复",
+  "settings_playback_resume_position_subtitle": "打开视频时，自动从上次中断的地方继续播放",
+  "main_startup_failed": "StashFlow 启动失败",
+  "main_startup_failed_desc": "在应用程序完成初始化之前启动服务失败。检查诊断后重新启动应用程序。",
+  "common_searching_for": "正在搜索：“{query}”",
+  "cast_device": "设备"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -859,5 +859,11 @@
   "scene_info_sprite": "雪碧",
   "scene_info_technical": "技术的",
   "scene_studio_id": "ID：{id}",
-  "scene_rating_stars": "{count, plural, =1{1 星} other{{count} 星星}}"
+  "scene_rating_stars": "{count, plural, =1{1 星} other{{count} 星星}}",
+  "settings_playback_resume_position": "从上次播放位置恢复",
+  "settings_playback_resume_position_subtitle": "打开视频时，自动从上次中断的地方继续播放",
+  "main_startup_failed": "StashFlow 启动失败",
+  "main_startup_failed_desc": "在应用程序完成初始化之前启动服务失败。检查诊断后重新启动应用程序。",
+  "common_searching_for": "正在搜索：“{query}”",
+  "cast_device": "设备"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -859,5 +859,11 @@
   "scene_info_sprite": "雪碧",
   "scene_info_technical": "技術的",
   "scene_studio_id": "ID：{id}",
-  "scene_rating_stars": "{count, plural, =1{1 顆星} other{{count} 星星}}"
+  "scene_rating_stars": "{count, plural, =1{1 顆星} other{{count} 星星}}",
+  "settings_playback_resume_position": "從上次播放位置恢復",
+  "settings_playback_resume_position_subtitle": "打開影片時，自動從上次中斷的地方繼續播放",
+  "main_startup_failed": "StashFlow 啟動失敗",
+  "main_startup_failed_desc": "在應用程式完成初始化之前啟動服務失敗。檢查診斷後重新啟動應用程式。",
+  "common_searching_for": "正在搜尋：“{query}”",
+  "cast_device": "裝置"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -160,6 +160,8 @@ class StartupErrorApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
         body: SafeArea(
           child: SingleChildScrollView(
@@ -173,12 +175,12 @@ class StartupErrorApp extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        'StashFlow failed to start',
+                        context.l10n.main_startup_failed,
                         style: Theme.of(context).textTheme.headlineSmall,
                       ),
                       const SizedBox(height: 12),
-                      const Text(
-                        'A startup service failed before the app could finish initializing. Restart the app after checking diagnostics.',
+                      Text(
+                        context.l10n.main_startup_failed_desc,
                       ),
                       const SizedBox(height: 16),
                       DecoratedBox(


### PR DESCRIPTION
This PR addresses the issue of finding hardcoded text strings in the project and replacing them with localizable `l10n` keys.

- Replaced hardcoded text in `main.dart` with `main_startup_failed` and `main_startup_failed_desc`.
- Replaced hardcoded search text in `list_page_scaffold.dart` with `common_searching_for`.
- Replaced the hardcoded 'Device' string for casting in `player_surface.dart` with `cast_device`. 
- Added the corresponding keys to all `.arb` files and translated the untranslated items via `googletrans` API.
- Regenerated localizations via `flutter gen-l10n` and resolved analyzer issues.

---
*PR created automatically by Jules for task [10420142292415145639](https://jules.google.com/task/10420142292415145639) started by @Alchemist-Aloha*