### PR TITLE
🎨 Palette: Replace text GestureDetector with InkWell and Semantics

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - InkWell over GestureDetector for Text Links
+**Learning:** Raw `GestureDetector`s lack visual feedback (ripple effect) and screen-reader accessibility when used for interactive UI elements.
+**Action:** When creating purely interactive UI elements that trigger actions or navigation, avoid using a raw `GestureDetector`. Instead, wrap them in a `Material` widget (if missing) and use `InkWell` combined with `Semantics(button: true, label: ...)` to provide touch feedback, keyboard focusability, and screen-reader accessibility.

--- a/lib/core/presentation/widgets/media_widgets.dart
+++ b/lib/core/presentation/widgets/media_widgets.dart
@@ -99,18 +99,29 @@ class MediaHeader extends StatelessWidget {
         ),
         if (secondaryTitle != null) ...[
           SizedBox(height: context.dimensions.spacingSmall / 2),
-          GestureDetector(
-            onTap: onSecondaryTitleTap,
-            child: Text(
-              secondaryTitle!,
-              style: context.textTheme.titleMedium?.copyWith(
-                color: onSecondaryTitleTap != null
-                    ? context.colors.primary
-                    : context.colors.onSurfaceVariant,
-                fontWeight: FontWeight.w500,
-                decoration: onSecondaryTitleTap != null
-                    ? TextDecoration.underline
-                    : TextDecoration.none,
+          Semantics(
+            button: onSecondaryTitleTap != null,
+            label: onSecondaryTitleTap != null ? 'Open $secondaryTitle' : null,
+            child: Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: onSecondaryTitleTap,
+                borderRadius: BorderRadius.circular(4),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 2.0, vertical: 2.0),
+                  child: Text(
+                    secondaryTitle!,
+                    style: context.textTheme.titleMedium?.copyWith(
+                      color: onSecondaryTitleTap != null
+                          ? context.colors.primary
+                          : context.colors.onSurfaceVariant,
+                      fontWeight: FontWeight.w500,
+                      decoration: onSecondaryTitleTap != null
+                          ? TextDecoration.underline
+                          : TextDecoration.none,
+                    ),
+                  ),
+                ),
               ),
             ),
           ),

--- a/lib/features/scenes/presentation/pages/scene_details_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_details_page.dart
@@ -497,20 +497,31 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
     return Row(
       children: [
         if (scene.studioName != null)
-          GestureDetector(
-            onTap: canOpenStudio
-                ? () => context.push('/studios/studio/${scene.studioId}')
-                : null,
-            child: Text(
-              scene.studioName!,
-              style: context.textTheme.titleMedium?.copyWith(
-                color: canOpenStudio
-                    ? context.colors.primary
-                    : context.colors.onSurface,
-                fontWeight: FontWeight.w500,
-                decoration: canOpenStudio
-                    ? TextDecoration.underline
-                    : TextDecoration.none,
+          Semantics(
+            button: canOpenStudio,
+            label: canOpenStudio ? 'Open studio ${scene.studioName}' : null,
+            child: Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: canOpenStudio
+                    ? () => context.push('/studios/studio/${scene.studioId}')
+                    : null,
+                borderRadius: BorderRadius.circular(4),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 2.0, vertical: 2.0),
+                  child: Text(
+                    scene.studioName!,
+                    style: context.textTheme.titleMedium?.copyWith(
+                      color: canOpenStudio
+                          ? context.colors.primary
+                          : context.colors.onSurface,
+                      fontWeight: FontWeight.w500,
+                      decoration: canOpenStudio
+                          ? TextDecoration.underline
+                          : TextDecoration.none,
+                    ),
+                  ),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
**What:**
Replaced `GestureDetector` widgets with `InkWell` wrapped in `Semantics` and `Material` for the Studio Name link (`SceneDetailsPage`) and Secondary Title link (`MediaTitleWidget`).

**Why:**
Raw `GestureDetector` widgets do not provide visual touch feedback when tapped, nor do they inherently provide screen-reader accessibility traits.

**Accessibility:**
Added conditional `button` and `label` properties to the `Semantics` widgets so that when the links are active, screen readers announce them properly as clickable buttons with descriptive actions (e.g., "Open studio..."). When inactive, they fall back to being announced as standard text. The `InkWell` also ensures a ripple effect appears on touch/click, improving visual confirmation of the interaction.

---
*PR created automatically by Jules for task [9497982683074723940](https://jules.google.com/task/9497982683074723940) started by @Alchemist-Aloha*