### PR TITLE
🎨 Palette: Improve text link accessibility and interaction feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Replacing Raw GestureDetector Text Links with Semantics and InkWell
+**Learning:** Found that custom plain text links used for navigation (like clicking on a Studio name to open its details) were wrapped in a basic `GestureDetector` without providing accessibility roles, hover states, or touch feedback. This makes them invisible to screen readers as interactive elements and feels "dead" to touch or mouse interaction.
+**Action:** Replaced the `GestureDetector` wrapper with `Semantics(button: true)` + `Material` + `InkWell`. By adding a small `padding: EdgeInsets.symmetric(horizontal: 2, vertical: 1)` to the `InkWell`, it gives the ripple animation room to breathe while keeping the layout footprint minimal.

--- a/lib/core/presentation/widgets/media_widgets.dart
+++ b/lib/core/presentation/widgets/media_widgets.dart
@@ -99,18 +99,29 @@ class MediaHeader extends StatelessWidget {
         ),
         if (secondaryTitle != null) ...[
           SizedBox(height: context.dimensions.spacingSmall / 2),
-          GestureDetector(
-            onTap: onSecondaryTitleTap,
-            child: Text(
-              secondaryTitle!,
-              style: context.textTheme.titleMedium?.copyWith(
-                color: onSecondaryTitleTap != null
-                    ? context.colors.primary
-                    : context.colors.onSurfaceVariant,
-                fontWeight: FontWeight.w500,
-                decoration: onSecondaryTitleTap != null
-                    ? TextDecoration.underline
-                    : TextDecoration.none,
+          Semantics(
+            button: onSecondaryTitleTap != null,
+            label: onSecondaryTitleTap != null ? 'Open $secondaryTitle details' : null,
+            child: Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: onSecondaryTitleTap,
+                borderRadius: BorderRadius.circular(4),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 1),
+                  child: Text(
+                    secondaryTitle!,
+                    style: context.textTheme.titleMedium?.copyWith(
+                      color: onSecondaryTitleTap != null
+                          ? context.colors.primary
+                          : context.colors.onSurfaceVariant,
+                      fontWeight: FontWeight.w500,
+                      decoration: onSecondaryTitleTap != null
+                          ? TextDecoration.underline
+                          : TextDecoration.none,
+                    ),
+                  ),
+                ),
               ),
             ),
           ),

--- a/lib/features/scenes/presentation/pages/scene_details_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_details_page.dart
@@ -497,20 +497,31 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
     return Row(
       children: [
         if (scene.studioName != null)
-          GestureDetector(
-            onTap: canOpenStudio
-                ? () => context.push('/studios/studio/${scene.studioId}')
-                : null,
-            child: Text(
-              scene.studioName!,
-              style: context.textTheme.titleMedium?.copyWith(
-                color: canOpenStudio
-                    ? context.colors.primary
-                    : context.colors.onSurface,
-                fontWeight: FontWeight.w500,
-                decoration: canOpenStudio
-                    ? TextDecoration.underline
-                    : TextDecoration.none,
+          Semantics(
+            button: canOpenStudio,
+            label: canOpenStudio ? 'Open ${scene.studioName} details' : null,
+            child: Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: canOpenStudio
+                    ? () => context.push('/studios/studio/${scene.studioId}')
+                    : null,
+                borderRadius: BorderRadius.circular(4),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 1),
+                  child: Text(
+                    scene.studioName!,
+                    style: context.textTheme.titleMedium?.copyWith(
+                      color: canOpenStudio
+                          ? context.colors.primary
+                          : context.colors.onSurface,
+                      fontWeight: FontWeight.w500,
+                      decoration: canOpenStudio
+                          ? TextDecoration.underline
+                          : TextDecoration.none,
+                    ),
+                  ),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
What:
Replaced raw `GestureDetector` wrappers on navigational text links (Studio name in `SceneDetailsPage` and secondary title in `MediaHeader`) with `Semantics`, `Material`, and `InkWell`.

Why:
The plain text links felt "dead" to user interaction as they lacked hover states and touch ripple feedback.

Before/After:
Before, tapping on "Studio Name" under a scene title just instantly fired the navigation. Now, hovering over it shows a cursor change/highlight, and tapping it provides the standard Material ripple effect.

Accessibility:
Adding `Semantics(button: true)` ensures that screen readers properly announce these elements as interactive buttons rather than just reading static text. The `InkWell` adds keyboard focusability for users navigating without a mouse or touch screen.

---
*PR created automatically by Jules for task [13620994348364498433](https://jules.google.com/task/13620994348364498433) started by @Alchemist-Aloha*