### PR TITLE
i18n: localize security settings and app lock gate

### DIFF
--- a/lib/core/presentation/widgets/app_lock_gate.dart
+++ b/lib/core/presentation/widgets/app_lock_gate.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:stash_app_flutter/core/utils/l10n_extensions.dart';
 import 'package:stash_app_flutter/features/setup/presentation/providers/app_lock_settings_provider.dart';
 
 class AppLockGate extends ConsumerStatefulWidget {
@@ -170,7 +171,7 @@ class _PasscodeLockScreenState extends ConsumerState<_PasscodeLockScreen> {
 
     setState(() {
       _submitting = false;
-      _error = 'Incorrect passcode';
+      _error = context.l10n.auth_incorrect_passcode;
     });
   }
 
@@ -195,11 +196,11 @@ class _PasscodeLockScreenState extends ConsumerState<_PasscodeLockScreen> {
                     ),
                     const SizedBox(height: 12),
                     Text(
-                      'App Locked',
+                      context.l10n.auth_app_locked,
                       style: Theme.of(context).textTheme.headlineSmall,
                     ),
                     const SizedBox(height: 8),
-                    const Text('Enter your passcode to continue.'),
+                    Text(context.l10n.auth_enter_passcode),
                     const SizedBox(height: 20),
                     TextField(
                       controller: _controller,
@@ -211,7 +212,7 @@ class _PasscodeLockScreenState extends ConsumerState<_PasscodeLockScreen> {
                       enabled: !_submitting,
                       onSubmitted: (_) => _unlock(),
                       decoration: InputDecoration(
-                        labelText: 'Passcode',
+                        labelText: context.l10n.settings_security_passcode,
                         errorText: _error,
                       ),
                     ),
@@ -228,7 +229,7 @@ class _PasscodeLockScreenState extends ConsumerState<_PasscodeLockScreen> {
                                   strokeWidth: 2,
                                 ),
                               )
-                            : const Text('Unlock'),
+                            : Text(context.l10n.auth_unlock),
                       ),
                     ),
                   ],

--- a/lib/features/setup/presentation/pages/settings/security_settings_page.dart
+++ b/lib/features/setup/presentation/pages/settings/security_settings_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:stash_app_flutter/core/presentation/theme/app_theme.dart';
+import 'package:stash_app_flutter/core/utils/l10n_extensions.dart';
 import 'package:stash_app_flutter/features/setup/presentation/providers/app_lock_settings_provider.dart';
 import '../../widgets/settings_page_shell.dart';
 
@@ -15,20 +16,20 @@ class SecuritySettingsPage extends ConsumerWidget {
     final notifier = ref.read(appLockSettingsProvider.notifier);
 
     return SettingsPageShell(
-      title: 'Security',
+      title: context.l10n.settings_security_title,
       child: ListView(
         padding: EdgeInsets.all(context.dimensions.spacingLarge),
         children: [
           SettingsSectionCard(
-            title: 'App lock',
-            subtitle: 'Protect access with a passcode after backgrounding.',
+            title: context.l10n.settings_security_app_lock,
+            subtitle: context.l10n.settings_security_app_lock_subtitle,
             child: Column(
               children: [
                 ListTile(
                   contentPadding: EdgeInsets.zero,
-                  title: const Text('Passcode'),
+                  title: Text(context.l10n.settings_security_passcode),
                   subtitle: Text(
-                    settings.hasPasscode ? 'Configured' : 'Not configured',
+                    settings.hasPasscode ? context.l10n.settings_security_passcode_configured : context.l10n.settings_security_passcode_not_configured,
                   ),
                   trailing: Wrap(
                     spacing: 8,
@@ -40,11 +41,11 @@ class SecuritySettingsPage extends ConsumerWidget {
                           await notifier.setPasscode(passcode);
                           if (context.mounted) {
                             ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(content: Text('Passcode saved')),
+                              SnackBar(content: Text(context.l10n.settings_security_passcode_saved)),
                             );
                           }
                         },
-                        child: Text(settings.hasPasscode ? 'Change' : 'Set'),
+                        child: Text(settings.hasPasscode ? context.l10n.common_change : context.l10n.common_set),
                       ),
                       if (settings.hasPasscode)
                         TextButton(
@@ -52,13 +53,13 @@ class SecuritySettingsPage extends ConsumerWidget {
                             await notifier.clearPasscode();
                             if (context.mounted) {
                               ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(
-                                  content: Text('Passcode removed'),
+                                SnackBar(
+                                  content: Text(context.l10n.settings_security_passcode_removed),
                                 ),
                               );
                             }
                           },
-                          child: const Text('Remove'),
+                          child: Text(context.l10n.common_remove),
                         ),
                     ],
                   ),
@@ -66,9 +67,9 @@ class SecuritySettingsPage extends ConsumerWidget {
                 Divider(height: context.dimensions.spacingLarge),
                 SwitchListTile.adaptive(
                   contentPadding: EdgeInsets.zero,
-                  title: const Text('Enable app lock'),
-                  subtitle: const Text(
-                    'Require passcode on app resume/launch.',
+                  title: Text(context.l10n.settings_security_enable_app_lock),
+                  subtitle: Text(
+                    context.l10n.settings_security_enable_app_lock_subtitle,
                   ),
                   value: settings.enabled && settings.hasPasscode,
                   onChanged: (value) async {
@@ -83,9 +84,9 @@ class SecuritySettingsPage extends ConsumerWidget {
                 Divider(height: context.dimensions.spacingLarge),
                 SwitchListTile.adaptive(
                   contentPadding: EdgeInsets.zero,
-                  title: const Text('Lock on app launch'),
-                  subtitle: const Text(
-                    'Ask for passcode immediately when app opens.',
+                  title: Text(context.l10n.settings_security_lock_on_launch),
+                  subtitle: Text(
+                    context.l10n.settings_security_lock_on_launch_subtitle,
                   ),
                   value: settings.lockOnLaunch,
                   onChanged: settings.enabled && settings.hasPasscode
@@ -95,9 +96,9 @@ class SecuritySettingsPage extends ConsumerWidget {
                 Divider(height: context.dimensions.spacingLarge),
                 ListTile(
                   contentPadding: EdgeInsets.zero,
-                  title: const Text('Background lock timer'),
-                  subtitle: const Text(
-                    'How long the app can stay in background before locking.',
+                  title: Text(context.l10n.settings_security_background_lock_timer),
+                  subtitle: Text(
+                    context.l10n.settings_security_background_lock_timer_subtitle,
                   ),
                   trailing: DropdownButton<int>(
                     value: settings.backgroundLockSeconds,
@@ -112,7 +113,7 @@ class SecuritySettingsPage extends ConsumerWidget {
                         .map(
                           (seconds) => DropdownMenuItem<int>(
                             value: seconds,
-                            child: Text(_formatTimeout(seconds)),
+                            child: Text(_formatTimeout(context, seconds)),
                           ),
                         )
                         .toList(),
@@ -126,11 +127,11 @@ class SecuritySettingsPage extends ConsumerWidget {
     );
   }
 
-  static String _formatTimeout(int seconds) {
-    if (seconds == 0) return 'Immediately';
-    if (seconds < 60) return '$seconds sec';
-    if (seconds % 60 == 0) return '${seconds ~/ 60} min';
-    return '${seconds}s';
+  static String _formatTimeout(BuildContext context, int seconds) {
+    if (seconds == 0) return context.l10n.common_immediately;
+    if (seconds < 60) return context.l10n.common_sec(seconds);
+    if (seconds % 60 == 0) return context.l10n.common_min(seconds ~/ 60);
+    return context.l10n.common_s(seconds);
   }
 
   static Future<String?> _showPasscodeDialog(BuildContext context) async {
@@ -144,7 +145,7 @@ class SecuritySettingsPage extends ConsumerWidget {
         return StatefulBuilder(
           builder: (context, setState) {
             return AlertDialog(
-              title: const Text('Set passcode'),
+              title: Text(context.l10n.settings_security_set_passcode),
               content: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -153,8 +154,8 @@ class SecuritySettingsPage extends ConsumerWidget {
                     keyboardType: TextInputType.number,
                     obscureText: true,
                     maxLength: 8,
-                    decoration: const InputDecoration(
-                      labelText: 'Passcode (4-8 digits)',
+                    decoration: InputDecoration(
+                      labelText: context.l10n.settings_security_passcode_prompt,
                     ),
                   ),
                   TextField(
@@ -162,7 +163,7 @@ class SecuritySettingsPage extends ConsumerWidget {
                     keyboardType: TextInputType.number,
                     obscureText: true,
                     maxLength: 8,
-                    decoration: const InputDecoration(labelText: 'Confirm'),
+                    decoration: InputDecoration(labelText: context.l10n.settings_security_confirm_passcode),
                   ),
                   if (error != null)
                     Padding(
@@ -179,7 +180,7 @@ class SecuritySettingsPage extends ConsumerWidget {
               actions: [
                 TextButton(
                   onPressed: () => Navigator.of(dialogContext).pop(),
-                  child: const Text('Cancel'),
+                  child: Text(context.l10n.common_cancel),
                 ),
                 FilledButton(
                   onPressed: () {
@@ -188,17 +189,17 @@ class SecuritySettingsPage extends ConsumerWidget {
                     final numeric = RegExp(r'^\d{4,8}$');
                     if (!numeric.hasMatch(passcode)) {
                       setState(
-                        () => error = 'Use only digits, with length 4-8.',
+                        () => error = context.l10n.settings_security_error_numeric,
                       );
                       return;
                     }
                     if (passcode != confirm) {
-                      setState(() => error = 'Passcodes do not match.');
+                      setState(() => error = context.l10n.settings_security_error_mismatch);
                       return;
                     }
                     Navigator.of(dialogContext).pop(passcode);
                   },
-                  child: const Text('Save'),
+                  child: Text(context.l10n.common_save),
                 ),
               ],
             );

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -900,5 +900,55 @@
   "main_startup_failed": "StashFlow konnte nicht gestartet werden",
   "main_startup_failed_desc": "Ein Startdienst ist fehlgeschlagen, bevor die App die Initialisierung abschließen konnte.Starten Sie die App neu, nachdem Sie die Diagnose überprüft haben.",
   "common_searching_for": "Suche nach: „{query}“",
-  "cast_device": "Gerät"
+  "cast_device": "Gerät",
+  "auth_enter_passcode": "Geben Sie Ihren Passcode ein, um fortzufahren.",
+  "auth_unlock": "Entsperren",
+  "auth_incorrect_passcode": "Falscher Passcode",
+  "auth_app_locked": "App gesperrt",
+  "settings_security_passcode": "Passcode",
+  "settings_security_passcode_configured": "Konfiguriert",
+  "settings_security_passcode_not_configured": "Nicht konfiguriert",
+  "settings_security_passcode_saved": "Passcode gespeichert",
+  "settings_security_passcode_removed": "Passcode entfernt",
+  "settings_security_enable_app_lock": "App-Sperre aktivieren",
+  "settings_security_enable_app_lock_subtitle": "Passcode beim Fortsetzen/Starten der App erforderlich.",
+  "settings_security_lock_on_launch": "Beim App-Start sperren",
+  "settings_security_lock_on_launch_subtitle": "Fragen Sie sofort nach dem Passwort, wenn die App geöffnet wird.",
+  "settings_security_background_lock_timer": "Hintergrundsperr-Timer",
+  "settings_security_background_lock_timer_subtitle": "Wie lange die App im Hintergrund bleiben kann, bevor sie gesperrt wird.",
+  "settings_security_set_passcode": "Passcode festlegen",
+  "settings_security_passcode_prompt": "Passcode (4–8 Ziffern)",
+  "settings_security_confirm_passcode": "Bestätigen",
+  "settings_security_error_numeric": "Verwenden Sie nur Ziffern mit einer Länge von 4–8.",
+  "settings_security_error_mismatch": "Passcodes stimmen nicht überein.",
+  "common_change": "Ändern",
+  "common_set": "Satz",
+  "common_immediately": "Sofort",
+  "common_sec": "{value} Sek",
+  "@common_sec": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_min": "{value} min",
+  "@common_min": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_s": "{value}s",
+  "@common_s": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "settings_security_title": "Sicherheit",
+  "settings_security_app_lock": "App-Sperre",
+  "settings_security_app_lock_subtitle": "Schützen Sie den Zugriff nach dem Hintergrundbetrieb mit einem Passcode."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -999,5 +999,55 @@
       }
     }
   },
-  "cast_device": "Device"
+  "cast_device": "Device",
+  "auth_enter_passcode": "Enter your passcode to continue.",
+  "auth_unlock": "Unlock",
+  "auth_incorrect_passcode": "Incorrect passcode",
+  "auth_app_locked": "App Locked",
+  "settings_security_passcode": "Passcode",
+  "settings_security_passcode_configured": "Configured",
+  "settings_security_passcode_not_configured": "Not configured",
+  "settings_security_passcode_saved": "Passcode saved",
+  "settings_security_passcode_removed": "Passcode removed",
+  "settings_security_enable_app_lock": "Enable app lock",
+  "settings_security_enable_app_lock_subtitle": "Require passcode on app resume/launch.",
+  "settings_security_lock_on_launch": "Lock on app launch",
+  "settings_security_lock_on_launch_subtitle": "Ask for passcode immediately when app opens.",
+  "settings_security_background_lock_timer": "Background lock timer",
+  "settings_security_background_lock_timer_subtitle": "How long the app can stay in background before locking.",
+  "settings_security_set_passcode": "Set passcode",
+  "settings_security_passcode_prompt": "Passcode (4-8 digits)",
+  "settings_security_confirm_passcode": "Confirm",
+  "settings_security_error_numeric": "Use only digits, with length 4-8.",
+  "settings_security_error_mismatch": "Passcodes do not match.",
+  "common_change": "Change",
+  "common_set": "Set",
+  "common_immediately": "Immediately",
+  "common_sec": "{value} sec",
+  "@common_sec": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_min": "{value} min",
+  "@common_min": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_s": "{value}s",
+  "@common_s": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "settings_security_title": "Security",
+  "settings_security_app_lock": "App lock",
+  "settings_security_app_lock_subtitle": "Protect access with a passcode after backgrounding."
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -879,5 +879,55 @@
   "main_startup_failed": "StashFlow no pudo iniciarse",
   "main_startup_failed_desc": "Un servicio de inicio falló antes de que la aplicación pudiera terminar de inicializarse.Reinicie la aplicación después de verificar los diagnósticos.",
   "common_searching_for": "Buscando: \"{query}\"",
-  "cast_device": "Dispositivo"
+  "cast_device": "Dispositivo",
+  "auth_enter_passcode": "Ingrese su contraseña para continuar.",
+  "auth_unlock": "Descubrir",
+  "auth_incorrect_passcode": "Código de acceso incorrecto",
+  "auth_app_locked": "Aplicación bloqueada",
+  "settings_security_passcode": "Código de acceso",
+  "settings_security_passcode_configured": "Configurado",
+  "settings_security_passcode_not_configured": "No configurado",
+  "settings_security_passcode_saved": "Código de acceso guardado",
+  "settings_security_passcode_removed": "Código de acceso eliminado",
+  "settings_security_enable_app_lock": "Habilitar bloqueo de aplicaciones",
+  "settings_security_enable_app_lock_subtitle": "Requerir código de acceso al reanudar/iniciar la aplicación.",
+  "settings_security_lock_on_launch": "Bloquear al iniciar la aplicación",
+  "settings_security_lock_on_launch_subtitle": "Solicite el código de acceso inmediatamente cuando se abra la aplicación.",
+  "settings_security_background_lock_timer": "Temporizador de bloqueo de fondo",
+  "settings_security_background_lock_timer_subtitle": "Cuánto tiempo puede permanecer la aplicación en segundo plano antes de bloquearse.",
+  "settings_security_set_passcode": "Establecer contraseña",
+  "settings_security_passcode_prompt": "Código de acceso (4-8 dígitos)",
+  "settings_security_confirm_passcode": "Confirmar",
+  "settings_security_error_numeric": "Utilice sólo dígitos, con una longitud de 4 a 8.",
+  "settings_security_error_mismatch": "Las contraseñas no coinciden.",
+  "common_change": "Cambiar",
+  "common_set": "Colocar",
+  "common_immediately": "Inmediatamente",
+  "common_sec": "{value} seg",
+  "@common_sec": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_min": "{value} min",
+  "@common_min": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_s": "{value}s",
+  "@common_s": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "settings_security_title": "Seguridad",
+  "settings_security_app_lock": "Bloqueo de aplicaciones",
+  "settings_security_app_lock_subtitle": "Proteja el acceso con una contraseña después de ponerlo en segundo plano."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -879,5 +879,55 @@
   "main_startup_failed": "StashFlow n'a pas réussi à démarrer",
   "main_startup_failed_desc": "Un service de démarrage a échoué avant que l'application puisse terminer son initialisation.Redémarrez l'application après avoir vérifié les diagnostics.",
   "common_searching_for": "Recherche de : \"{query}\"",
-  "cast_device": "Appareil"
+  "cast_device": "Appareil",
+  "auth_enter_passcode": "Entrez votre mot de passe pour continuer.",
+  "auth_unlock": "Ouvrir",
+  "auth_incorrect_passcode": "Mot de passe incorrect",
+  "auth_app_locked": "Application verrouillée",
+  "settings_security_passcode": "Code d'accès",
+  "settings_security_passcode_configured": "Configuré",
+  "settings_security_passcode_not_configured": "Non configuré",
+  "settings_security_passcode_saved": "Code d'accès enregistré",
+  "settings_security_passcode_removed": "Code d'accès supprimé",
+  "settings_security_enable_app_lock": "Activer le verrouillage des applications",
+  "settings_security_enable_app_lock_subtitle": "Exiger un mot de passe lors de la reprise/du lancement de l'application.",
+  "settings_security_lock_on_launch": "Verrouiller le lancement de l'application",
+  "settings_security_lock_on_launch_subtitle": "Demandez le mot de passe immédiatement lorsque l'application s'ouvre.",
+  "settings_security_background_lock_timer": "Minuterie de verrouillage en arrière-plan",
+  "settings_security_background_lock_timer_subtitle": "Combien de temps l'application peut rester en arrière-plan avant de se verrouiller.",
+  "settings_security_set_passcode": "Définir le mot de passe",
+  "settings_security_passcode_prompt": "Code d'accès (4 à 8 chiffres)",
+  "settings_security_confirm_passcode": "Confirmer",
+  "settings_security_error_numeric": "Utilisez uniquement des chiffres, d'une longueur de 4 à 8.",
+  "settings_security_error_mismatch": "Les codes d'accès ne correspondent pas.",
+  "common_change": "Changement",
+  "common_set": "Ensemble",
+  "common_immediately": "Immédiatement",
+  "common_sec": "{value} s",
+  "@common_sec": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_min": "{value} min",
+  "@common_min": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_s": "{value}s",
+  "@common_s": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "settings_security_title": "Sécurité",
+  "settings_security_app_lock": "Verrouillage d'application",
+  "settings_security_app_lock_subtitle": "Protégez l’accès avec un mot de passe après la mise en arrière-plan."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -884,5 +884,55 @@
   "main_startup_failed": "Impossibile avviare StashFlow",
   "main_startup_failed_desc": "Un servizio di avvio non è riuscito prima che l'app potesse completare l'inizializzazione.Riavvia l'app dopo aver controllato la diagnostica.",
   "common_searching_for": "Cercando: \"{query}\"",
-  "cast_device": "Dispositivo"
+  "cast_device": "Dispositivo",
+  "auth_enter_passcode": "Inserisci il tuo passcode per continuare.",
+  "auth_unlock": "Sbloccare",
+  "auth_incorrect_passcode": "Codice di accesso errato",
+  "auth_app_locked": "Applicazione bloccata",
+  "settings_security_passcode": "Codice di accesso",
+  "settings_security_passcode_configured": "Configurato",
+  "settings_security_passcode_not_configured": "Non configurato",
+  "settings_security_passcode_saved": "Codice di accesso salvato",
+  "settings_security_passcode_removed": "Codice rimosso",
+  "settings_security_enable_app_lock": "Abilita il blocco dell'app",
+  "settings_security_enable_app_lock_subtitle": "Richiedi il passcode al ripristino/avvio dell'app.",
+  "settings_security_lock_on_launch": "Blocca all'avvio dell'app",
+  "settings_security_lock_on_launch_subtitle": "Richiedi immediatamente il passcode all'apertura dell'app.",
+  "settings_security_background_lock_timer": "Temporizzatore di blocco dello sfondo",
+  "settings_security_background_lock_timer_subtitle": "Per quanto tempo l'app può rimanere in background prima di bloccarsi.",
+  "settings_security_set_passcode": "Imposta il codice di accesso",
+  "settings_security_passcode_prompt": "Codice di accesso (4-8 cifre)",
+  "settings_security_confirm_passcode": "Confermare",
+  "settings_security_error_numeric": "Utilizzare solo cifre, con lunghezza compresa tra 4 e 8.",
+  "settings_security_error_mismatch": "I codici di accesso non corrispondono.",
+  "common_change": "Modifica",
+  "common_set": "Impostato",
+  "common_immediately": "Immediatamente",
+  "common_sec": "{value} sec",
+  "@common_sec": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_min": "{value} min",
+  "@common_min": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_s": "{value}s",
+  "@common_s": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "settings_security_title": "Sicurezza",
+  "settings_security_app_lock": "Blocco dell'app",
+  "settings_security_app_lock_subtitle": "Proteggi l'accesso con un passcode dopo il background."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -879,5 +879,55 @@
   "main_startup_failed": "StashFlow の開始に失敗しました",
   "main_startup_failed_desc": "アプリの初期化が完了する前に、スタートアップ サービスが失敗しました。診断を確認した後、アプリを再起動します。",
   "common_searching_for": "検索中:「{query}」",
-  "cast_device": "デバイス"
+  "cast_device": "デバイス",
+  "auth_enter_passcode": "続行するにはパスコードを入力してください。",
+  "auth_unlock": "ロックを解除する",
+  "auth_incorrect_passcode": "間違ったパスコード",
+  "auth_app_locked": "アプリがロックされました",
+  "settings_security_passcode": "パスコード",
+  "settings_security_passcode_configured": "設定済み",
+  "settings_security_passcode_not_configured": "未設定",
+  "settings_security_passcode_saved": "パスコードが保存されました",
+  "settings_security_passcode_removed": "パスコードが削除されました",
+  "settings_security_enable_app_lock": "アプリロックを有効にする",
+  "settings_security_enable_app_lock_subtitle": "アプリの再開/起動時にパスコードを要求します。",
+  "settings_security_lock_on_launch": "アプリ起動時にロックする",
+  "settings_security_lock_on_launch_subtitle": "アプリを開いたらすぐにパスコードを要求します。",
+  "settings_security_background_lock_timer": "バックグラウンドロックタイマー",
+  "settings_security_background_lock_timer_subtitle": "アプリがロックされるまでにバックグラウンドに留まることができる時間。",
+  "settings_security_set_passcode": "パスコードを設定する",
+  "settings_security_passcode_prompt": "パスコード（4～8桁）",
+  "settings_security_confirm_passcode": "確認する",
+  "settings_security_error_numeric": "長さ 4 ～ 8 の数字のみを使用してください。",
+  "settings_security_error_mismatch": "パスコードが一致しません。",
+  "common_change": "変化",
+  "common_set": "セット",
+  "common_immediately": "すぐに",
+  "common_sec": "{value} 秒",
+  "@common_sec": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_min": "{value}分",
+  "@common_min": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_s": "{value}s",
+  "@common_s": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "settings_security_title": "安全",
+  "settings_security_app_lock": "アプリロック",
+  "settings_security_app_lock_subtitle": "バックグラウンド化後はパスコードでアクセスを保護します。"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -879,5 +879,55 @@
   "main_startup_failed": "StashFlow를 시작하지 못했습니다.",
   "main_startup_failed_desc": "앱 초기화가 완료되기 전에 시작 서비스가 실패했습니다.진단을 확인한 후 앱을 다시 시작하세요.",
   "common_searching_for": "검색 중: \"{query}\"",
-  "cast_device": "장치"
+  "cast_device": "장치",
+  "auth_enter_passcode": "계속하려면 비밀번호를 입력하세요.",
+  "auth_unlock": "터놓다",
+  "auth_incorrect_passcode": "잘못된 비밀번호",
+  "auth_app_locked": "앱이 잠겼습니다.",
+  "settings_security_passcode": "비밀번호",
+  "settings_security_passcode_configured": "구성됨",
+  "settings_security_passcode_not_configured": "구성되지 않음",
+  "settings_security_passcode_saved": "비밀번호가 저장되었습니다",
+  "settings_security_passcode_removed": "비밀번호가 삭제되었습니다.",
+  "settings_security_enable_app_lock": "앱 잠금 활성화",
+  "settings_security_enable_app_lock_subtitle": "앱 재개/실행 시 비밀번호가 필요합니다.",
+  "settings_security_lock_on_launch": "앱 실행 시 잠금",
+  "settings_security_lock_on_launch_subtitle": "앱이 열리면 즉시 비밀번호를 요청하세요.",
+  "settings_security_background_lock_timer": "백그라운드 잠금 타이머",
+  "settings_security_background_lock_timer_subtitle": "앱이 잠기기 전에 백그라운드에 머무를 수 있는 시간입니다.",
+  "settings_security_set_passcode": "비밀번호 설정",
+  "settings_security_passcode_prompt": "비밀번호(4~8자리)",
+  "settings_security_confirm_passcode": "확인하다",
+  "settings_security_error_numeric": "길이가 4~8인 숫자만 사용하세요.",
+  "settings_security_error_mismatch": "비밀번호가 일치하지 않습니다.",
+  "common_change": "변화",
+  "common_set": "세트",
+  "common_immediately": "즉시",
+  "common_sec": "{value}초",
+  "@common_sec": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_min": "{value}분",
+  "@common_min": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_s": "{value}s",
+  "@common_s": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "settings_security_title": "보안",
+  "settings_security_app_lock": "앱 잠금",
+  "settings_security_app_lock_subtitle": "백그라운드 후 비밀번호로 접근을 보호하세요."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4523,6 +4523,180 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Device'**
   String get cast_device;
+
+  /// No description provided for @auth_enter_passcode.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter your passcode to continue.'**
+  String get auth_enter_passcode;
+
+  /// No description provided for @auth_unlock.
+  ///
+  /// In en, this message translates to:
+  /// **'Unlock'**
+  String get auth_unlock;
+
+  /// No description provided for @auth_incorrect_passcode.
+  ///
+  /// In en, this message translates to:
+  /// **'Incorrect passcode'**
+  String get auth_incorrect_passcode;
+
+  /// No description provided for @auth_app_locked.
+  ///
+  /// In en, this message translates to:
+  /// **'App Locked'**
+  String get auth_app_locked;
+
+  /// No description provided for @settings_security_passcode.
+  ///
+  /// In en, this message translates to:
+  /// **'Passcode'**
+  String get settings_security_passcode;
+
+  /// No description provided for @settings_security_passcode_configured.
+  ///
+  /// In en, this message translates to:
+  /// **'Configured'**
+  String get settings_security_passcode_configured;
+
+  /// No description provided for @settings_security_passcode_not_configured.
+  ///
+  /// In en, this message translates to:
+  /// **'Not configured'**
+  String get settings_security_passcode_not_configured;
+
+  /// No description provided for @settings_security_passcode_saved.
+  ///
+  /// In en, this message translates to:
+  /// **'Passcode saved'**
+  String get settings_security_passcode_saved;
+
+  /// No description provided for @settings_security_passcode_removed.
+  ///
+  /// In en, this message translates to:
+  /// **'Passcode removed'**
+  String get settings_security_passcode_removed;
+
+  /// No description provided for @settings_security_enable_app_lock.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable app lock'**
+  String get settings_security_enable_app_lock;
+
+  /// No description provided for @settings_security_enable_app_lock_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Require passcode on app resume/launch.'**
+  String get settings_security_enable_app_lock_subtitle;
+
+  /// No description provided for @settings_security_lock_on_launch.
+  ///
+  /// In en, this message translates to:
+  /// **'Lock on app launch'**
+  String get settings_security_lock_on_launch;
+
+  /// No description provided for @settings_security_lock_on_launch_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Ask for passcode immediately when app opens.'**
+  String get settings_security_lock_on_launch_subtitle;
+
+  /// No description provided for @settings_security_background_lock_timer.
+  ///
+  /// In en, this message translates to:
+  /// **'Background lock timer'**
+  String get settings_security_background_lock_timer;
+
+  /// No description provided for @settings_security_background_lock_timer_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'How long the app can stay in background before locking.'**
+  String get settings_security_background_lock_timer_subtitle;
+
+  /// No description provided for @settings_security_set_passcode.
+  ///
+  /// In en, this message translates to:
+  /// **'Set passcode'**
+  String get settings_security_set_passcode;
+
+  /// No description provided for @settings_security_passcode_prompt.
+  ///
+  /// In en, this message translates to:
+  /// **'Passcode (4-8 digits)'**
+  String get settings_security_passcode_prompt;
+
+  /// No description provided for @settings_security_confirm_passcode.
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm'**
+  String get settings_security_confirm_passcode;
+
+  /// No description provided for @settings_security_error_numeric.
+  ///
+  /// In en, this message translates to:
+  /// **'Use only digits, with length 4-8.'**
+  String get settings_security_error_numeric;
+
+  /// No description provided for @settings_security_error_mismatch.
+  ///
+  /// In en, this message translates to:
+  /// **'Passcodes do not match.'**
+  String get settings_security_error_mismatch;
+
+  /// No description provided for @common_change.
+  ///
+  /// In en, this message translates to:
+  /// **'Change'**
+  String get common_change;
+
+  /// No description provided for @common_set.
+  ///
+  /// In en, this message translates to:
+  /// **'Set'**
+  String get common_set;
+
+  /// No description provided for @common_immediately.
+  ///
+  /// In en, this message translates to:
+  /// **'Immediately'**
+  String get common_immediately;
+
+  /// No description provided for @common_sec.
+  ///
+  /// In en, this message translates to:
+  /// **'{value} sec'**
+  String common_sec(int value);
+
+  /// No description provided for @common_min.
+  ///
+  /// In en, this message translates to:
+  /// **'{value} min'**
+  String common_min(int value);
+
+  /// No description provided for @common_s.
+  ///
+  /// In en, this message translates to:
+  /// **'{value}s'**
+  String common_s(int value);
+
+  /// No description provided for @settings_security_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Security'**
+  String get settings_security_title;
+
+  /// No description provided for @settings_security_app_lock.
+  ///
+  /// In en, this message translates to:
+  /// **'App lock'**
+  String get settings_security_app_lock;
+
+  /// No description provided for @settings_security_app_lock_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Protect access with a passcode after backgrounding.'**
+  String get settings_security_app_lock_subtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2464,4 +2464,105 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get cast_device => 'Gerät';
+
+  @override
+  String get auth_enter_passcode =>
+      'Geben Sie Ihren Passcode ein, um fortzufahren.';
+
+  @override
+  String get auth_unlock => 'Entsperren';
+
+  @override
+  String get auth_incorrect_passcode => 'Falscher Passcode';
+
+  @override
+  String get auth_app_locked => 'App gesperrt';
+
+  @override
+  String get settings_security_passcode => 'Passcode';
+
+  @override
+  String get settings_security_passcode_configured => 'Konfiguriert';
+
+  @override
+  String get settings_security_passcode_not_configured => 'Nicht konfiguriert';
+
+  @override
+  String get settings_security_passcode_saved => 'Passcode gespeichert';
+
+  @override
+  String get settings_security_passcode_removed => 'Passcode entfernt';
+
+  @override
+  String get settings_security_enable_app_lock => 'App-Sperre aktivieren';
+
+  @override
+  String get settings_security_enable_app_lock_subtitle =>
+      'Passcode beim Fortsetzen/Starten der App erforderlich.';
+
+  @override
+  String get settings_security_lock_on_launch => 'Beim App-Start sperren';
+
+  @override
+  String get settings_security_lock_on_launch_subtitle =>
+      'Fragen Sie sofort nach dem Passwort, wenn die App geöffnet wird.';
+
+  @override
+  String get settings_security_background_lock_timer =>
+      'Hintergrundsperr-Timer';
+
+  @override
+  String get settings_security_background_lock_timer_subtitle =>
+      'Wie lange die App im Hintergrund bleiben kann, bevor sie gesperrt wird.';
+
+  @override
+  String get settings_security_set_passcode => 'Passcode festlegen';
+
+  @override
+  String get settings_security_passcode_prompt => 'Passcode (4–8 Ziffern)';
+
+  @override
+  String get settings_security_confirm_passcode => 'Bestätigen';
+
+  @override
+  String get settings_security_error_numeric =>
+      'Verwenden Sie nur Ziffern mit einer Länge von 4–8.';
+
+  @override
+  String get settings_security_error_mismatch =>
+      'Passcodes stimmen nicht überein.';
+
+  @override
+  String get common_change => 'Ändern';
+
+  @override
+  String get common_set => 'Satz';
+
+  @override
+  String get common_immediately => 'Sofort';
+
+  @override
+  String common_sec(int value) {
+    return '$value Sek';
+  }
+
+  @override
+  String common_min(int value) {
+    return '$value min';
+  }
+
+  @override
+  String common_s(int value) {
+    return '${value}s';
+  }
+
+  @override
+  String get settings_security_title => 'Sicherheit';
+
+  @override
+  String get settings_security_app_lock => 'App-Sperre';
+
+  @override
+  String get settings_security_app_lock_subtitle =>
+      'Schützen Sie den Zugriff nach dem Hintergrundbetrieb mit einem Passcode.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2425,4 +2425,102 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get cast_device => 'Device';
+
+  @override
+  String get auth_enter_passcode => 'Enter your passcode to continue.';
+
+  @override
+  String get auth_unlock => 'Unlock';
+
+  @override
+  String get auth_incorrect_passcode => 'Incorrect passcode';
+
+  @override
+  String get auth_app_locked => 'App Locked';
+
+  @override
+  String get settings_security_passcode => 'Passcode';
+
+  @override
+  String get settings_security_passcode_configured => 'Configured';
+
+  @override
+  String get settings_security_passcode_not_configured => 'Not configured';
+
+  @override
+  String get settings_security_passcode_saved => 'Passcode saved';
+
+  @override
+  String get settings_security_passcode_removed => 'Passcode removed';
+
+  @override
+  String get settings_security_enable_app_lock => 'Enable app lock';
+
+  @override
+  String get settings_security_enable_app_lock_subtitle =>
+      'Require passcode on app resume/launch.';
+
+  @override
+  String get settings_security_lock_on_launch => 'Lock on app launch';
+
+  @override
+  String get settings_security_lock_on_launch_subtitle =>
+      'Ask for passcode immediately when app opens.';
+
+  @override
+  String get settings_security_background_lock_timer => 'Background lock timer';
+
+  @override
+  String get settings_security_background_lock_timer_subtitle =>
+      'How long the app can stay in background before locking.';
+
+  @override
+  String get settings_security_set_passcode => 'Set passcode';
+
+  @override
+  String get settings_security_passcode_prompt => 'Passcode (4-8 digits)';
+
+  @override
+  String get settings_security_confirm_passcode => 'Confirm';
+
+  @override
+  String get settings_security_error_numeric =>
+      'Use only digits, with length 4-8.';
+
+  @override
+  String get settings_security_error_mismatch => 'Passcodes do not match.';
+
+  @override
+  String get common_change => 'Change';
+
+  @override
+  String get common_set => 'Set';
+
+  @override
+  String get common_immediately => 'Immediately';
+
+  @override
+  String common_sec(int value) {
+    return '$value sec';
+  }
+
+  @override
+  String common_min(int value) {
+    return '$value min';
+  }
+
+  @override
+  String common_s(int value) {
+    return '${value}s';
+  }
+
+  @override
+  String get settings_security_title => 'Security';
+
+  @override
+  String get settings_security_app_lock => 'App lock';
+
+  @override
+  String get settings_security_app_lock_subtitle =>
+      'Protect access with a passcode after backgrounding.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2487,4 +2487,107 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get cast_device => 'Dispositivo';
+
+  @override
+  String get auth_enter_passcode => 'Ingrese su contraseña para continuar.';
+
+  @override
+  String get auth_unlock => 'Descubrir';
+
+  @override
+  String get auth_incorrect_passcode => 'Código de acceso incorrecto';
+
+  @override
+  String get auth_app_locked => 'Aplicación bloqueada';
+
+  @override
+  String get settings_security_passcode => 'Código de acceso';
+
+  @override
+  String get settings_security_passcode_configured => 'Configurado';
+
+  @override
+  String get settings_security_passcode_not_configured => 'No configurado';
+
+  @override
+  String get settings_security_passcode_saved => 'Código de acceso guardado';
+
+  @override
+  String get settings_security_passcode_removed => 'Código de acceso eliminado';
+
+  @override
+  String get settings_security_enable_app_lock =>
+      'Habilitar bloqueo de aplicaciones';
+
+  @override
+  String get settings_security_enable_app_lock_subtitle =>
+      'Requerir código de acceso al reanudar/iniciar la aplicación.';
+
+  @override
+  String get settings_security_lock_on_launch =>
+      'Bloquear al iniciar la aplicación';
+
+  @override
+  String get settings_security_lock_on_launch_subtitle =>
+      'Solicite el código de acceso inmediatamente cuando se abra la aplicación.';
+
+  @override
+  String get settings_security_background_lock_timer =>
+      'Temporizador de bloqueo de fondo';
+
+  @override
+  String get settings_security_background_lock_timer_subtitle =>
+      'Cuánto tiempo puede permanecer la aplicación en segundo plano antes de bloquearse.';
+
+  @override
+  String get settings_security_set_passcode => 'Establecer contraseña';
+
+  @override
+  String get settings_security_passcode_prompt =>
+      'Código de acceso (4-8 dígitos)';
+
+  @override
+  String get settings_security_confirm_passcode => 'Confirmar';
+
+  @override
+  String get settings_security_error_numeric =>
+      'Utilice sólo dígitos, con una longitud de 4 a 8.';
+
+  @override
+  String get settings_security_error_mismatch =>
+      'Las contraseñas no coinciden.';
+
+  @override
+  String get common_change => 'Cambiar';
+
+  @override
+  String get common_set => 'Colocar';
+
+  @override
+  String get common_immediately => 'Inmediatamente';
+
+  @override
+  String common_sec(int value) {
+    return '$value seg';
+  }
+
+  @override
+  String common_min(int value) {
+    return '$value min';
+  }
+
+  @override
+  String common_s(int value) {
+    return '${value}s';
+  }
+
+  @override
+  String get settings_security_title => 'Seguridad';
+
+  @override
+  String get settings_security_app_lock => 'Bloqueo de aplicaciones';
+
+  @override
+  String get settings_security_app_lock_subtitle =>
+      'Proteja el acceso con una contraseña después de ponerlo en segundo plano.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2477,4 +2477,107 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get cast_device => 'Appareil';
+
+  @override
+  String get auth_enter_passcode => 'Entrez votre mot de passe pour continuer.';
+
+  @override
+  String get auth_unlock => 'Ouvrir';
+
+  @override
+  String get auth_incorrect_passcode => 'Mot de passe incorrect';
+
+  @override
+  String get auth_app_locked => 'Application verrouillée';
+
+  @override
+  String get settings_security_passcode => 'Code d\'accès';
+
+  @override
+  String get settings_security_passcode_configured => 'Configuré';
+
+  @override
+  String get settings_security_passcode_not_configured => 'Non configuré';
+
+  @override
+  String get settings_security_passcode_saved => 'Code d\'accès enregistré';
+
+  @override
+  String get settings_security_passcode_removed => 'Code d\'accès supprimé';
+
+  @override
+  String get settings_security_enable_app_lock =>
+      'Activer le verrouillage des applications';
+
+  @override
+  String get settings_security_enable_app_lock_subtitle =>
+      'Exiger un mot de passe lors de la reprise/du lancement de l\'application.';
+
+  @override
+  String get settings_security_lock_on_launch =>
+      'Verrouiller le lancement de l\'application';
+
+  @override
+  String get settings_security_lock_on_launch_subtitle =>
+      'Demandez le mot de passe immédiatement lorsque l\'application s\'ouvre.';
+
+  @override
+  String get settings_security_background_lock_timer =>
+      'Minuterie de verrouillage en arrière-plan';
+
+  @override
+  String get settings_security_background_lock_timer_subtitle =>
+      'Combien de temps l\'application peut rester en arrière-plan avant de se verrouiller.';
+
+  @override
+  String get settings_security_set_passcode => 'Définir le mot de passe';
+
+  @override
+  String get settings_security_passcode_prompt =>
+      'Code d\'accès (4 à 8 chiffres)';
+
+  @override
+  String get settings_security_confirm_passcode => 'Confirmer';
+
+  @override
+  String get settings_security_error_numeric =>
+      'Utilisez uniquement des chiffres, d\'une longueur de 4 à 8.';
+
+  @override
+  String get settings_security_error_mismatch =>
+      'Les codes d\'accès ne correspondent pas.';
+
+  @override
+  String get common_change => 'Changement';
+
+  @override
+  String get common_set => 'Ensemble';
+
+  @override
+  String get common_immediately => 'Immédiatement';
+
+  @override
+  String common_sec(int value) {
+    return '$value s';
+  }
+
+  @override
+  String common_min(int value) {
+    return '$value min';
+  }
+
+  @override
+  String common_s(int value) {
+    return '${value}s';
+  }
+
+  @override
+  String get settings_security_title => 'Sécurité';
+
+  @override
+  String get settings_security_app_lock => 'Verrouillage d\'application';
+
+  @override
+  String get settings_security_app_lock_subtitle =>
+      'Protégez l’accès avec un mot de passe après la mise en arrière-plan.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2481,4 +2481,105 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get cast_device => 'Dispositivo';
+
+  @override
+  String get auth_enter_passcode => 'Inserisci il tuo passcode per continuare.';
+
+  @override
+  String get auth_unlock => 'Sbloccare';
+
+  @override
+  String get auth_incorrect_passcode => 'Codice di accesso errato';
+
+  @override
+  String get auth_app_locked => 'Applicazione bloccata';
+
+  @override
+  String get settings_security_passcode => 'Codice di accesso';
+
+  @override
+  String get settings_security_passcode_configured => 'Configurato';
+
+  @override
+  String get settings_security_passcode_not_configured => 'Non configurato';
+
+  @override
+  String get settings_security_passcode_saved => 'Codice di accesso salvato';
+
+  @override
+  String get settings_security_passcode_removed => 'Codice rimosso';
+
+  @override
+  String get settings_security_enable_app_lock => 'Abilita il blocco dell\'app';
+
+  @override
+  String get settings_security_enable_app_lock_subtitle =>
+      'Richiedi il passcode al ripristino/avvio dell\'app.';
+
+  @override
+  String get settings_security_lock_on_launch => 'Blocca all\'avvio dell\'app';
+
+  @override
+  String get settings_security_lock_on_launch_subtitle =>
+      'Richiedi immediatamente il passcode all\'apertura dell\'app.';
+
+  @override
+  String get settings_security_background_lock_timer =>
+      'Temporizzatore di blocco dello sfondo';
+
+  @override
+  String get settings_security_background_lock_timer_subtitle =>
+      'Per quanto tempo l\'app può rimanere in background prima di bloccarsi.';
+
+  @override
+  String get settings_security_set_passcode => 'Imposta il codice di accesso';
+
+  @override
+  String get settings_security_passcode_prompt =>
+      'Codice di accesso (4-8 cifre)';
+
+  @override
+  String get settings_security_confirm_passcode => 'Confermare';
+
+  @override
+  String get settings_security_error_numeric =>
+      'Utilizzare solo cifre, con lunghezza compresa tra 4 e 8.';
+
+  @override
+  String get settings_security_error_mismatch =>
+      'I codici di accesso non corrispondono.';
+
+  @override
+  String get common_change => 'Modifica';
+
+  @override
+  String get common_set => 'Impostato';
+
+  @override
+  String get common_immediately => 'Immediatamente';
+
+  @override
+  String common_sec(int value) {
+    return '$value sec';
+  }
+
+  @override
+  String common_min(int value) {
+    return '$value min';
+  }
+
+  @override
+  String common_s(int value) {
+    return '${value}s';
+  }
+
+  @override
+  String get settings_security_title => 'Sicurezza';
+
+  @override
+  String get settings_security_app_lock => 'Blocco dell\'app';
+
+  @override
+  String get settings_security_app_lock_subtitle =>
+      'Proteggi l\'accesso con un passcode dopo il background.';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2376,4 +2376,101 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get cast_device => 'デバイス';
+
+  @override
+  String get auth_enter_passcode => '続行するにはパスコードを入力してください。';
+
+  @override
+  String get auth_unlock => 'ロックを解除する';
+
+  @override
+  String get auth_incorrect_passcode => '間違ったパスコード';
+
+  @override
+  String get auth_app_locked => 'アプリがロックされました';
+
+  @override
+  String get settings_security_passcode => 'パスコード';
+
+  @override
+  String get settings_security_passcode_configured => '設定済み';
+
+  @override
+  String get settings_security_passcode_not_configured => '未設定';
+
+  @override
+  String get settings_security_passcode_saved => 'パスコードが保存されました';
+
+  @override
+  String get settings_security_passcode_removed => 'パスコードが削除されました';
+
+  @override
+  String get settings_security_enable_app_lock => 'アプリロックを有効にする';
+
+  @override
+  String get settings_security_enable_app_lock_subtitle =>
+      'アプリの再開/起動時にパスコードを要求します。';
+
+  @override
+  String get settings_security_lock_on_launch => 'アプリ起動時にロックする';
+
+  @override
+  String get settings_security_lock_on_launch_subtitle =>
+      'アプリを開いたらすぐにパスコードを要求します。';
+
+  @override
+  String get settings_security_background_lock_timer => 'バックグラウンドロックタイマー';
+
+  @override
+  String get settings_security_background_lock_timer_subtitle =>
+      'アプリがロックされるまでにバックグラウンドに留まることができる時間。';
+
+  @override
+  String get settings_security_set_passcode => 'パスコードを設定する';
+
+  @override
+  String get settings_security_passcode_prompt => 'パスコード（4～8桁）';
+
+  @override
+  String get settings_security_confirm_passcode => '確認する';
+
+  @override
+  String get settings_security_error_numeric => '長さ 4 ～ 8 の数字のみを使用してください。';
+
+  @override
+  String get settings_security_error_mismatch => 'パスコードが一致しません。';
+
+  @override
+  String get common_change => '変化';
+
+  @override
+  String get common_set => 'セット';
+
+  @override
+  String get common_immediately => 'すぐに';
+
+  @override
+  String common_sec(int value) {
+    return '$value 秒';
+  }
+
+  @override
+  String common_min(int value) {
+    return '$value分';
+  }
+
+  @override
+  String common_s(int value) {
+    return '${value}s';
+  }
+
+  @override
+  String get settings_security_title => '安全';
+
+  @override
+  String get settings_security_app_lock => 'アプリロック';
+
+  @override
+  String get settings_security_app_lock_subtitle =>
+      'バックグラウンド化後はパスコードでアクセスを保護します。';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2376,4 +2376,100 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get cast_device => '장치';
+
+  @override
+  String get auth_enter_passcode => '계속하려면 비밀번호를 입력하세요.';
+
+  @override
+  String get auth_unlock => '터놓다';
+
+  @override
+  String get auth_incorrect_passcode => '잘못된 비밀번호';
+
+  @override
+  String get auth_app_locked => '앱이 잠겼습니다.';
+
+  @override
+  String get settings_security_passcode => '비밀번호';
+
+  @override
+  String get settings_security_passcode_configured => '구성됨';
+
+  @override
+  String get settings_security_passcode_not_configured => '구성되지 않음';
+
+  @override
+  String get settings_security_passcode_saved => '비밀번호가 저장되었습니다';
+
+  @override
+  String get settings_security_passcode_removed => '비밀번호가 삭제되었습니다.';
+
+  @override
+  String get settings_security_enable_app_lock => '앱 잠금 활성화';
+
+  @override
+  String get settings_security_enable_app_lock_subtitle =>
+      '앱 재개/실행 시 비밀번호가 필요합니다.';
+
+  @override
+  String get settings_security_lock_on_launch => '앱 실행 시 잠금';
+
+  @override
+  String get settings_security_lock_on_launch_subtitle =>
+      '앱이 열리면 즉시 비밀번호를 요청하세요.';
+
+  @override
+  String get settings_security_background_lock_timer => '백그라운드 잠금 타이머';
+
+  @override
+  String get settings_security_background_lock_timer_subtitle =>
+      '앱이 잠기기 전에 백그라운드에 머무를 수 있는 시간입니다.';
+
+  @override
+  String get settings_security_set_passcode => '비밀번호 설정';
+
+  @override
+  String get settings_security_passcode_prompt => '비밀번호(4~8자리)';
+
+  @override
+  String get settings_security_confirm_passcode => '확인하다';
+
+  @override
+  String get settings_security_error_numeric => '길이가 4~8인 숫자만 사용하세요.';
+
+  @override
+  String get settings_security_error_mismatch => '비밀번호가 일치하지 않습니다.';
+
+  @override
+  String get common_change => '변화';
+
+  @override
+  String get common_set => '세트';
+
+  @override
+  String get common_immediately => '즉시';
+
+  @override
+  String common_sec(int value) {
+    return '$value초';
+  }
+
+  @override
+  String common_min(int value) {
+    return '$value분';
+  }
+
+  @override
+  String common_s(int value) {
+    return '${value}s';
+  }
+
+  @override
+  String get settings_security_title => '보안';
+
+  @override
+  String get settings_security_app_lock => '앱 잠금';
+
+  @override
+  String get settings_security_app_lock_subtitle => '백그라운드 후 비밀번호로 접근을 보호하세요.';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2457,4 +2457,105 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get cast_device => 'Устройство';
+
+  @override
+  String get auth_enter_passcode => 'Введите свой пароль, чтобы продолжить.';
+
+  @override
+  String get auth_unlock => 'Разблокировать';
+
+  @override
+  String get auth_incorrect_passcode => 'Неправильный пароль';
+
+  @override
+  String get auth_app_locked => 'Приложение заблокировано';
+
+  @override
+  String get settings_security_passcode => 'Код доступа';
+
+  @override
+  String get settings_security_passcode_configured => 'Настроено';
+
+  @override
+  String get settings_security_passcode_not_configured => 'Не настроено';
+
+  @override
+  String get settings_security_passcode_saved => 'Код доступа сохранен.';
+
+  @override
+  String get settings_security_passcode_removed => 'Код доступа удален.';
+
+  @override
+  String get settings_security_enable_app_lock =>
+      'Включить блокировку приложения';
+
+  @override
+  String get settings_security_enable_app_lock_subtitle =>
+      'Требовать пароль при возобновлении/запуске приложения.';
+
+  @override
+  String get settings_security_lock_on_launch =>
+      'Блокировка запуска приложения';
+
+  @override
+  String get settings_security_lock_on_launch_subtitle =>
+      'Запросите пароль сразу после открытия приложения.';
+
+  @override
+  String get settings_security_background_lock_timer =>
+      'Таймер блокировки фона';
+
+  @override
+  String get settings_security_background_lock_timer_subtitle =>
+      'Как долго приложение может оставаться в фоновом режиме перед блокировкой.';
+
+  @override
+  String get settings_security_set_passcode => 'Установить пароль';
+
+  @override
+  String get settings_security_passcode_prompt => 'Код доступа (4–8 цифр)';
+
+  @override
+  String get settings_security_confirm_passcode => 'Подтверждать';
+
+  @override
+  String get settings_security_error_numeric =>
+      'Используйте только цифры длиной 4–8.';
+
+  @override
+  String get settings_security_error_mismatch => 'Пароли не совпадают.';
+
+  @override
+  String get common_change => 'Изменять';
+
+  @override
+  String get common_set => 'Набор';
+
+  @override
+  String get common_immediately => 'Немедленно';
+
+  @override
+  String common_sec(int value) {
+    return '$value сек.';
+  }
+
+  @override
+  String common_min(int value) {
+    return '$value мин.';
+  }
+
+  @override
+  String common_s(int value) {
+    return '${value}s';
+  }
+
+  @override
+  String get settings_security_title => 'Безопасность';
+
+  @override
+  String get settings_security_app_lock => 'Блокировка приложения';
+
+  @override
+  String get settings_security_app_lock_subtitle =>
+      'Защитите доступ с помощью пароля после фонового режима.';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2352,6 +2352,100 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get cast_device => '设备';
+
+  @override
+  String get auth_enter_passcode => '输入您的密码以继续。';
+
+  @override
+  String get auth_unlock => '开锁';
+
+  @override
+  String get auth_incorrect_passcode => '密码不正确';
+
+  @override
+  String get auth_app_locked => '应用程序已锁定';
+
+  @override
+  String get settings_security_passcode => '密码';
+
+  @override
+  String get settings_security_passcode_configured => '已配置';
+
+  @override
+  String get settings_security_passcode_not_configured => '未配置';
+
+  @override
+  String get settings_security_passcode_saved => '密码已保存';
+
+  @override
+  String get settings_security_passcode_removed => '密码已删除';
+
+  @override
+  String get settings_security_enable_app_lock => '启用应用程序锁定';
+
+  @override
+  String get settings_security_enable_app_lock_subtitle => '应用程序恢复/启动时需要密码。';
+
+  @override
+  String get settings_security_lock_on_launch => '锁定应用程序启动';
+
+  @override
+  String get settings_security_lock_on_launch_subtitle => '应用程序打开时立即询问密码。';
+
+  @override
+  String get settings_security_background_lock_timer => '后台锁定定时器';
+
+  @override
+  String get settings_security_background_lock_timer_subtitle =>
+      '应用程序在锁定之前可以在后台停留多长时间。';
+
+  @override
+  String get settings_security_set_passcode => '设置密码';
+
+  @override
+  String get settings_security_passcode_prompt => '密码（4-8位）';
+
+  @override
+  String get settings_security_confirm_passcode => '确认';
+
+  @override
+  String get settings_security_error_numeric => '仅使用数字，长度为 4-8。';
+
+  @override
+  String get settings_security_error_mismatch => '密码不匹配。';
+
+  @override
+  String get common_change => '改变';
+
+  @override
+  String get common_set => '放';
+
+  @override
+  String get common_immediately => '立即地';
+
+  @override
+  String common_sec(int value) {
+    return '$value 秒';
+  }
+
+  @override
+  String common_min(int value) {
+    return '$value 分钟';
+  }
+
+  @override
+  String common_s(int value) {
+    return '${value}s';
+  }
+
+  @override
+  String get settings_security_title => '安全';
+
+  @override
+  String get settings_security_app_lock => '应用锁';
+
+  @override
+  String get settings_security_app_lock_subtitle => '后台运行后使用密码保护访问。';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -4702,6 +4796,100 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get cast_device => '设备';
+
+  @override
+  String get auth_enter_passcode => '输入您的密码以继续。';
+
+  @override
+  String get auth_unlock => '开锁';
+
+  @override
+  String get auth_incorrect_passcode => '密码不正确';
+
+  @override
+  String get auth_app_locked => '应用程序已锁定';
+
+  @override
+  String get settings_security_passcode => '密码';
+
+  @override
+  String get settings_security_passcode_configured => '已配置';
+
+  @override
+  String get settings_security_passcode_not_configured => '未配置';
+
+  @override
+  String get settings_security_passcode_saved => '密码已保存';
+
+  @override
+  String get settings_security_passcode_removed => '密码已删除';
+
+  @override
+  String get settings_security_enable_app_lock => '启用应用程序锁定';
+
+  @override
+  String get settings_security_enable_app_lock_subtitle => '应用程序恢复/启动时需要密码。';
+
+  @override
+  String get settings_security_lock_on_launch => '锁定应用程序启动';
+
+  @override
+  String get settings_security_lock_on_launch_subtitle => '应用程序打开时立即询问密码。';
+
+  @override
+  String get settings_security_background_lock_timer => '后台锁定定时器';
+
+  @override
+  String get settings_security_background_lock_timer_subtitle =>
+      '应用程序在锁定之前可以在后台停留多长时间。';
+
+  @override
+  String get settings_security_set_passcode => '设置密码';
+
+  @override
+  String get settings_security_passcode_prompt => '密码（4-8位）';
+
+  @override
+  String get settings_security_confirm_passcode => '确认';
+
+  @override
+  String get settings_security_error_numeric => '仅使用数字，长度为 4-8。';
+
+  @override
+  String get settings_security_error_mismatch => '密码不匹配。';
+
+  @override
+  String get common_change => '改变';
+
+  @override
+  String get common_set => '放';
+
+  @override
+  String get common_immediately => '立即地';
+
+  @override
+  String common_sec(int value) {
+    return '$value 秒';
+  }
+
+  @override
+  String common_min(int value) {
+    return '$value 分钟';
+  }
+
+  @override
+  String common_s(int value) {
+    return '${value}s';
+  }
+
+  @override
+  String get settings_security_title => '安全';
+
+  @override
+  String get settings_security_app_lock => '应用锁';
+
+  @override
+  String get settings_security_app_lock_subtitle => '后台运行后使用密码保护访问。';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -7056,4 +7244,98 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get cast_device => '裝置';
+
+  @override
+  String get auth_enter_passcode => '輸入您的密碼以繼續。';
+
+  @override
+  String get auth_unlock => '開鎖';
+
+  @override
+  String get auth_incorrect_passcode => '密碼不正確';
+
+  @override
+  String get auth_app_locked => '應用程式已鎖定';
+
+  @override
+  String get settings_security_passcode => '密碼';
+
+  @override
+  String get settings_security_passcode_configured => '已配置';
+
+  @override
+  String get settings_security_passcode_not_configured => '未配置';
+
+  @override
+  String get settings_security_passcode_saved => '密碼已儲存';
+
+  @override
+  String get settings_security_passcode_removed => '密碼已刪除';
+
+  @override
+  String get settings_security_enable_app_lock => '啟用應用程式鎖定';
+
+  @override
+  String get settings_security_enable_app_lock_subtitle => '應用程式恢復/啟動時需要密碼。';
+
+  @override
+  String get settings_security_lock_on_launch => '鎖定應用程式啟動';
+
+  @override
+  String get settings_security_lock_on_launch_subtitle => '應用程式開啟時立即詢問密碼。';
+
+  @override
+  String get settings_security_background_lock_timer => '後台鎖定定時器';
+
+  @override
+  String get settings_security_background_lock_timer_subtitle =>
+      '應用程式在鎖定之前可以在背景停留多長時間。';
+
+  @override
+  String get settings_security_set_passcode => '設定密碼';
+
+  @override
+  String get settings_security_passcode_prompt => '密碼（4-8位）';
+
+  @override
+  String get settings_security_confirm_passcode => '確認';
+
+  @override
+  String get settings_security_error_numeric => '僅使用數字，長度為 4-8。';
+
+  @override
+  String get settings_security_error_mismatch => '密碼不符。';
+
+  @override
+  String get common_change => '改變';
+
+  @override
+  String get common_set => '放';
+
+  @override
+  String get common_immediately => '立即地';
+
+  @override
+  String common_sec(int value) {
+    return '$value 秒';
+  }
+
+  @override
+  String common_min(int value) {
+    return '$value 分鐘';
+  }
+
+  @override
+  String common_s(int value) {
+    return '${value}s';
+  }
+
+  @override
+  String get settings_security_title => '安全';
+
+  @override
+  String get settings_security_app_lock => '應用鎖';
+
+  @override
+  String get settings_security_app_lock_subtitle => '後台運行後使用密碼保護存取。';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -879,5 +879,55 @@
   "main_startup_failed": "StashFlow не удалось запустить",
   "main_startup_failed_desc": "Служба запуска завершилась сбоем до того, как приложение смогло завершить инициализацию.Перезапустите приложение после проверки диагностики.",
   "common_searching_for": "Поиск: \"{query}\"",
-  "cast_device": "Устройство"
+  "cast_device": "Устройство",
+  "auth_enter_passcode": "Введите свой пароль, чтобы продолжить.",
+  "auth_unlock": "Разблокировать",
+  "auth_incorrect_passcode": "Неправильный пароль",
+  "auth_app_locked": "Приложение заблокировано",
+  "settings_security_passcode": "Код доступа",
+  "settings_security_passcode_configured": "Настроено",
+  "settings_security_passcode_not_configured": "Не настроено",
+  "settings_security_passcode_saved": "Код доступа сохранен.",
+  "settings_security_passcode_removed": "Код доступа удален.",
+  "settings_security_enable_app_lock": "Включить блокировку приложения",
+  "settings_security_enable_app_lock_subtitle": "Требовать пароль при возобновлении/запуске приложения.",
+  "settings_security_lock_on_launch": "Блокировка запуска приложения",
+  "settings_security_lock_on_launch_subtitle": "Запросите пароль сразу после открытия приложения.",
+  "settings_security_background_lock_timer": "Таймер блокировки фона",
+  "settings_security_background_lock_timer_subtitle": "Как долго приложение может оставаться в фоновом режиме перед блокировкой.",
+  "settings_security_set_passcode": "Установить пароль",
+  "settings_security_passcode_prompt": "Код доступа (4–8 цифр)",
+  "settings_security_confirm_passcode": "Подтверждать",
+  "settings_security_error_numeric": "Используйте только цифры длиной 4–8.",
+  "settings_security_error_mismatch": "Пароли не совпадают.",
+  "common_change": "Изменять",
+  "common_set": "Набор",
+  "common_immediately": "Немедленно",
+  "common_sec": "{value} сек.",
+  "@common_sec": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_min": "{value} мин.",
+  "@common_min": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_s": "{value}s",
+  "@common_s": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "settings_security_title": "Безопасность",
+  "settings_security_app_lock": "Блокировка приложения",
+  "settings_security_app_lock_subtitle": "Защитите доступ с помощью пароля после фонового режима."
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -879,5 +879,55 @@
   "main_startup_failed": "StashFlow 启动失败",
   "main_startup_failed_desc": "在应用程序完成初始化之前启动服务失败。检查诊断后重新启动应用程序。",
   "common_searching_for": "正在搜索：“{query}”",
-  "cast_device": "设备"
+  "cast_device": "设备",
+  "auth_enter_passcode": "输入您的密码以继续。",
+  "auth_unlock": "开锁",
+  "auth_incorrect_passcode": "密码不正确",
+  "auth_app_locked": "应用程序已锁定",
+  "settings_security_passcode": "密码",
+  "settings_security_passcode_configured": "已配置",
+  "settings_security_passcode_not_configured": "未配置",
+  "settings_security_passcode_saved": "密码已保存",
+  "settings_security_passcode_removed": "密码已删除",
+  "settings_security_enable_app_lock": "启用应用程序锁定",
+  "settings_security_enable_app_lock_subtitle": "应用程序恢复/启动时需要密码。",
+  "settings_security_lock_on_launch": "锁定应用程序启动",
+  "settings_security_lock_on_launch_subtitle": "应用程序打开时立即询问密码。",
+  "settings_security_background_lock_timer": "后台锁定定时器",
+  "settings_security_background_lock_timer_subtitle": "应用程序在锁定之前可以在后台停留多长时间。",
+  "settings_security_set_passcode": "设置密码",
+  "settings_security_passcode_prompt": "密码（4-8位）",
+  "settings_security_confirm_passcode": "确认",
+  "settings_security_error_numeric": "仅使用数字，长度为 4-8。",
+  "settings_security_error_mismatch": "密码不匹配。",
+  "common_change": "改变",
+  "common_set": "放",
+  "common_immediately": "立即地",
+  "common_sec": "{value} 秒",
+  "@common_sec": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_min": "{value} 分钟",
+  "@common_min": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_s": "{value}s",
+  "@common_s": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "settings_security_title": "安全",
+  "settings_security_app_lock": "应用锁",
+  "settings_security_app_lock_subtitle": "后台运行后使用密码保护访问。"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -865,5 +865,55 @@
   "main_startup_failed": "StashFlow 启动失败",
   "main_startup_failed_desc": "在应用程序完成初始化之前启动服务失败。检查诊断后重新启动应用程序。",
   "common_searching_for": "正在搜索：“{query}”",
-  "cast_device": "设备"
+  "cast_device": "设备",
+  "auth_enter_passcode": "输入您的密码以继续。",
+  "auth_unlock": "开锁",
+  "auth_incorrect_passcode": "密码不正确",
+  "auth_app_locked": "应用程序已锁定",
+  "settings_security_passcode": "密码",
+  "settings_security_passcode_configured": "已配置",
+  "settings_security_passcode_not_configured": "未配置",
+  "settings_security_passcode_saved": "密码已保存",
+  "settings_security_passcode_removed": "密码已删除",
+  "settings_security_enable_app_lock": "启用应用程序锁定",
+  "settings_security_enable_app_lock_subtitle": "应用程序恢复/启动时需要密码。",
+  "settings_security_lock_on_launch": "锁定应用程序启动",
+  "settings_security_lock_on_launch_subtitle": "应用程序打开时立即询问密码。",
+  "settings_security_background_lock_timer": "后台锁定定时器",
+  "settings_security_background_lock_timer_subtitle": "应用程序在锁定之前可以在后台停留多长时间。",
+  "settings_security_set_passcode": "设置密码",
+  "settings_security_passcode_prompt": "密码（4-8位）",
+  "settings_security_confirm_passcode": "确认",
+  "settings_security_error_numeric": "仅使用数字，长度为 4-8。",
+  "settings_security_error_mismatch": "密码不匹配。",
+  "common_change": "改变",
+  "common_set": "放",
+  "common_immediately": "立即地",
+  "common_sec": "{value} 秒",
+  "@common_sec": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_min": "{value} 分钟",
+  "@common_min": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_s": "{value}s",
+  "@common_s": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "settings_security_title": "安全",
+  "settings_security_app_lock": "应用锁",
+  "settings_security_app_lock_subtitle": "后台运行后使用密码保护访问。"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -865,5 +865,55 @@
   "main_startup_failed": "StashFlow 啟動失敗",
   "main_startup_failed_desc": "在應用程式完成初始化之前啟動服務失敗。檢查診斷後重新啟動應用程式。",
   "common_searching_for": "正在搜尋：“{query}”",
-  "cast_device": "裝置"
+  "cast_device": "裝置",
+  "auth_enter_passcode": "輸入您的密碼以繼續。",
+  "auth_unlock": "開鎖",
+  "auth_incorrect_passcode": "密碼不正確",
+  "auth_app_locked": "應用程式已鎖定",
+  "settings_security_passcode": "密碼",
+  "settings_security_passcode_configured": "已配置",
+  "settings_security_passcode_not_configured": "未配置",
+  "settings_security_passcode_saved": "密碼已儲存",
+  "settings_security_passcode_removed": "密碼已刪除",
+  "settings_security_enable_app_lock": "啟用應用程式鎖定",
+  "settings_security_enable_app_lock_subtitle": "應用程式恢復/啟動時需要密碼。",
+  "settings_security_lock_on_launch": "鎖定應用程式啟動",
+  "settings_security_lock_on_launch_subtitle": "應用程式開啟時立即詢問密碼。",
+  "settings_security_background_lock_timer": "後台鎖定定時器",
+  "settings_security_background_lock_timer_subtitle": "應用程式在鎖定之前可以在背景停留多長時間。",
+  "settings_security_set_passcode": "設定密碼",
+  "settings_security_passcode_prompt": "密碼（4-8位）",
+  "settings_security_confirm_passcode": "確認",
+  "settings_security_error_numeric": "僅使用數字，長度為 4-8。",
+  "settings_security_error_mismatch": "密碼不符。",
+  "common_change": "改變",
+  "common_set": "放",
+  "common_immediately": "立即地",
+  "common_sec": "{value} 秒",
+  "@common_sec": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_min": "{value} 分鐘",
+  "@common_min": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "common_s": "{value}s",
+  "@common_s": {
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
+  "settings_security_title": "安全",
+  "settings_security_app_lock": "應用鎖",
+  "settings_security_app_lock_subtitle": "後台運行後使用密碼保護存取。"
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -880,10 +880,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1597,26 +1597,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Fixes hardcoded texts on the Security settings page and App Lock gate by moving them into the `.arb` translation files and correctly referencing them via `context.l10n`. Translations for non-English locales were generated via Google Translate script.

---
*PR created automatically by Jules for task [1891530502319989265](https://jules.google.com/task/1891530502319989265) started by @Alchemist-Aloha*