### PR TITLE
🎨 Palette: Use semantic IconButton for overlay controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Replacing Raw GestureDetector Text Links with Semantics and InkWell
 **Learning:** Found that custom plain text links used for navigation (like clicking on a Studio name to open its details) were wrapped in a basic `GestureDetector` without providing accessibility roles, hover states, or touch feedback. This makes them invisible to screen readers as interactive elements and feels "dead" to touch or mouse interaction.
 **Action:** Replaced the `GestureDetector` wrapper with `Semantics(button: true)` + `Material` + `InkWell`. By adding a small `padding: EdgeInsets.symmetric(horizontal: 2, vertical: 1)` to the `InkWell`, it gives the ripple animation room to breathe while keeping the layout footprint minimal.
+## 2024-05-18 - Replacing GestureDetector + Icon with IconButton
+**Learning:** In Flutter, `GestureDetector` combined with `Container` and `Icon` doesn't provide visual accessibility feedback (like splash ripples) and lacks semantic button properties.
+**Action:** Replace `GestureDetector` + `Icon` combinations with native `IconButton` widgets wherever simple button tap logic is required, restoring full accessibility, keyboard focus support, and native tooltips.

--- a/lib/features/scenes/presentation/widgets/tiktok_scenes_view.dart
+++ b/lib/features/scenes/presentation/widgets/tiktok_scenes_view.dart
@@ -1100,25 +1100,19 @@ class _OverlayButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Tooltip(
-        message: tooltip ?? '',
-        child: Container(
-          padding: const EdgeInsets.all(12),
-          decoration: const BoxDecoration(
-            color: Colors.transparent,
-            shape: BoxShape.circle,
-          ),
-          child: Icon(
-            icon,
-            color: Colors.white,
-            size: 28,
-            shadows: [
-              Shadow(color: Colors.black.withValues(alpha: 0.5), blurRadius: 8),
-            ],
-          ),
-        ),
+    return IconButton(
+      onPressed: onTap,
+      tooltip: tooltip,
+      padding: const EdgeInsets.all(12),
+      style: IconButton.styleFrom(
+        foregroundColor: Colors.white,
+      ),
+      icon: Icon(
+        icon,
+        size: 28,
+        shadows: [
+          Shadow(color: Colors.black.withValues(alpha: 0.5), blurRadius: 8),
+        ],
       ),
     );
   }


### PR DESCRIPTION
**What**:
Replaced the custom `_OverlayButton` implementation inside the TikTok scenes view, which was manually piecing together a `GestureDetector`, `Container`, and `Tooltip`. It now uses a standard Material `IconButton`.

**Why**:
`IconButton` is standard. `GestureDetector` works for taps but completely bypasses standard focus rings for keyboard navigation, does not provide visual tap feedback (splash/ripple effect), and fails to provide explicit semantic boundaries for screen readers by default.

**Accessibility**:
Using a standard `IconButton` natively applies proper semantics, touch ripples, hover states, and standardizes how tooltips read out on screen readers, drastically improving keyboard and screen reader accessibility for desktop/web users.

---
*PR created automatically by Jules for task [16517637535963664170](https://jules.google.com/task/16517637535963664170) started by @Alchemist-Aloha*