### PR TITLE
🎨 Palette: [UX improvement] Localize tooltips

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,6 +1,3 @@
-## 2024-05-18 - Replacing Raw GestureDetector Text Links with Semantics and InkWell
-**Learning:** Found that custom plain text links used for navigation (like clicking on a Studio name to open its details) were wrapped in a basic `GestureDetector` without providing accessibility roles, hover states, or touch feedback. This makes them invisible to screen readers as interactive elements and feels "dead" to touch or mouse interaction.
-**Action:** Replaced the `GestureDetector` wrapper with `Semantics(button: true)` + `Material` + `InkWell`. By adding a small `padding: EdgeInsets.symmetric(horizontal: 2, vertical: 1)` to the `InkWell`, it gives the ripple animation room to breathe while keeping the layout footprint minimal.
-## 2024-05-18 - Replacing GestureDetector + Icon with IconButton
-**Learning:** In Flutter, `GestureDetector` combined with `Container` and `Icon` doesn't provide visual accessibility feedback (like splash ripples) and lacks semantic button properties.
-**Action:** Replace `GestureDetector` + `Icon` combinations with native `IconButton` widgets wherever simple button tap logic is required, restoring full accessibility, keyboard focus support, and native tooltips.
+## 2026-06-03 - Localized Tooltips
+**Learning:** Found several floating action buttons and icon buttons using hardcoded English strings ('Saved filters') for their tooltips. Hardcoded strings harm accessibility for non-English screen reader users.
+**Action:** When working on tooltips, always grep for hardcoded strings and map them to `context.l10n` keys to ensure translations apply properly.

--- a/l10n_untranslated.json
+++ b/l10n_untranslated.json
@@ -1,1 +1,9 @@
-{}
+{
+  "zh_Hans": [
+    "common_saved_filters"
+  ],
+
+  "zh_Hant": [
+    "common_saved_filters"
+  ]
+}

--- a/lib/features/galleries/presentation/pages/galleries_page.dart
+++ b/lib/features/galleries/presentation/pages/galleries_page.dart
@@ -343,32 +343,36 @@ class _GalleriesPageState extends ConsumerState<GalleriesPage> {
         activeFilterCount: _activeFilterCount(effectiveFilter),
         defaultSortLabel: 'path',
         saveSuccessMessage: 'Gallery filter saved to server',
-        loadPresets: () => ref.read(savedFilterRepositoryProvider).findAll(
-          mode: 'GALLERIES',
-          fromRaw: (raw) => GallerySavedFilterConfig.fromServerPayload(
-            id: raw['id'] as String,
-            name: raw['name'] as String,
-            findFilter: raw['find_filter'],
-            objectFilter: raw['object_filter'],
-          ),
-        ),
-        savePreset: ({required String name, String? existingId}) {
-          return ref.read(savedFilterRepositoryProvider).save(
-            input: GallerySavedFilterConfig.current(
-              id: existingId,
-              name: name,
-              searchQuery: ref.read(gallerySearchQueryProvider),
-              sort: sortConfig.sort,
-              descending: sortConfig.descending,
-              filter: effectiveFilter,
-            ).toSaveInput(),
-            fromRaw: (raw) => GallerySavedFilterConfig.fromServerPayload(
-              id: raw['id'] as String,
-              name: raw['name'] as String,
-              findFilter: raw['find_filter'],
-              objectFilter: raw['object_filter'],
+        loadPresets: () => ref
+            .read(savedFilterRepositoryProvider)
+            .findAll(
+              mode: 'GALLERIES',
+              fromRaw: (raw) => GallerySavedFilterConfig.fromServerPayload(
+                id: raw['id'] as String,
+                name: raw['name'] as String,
+                findFilter: raw['find_filter'],
+                objectFilter: raw['object_filter'],
+              ),
             ),
-          );
+        savePreset: ({required String name, String? existingId}) {
+          return ref
+              .read(savedFilterRepositoryProvider)
+              .save(
+                input: GallerySavedFilterConfig.current(
+                  id: existingId,
+                  name: name,
+                  searchQuery: ref.read(gallerySearchQueryProvider),
+                  sort: sortConfig.sort,
+                  descending: sortConfig.descending,
+                  filter: effectiveFilter,
+                ).toSaveInput(),
+                fromRaw: (raw) => GallerySavedFilterConfig.fromServerPayload(
+                  id: raw['id'] as String,
+                  name: raw['name'] as String,
+                  findFilter: raw['find_filter'],
+                  objectFilter: raw['object_filter'],
+                ),
+              );
         },
         onLoad: _applySavedFilterConfig,
       ),
@@ -479,7 +483,7 @@ class _GalleriesPageState extends ConsumerState<GalleriesPage> {
           ],
         ),
         IconButton(
-          tooltip: 'Saved filters',
+          tooltip: context.l10n.common_saved_filters,
           icon: const Icon(Icons.bookmarks_outlined),
           onPressed: _showSavedFilterDialog,
         ),

--- a/lib/features/images/presentation/pages/images_page.dart
+++ b/lib/features/images/presentation/pages/images_page.dart
@@ -347,32 +347,36 @@ class _ImagesPageState extends ConsumerState<ImagesPage> {
         activeFilterCount: _activeFilterCount(effectiveFilter),
         defaultSortLabel: 'path',
         saveSuccessMessage: 'Image filter saved to server',
-        loadPresets: () => ref.read(savedFilterRepositoryProvider).findAll(
-          mode: 'IMAGES',
-          fromRaw: (raw) => ImageSavedFilterConfig.fromServerPayload(
-            id: raw['id'] as String,
-            name: raw['name'] as String,
-            findFilter: raw['find_filter'],
-            objectFilter: raw['object_filter'],
-          ),
-        ),
-        savePreset: ({required String name, String? existingId}) {
-          return ref.read(savedFilterRepositoryProvider).save(
-            input: ImageSavedFilterConfig.current(
-              id: existingId,
-              name: name,
-              searchQuery: ref.read(imageSearchQueryProvider),
-              sort: sortConfig.sort,
-              descending: sortConfig.descending,
-              filter: effectiveFilter,
-            ).toSaveInput(),
-            fromRaw: (raw) => ImageSavedFilterConfig.fromServerPayload(
-              id: raw['id'] as String,
-              name: raw['name'] as String,
-              findFilter: raw['find_filter'],
-              objectFilter: raw['object_filter'],
+        loadPresets: () => ref
+            .read(savedFilterRepositoryProvider)
+            .findAll(
+              mode: 'IMAGES',
+              fromRaw: (raw) => ImageSavedFilterConfig.fromServerPayload(
+                id: raw['id'] as String,
+                name: raw['name'] as String,
+                findFilter: raw['find_filter'],
+                objectFilter: raw['object_filter'],
+              ),
             ),
-          );
+        savePreset: ({required String name, String? existingId}) {
+          return ref
+              .read(savedFilterRepositoryProvider)
+              .save(
+                input: ImageSavedFilterConfig.current(
+                  id: existingId,
+                  name: name,
+                  searchQuery: ref.read(imageSearchQueryProvider),
+                  sort: sortConfig.sort,
+                  descending: sortConfig.descending,
+                  filter: effectiveFilter,
+                ).toSaveInput(),
+                fromRaw: (raw) => ImageSavedFilterConfig.fromServerPayload(
+                  id: raw['id'] as String,
+                  name: raw['name'] as String,
+                  findFilter: raw['find_filter'],
+                  objectFilter: raw['object_filter'],
+                ),
+              );
         },
         onLoad: _applySavedFilterConfig,
       ),
@@ -410,7 +414,8 @@ class _ImagesPageState extends ConsumerState<ImagesPage> {
       imageFilterStateProvider.select((s) => s.filter != const ImageFilter()),
     );
     final organizedFilter = ref.watch(imageOrganizedOnlyProvider);
-    final hasActiveFilters = filterActive || organizedFilter != OrganizedFilter.all;
+    final hasActiveFilters =
+        filterActive || organizedFilter != OrganizedFilter.all;
 
     int crossAxisCount = gridColumns ?? (isTablet ? 3 : (isMobile ? 2 : 5));
 
@@ -470,7 +475,7 @@ class _ImagesPageState extends ConsumerState<ImagesPage> {
           ],
         ),
         IconButton(
-          tooltip: 'Saved filters',
+          tooltip: context.l10n.common_saved_filters,
           icon: const Icon(Icons.bookmarks_outlined),
           onPressed: _showSavedFilterDialog,
         ),
@@ -478,11 +483,10 @@ class _ImagesPageState extends ConsumerState<ImagesPage> {
       searchHint: context.l10n.common_search_placeholder,
       onSearchChanged: _onSearchChanged,
       provider: imagesAsync,
-        itemBuilder: (context, image, memCacheWidth, memCacheHeight) =>
+      itemBuilder: (context, image, memCacheWidth, memCacheHeight) =>
           ImageCard(image: image, memCacheWidth: memCacheWidth),
-        loadingItemBuilder: (context, isGrid, index) => ImageCard.skeleton(
-        memCacheWidth: 300,
-        ),
+      loadingItemBuilder: (context, isGrid, index) =>
+          ImageCard.skeleton(memCacheWidth: 300),
       onRefresh: () => ref.read(imageListProvider.notifier).refresh(),
       onFetchNextPage: () =>
           ref.read(imageListProvider.notifier).fetchNextPage(),

--- a/lib/features/performers/presentation/pages/performers_page.dart
+++ b/lib/features/performers/presentation/pages/performers_page.dart
@@ -390,32 +390,36 @@ class _PerformersPageState extends ConsumerState<PerformersPage> {
         activeFilterCount: _activeFilterCount(filter),
         defaultSortLabel: 'name',
         saveSuccessMessage: 'Performer filter saved to server',
-        loadPresets: () => ref.read(savedFilterRepositoryProvider).findAll(
-          mode: 'PERFORMERS',
-          fromRaw: (raw) => PerformerSavedFilterConfig.fromServerPayload(
-            id: raw['id'] as String,
-            name: raw['name'] as String,
-            findFilter: raw['find_filter'],
-            objectFilter: raw['object_filter'],
-          ),
-        ),
-        savePreset: ({required String name, String? existingId}) {
-          return ref.read(savedFilterRepositoryProvider).save(
-            input: PerformerSavedFilterConfig.current(
-              id: existingId,
-              name: name,
-              searchQuery: ref.read(performerSearchQueryProvider),
-              sort: sortConfig.sort,
-              descending: sortConfig.descending,
-              filter: ref.read(performerFilterStateProvider),
-            ).toSaveInput(),
-            fromRaw: (raw) => PerformerSavedFilterConfig.fromServerPayload(
-              id: raw['id'] as String,
-              name: raw['name'] as String,
-              findFilter: raw['find_filter'],
-              objectFilter: raw['object_filter'],
+        loadPresets: () => ref
+            .read(savedFilterRepositoryProvider)
+            .findAll(
+              mode: 'PERFORMERS',
+              fromRaw: (raw) => PerformerSavedFilterConfig.fromServerPayload(
+                id: raw['id'] as String,
+                name: raw['name'] as String,
+                findFilter: raw['find_filter'],
+                objectFilter: raw['object_filter'],
+              ),
             ),
-          );
+        savePreset: ({required String name, String? existingId}) {
+          return ref
+              .read(savedFilterRepositoryProvider)
+              .save(
+                input: PerformerSavedFilterConfig.current(
+                  id: existingId,
+                  name: name,
+                  searchQuery: ref.read(performerSearchQueryProvider),
+                  sort: sortConfig.sort,
+                  descending: sortConfig.descending,
+                  filter: ref.read(performerFilterStateProvider),
+                ).toSaveInput(),
+                fromRaw: (raw) => PerformerSavedFilterConfig.fromServerPayload(
+                  id: raw['id'] as String,
+                  name: raw['name'] as String,
+                  findFilter: raw['find_filter'],
+                  objectFilter: raw['object_filter'],
+                ),
+              );
         },
         onLoad: _applySavedFilterConfig,
       ),
@@ -501,11 +505,10 @@ class _PerformersPageState extends ConsumerState<PerformersPage> {
                   constraints: const BoxConstraints(minWidth: 8, minHeight: 8),
                 ),
               ),
-
           ],
         ),
         IconButton(
-          tooltip: 'Saved filters',
+          tooltip: context.l10n.common_saved_filters,
           icon: const Icon(Icons.bookmarks_outlined),
           onPressed: _showSavedFilterDialog,
         ),
@@ -525,9 +528,8 @@ class _PerformersPageState extends ConsumerState<PerformersPage> {
           onTap: () => context.push('/performers/performer/${performer.id}'),
         );
       },
-      loadingItemBuilder: (context, isGrid, index) => PerformerCard.skeleton(
-        memCacheWidth: 300,
-      ),
+      loadingItemBuilder: (context, isGrid, index) =>
+          PerformerCard.skeleton(memCacheWidth: 300),
 
       floatingActionButton: randomNavigationEnabled
           ? performersAsync.maybeWhen(

--- a/lib/features/scenes/presentation/pages/scenes_page.dart
+++ b/lib/features/scenes/presentation/pages/scenes_page.dart
@@ -613,7 +613,7 @@ class _ScenesPageState extends ConsumerState<ScenesPage> {
           ],
         ),
         IconButton(
-          tooltip: 'Saved filters',
+          tooltip: context.l10n.common_saved_filters,
           icon: const Icon(Icons.bookmarks_outlined),
           onPressed: _showSavedFilterDialog,
         ),

--- a/lib/features/studios/presentation/pages/studios_page.dart
+++ b/lib/features/studios/presentation/pages/studios_page.dart
@@ -319,32 +319,36 @@ class _StudiosPageState extends ConsumerState<StudiosPage> {
         activeFilterCount: _activeFilterCount(filter),
         defaultSortLabel: 'name',
         saveSuccessMessage: 'Studio filter saved to server',
-        loadPresets: () => ref.read(savedFilterRepositoryProvider).findAll(
-          mode: 'STUDIOS',
-          fromRaw: (raw) => StudioSavedFilterConfig.fromServerPayload(
-            id: raw['id'] as String,
-            name: raw['name'] as String,
-            findFilter: raw['find_filter'],
-            objectFilter: raw['object_filter'],
-          ),
-        ),
-        savePreset: ({required String name, String? existingId}) {
-          return ref.read(savedFilterRepositoryProvider).save(
-            input: StudioSavedFilterConfig.current(
-              id: existingId,
-              name: name,
-              searchQuery: ref.read(studioSearchQueryProvider),
-              sort: sortConfig.sort,
-              descending: sortConfig.descending,
-              filter: ref.read(studioFilterStateProvider),
-            ).toSaveInput(),
-            fromRaw: (raw) => StudioSavedFilterConfig.fromServerPayload(
-              id: raw['id'] as String,
-              name: raw['name'] as String,
-              findFilter: raw['find_filter'],
-              objectFilter: raw['object_filter'],
+        loadPresets: () => ref
+            .read(savedFilterRepositoryProvider)
+            .findAll(
+              mode: 'STUDIOS',
+              fromRaw: (raw) => StudioSavedFilterConfig.fromServerPayload(
+                id: raw['id'] as String,
+                name: raw['name'] as String,
+                findFilter: raw['find_filter'],
+                objectFilter: raw['object_filter'],
+              ),
             ),
-          );
+        savePreset: ({required String name, String? existingId}) {
+          return ref
+              .read(savedFilterRepositoryProvider)
+              .save(
+                input: StudioSavedFilterConfig.current(
+                  id: existingId,
+                  name: name,
+                  searchQuery: ref.read(studioSearchQueryProvider),
+                  sort: sortConfig.sort,
+                  descending: sortConfig.descending,
+                  filter: ref.read(studioFilterStateProvider),
+                ).toSaveInput(),
+                fromRaw: (raw) => StudioSavedFilterConfig.fromServerPayload(
+                  id: raw['id'] as String,
+                  name: raw['name'] as String,
+                  findFilter: raw['find_filter'],
+                  objectFilter: raw['object_filter'],
+                ),
+              );
         },
         onLoad: _applySavedFilterConfig,
       ),
@@ -450,11 +454,10 @@ class _StudiosPageState extends ConsumerState<StudiosPage> {
                   constraints: const BoxConstraints(minWidth: 8, minHeight: 8),
                 ),
               ),
-
           ],
         ),
         IconButton(
-          tooltip: 'Saved filters',
+          tooltip: context.l10n.common_saved_filters,
           icon: const Icon(Icons.bookmarks_outlined),
           onPressed: _showSavedFilterDialog,
         ),
@@ -465,9 +468,9 @@ class _StudiosPageState extends ConsumerState<StudiosPage> {
           horizontal: context.dimensions.spacingMedium,
           vertical: 4,
         ),
-        color: Theme.of(context).colorScheme.primaryContainer.withValues(
-          alpha: 0.3,
-        ),
+        color: Theme.of(
+          context,
+        ).colorScheme.primaryContainer.withValues(alpha: 0.3),
         child: ListTile(
           onTap: () => context.push('/studios/studio/${studio.id}'),
           title: Text(
@@ -490,9 +493,9 @@ class _StudiosPageState extends ConsumerState<StudiosPage> {
             horizontal: context.dimensions.spacingMedium,
             vertical: 4,
           ),
-          color: Theme.of(context).colorScheme.primaryContainer.withValues(
-            alpha: 0.3,
-          ),
+          color: Theme.of(
+            context,
+          ).colorScheme.primaryContainer.withValues(alpha: 0.3),
           child: ListTile(
             title: Text(
               context.l10n.loading,

--- a/lib/features/tags/presentation/pages/tags_page.dart
+++ b/lib/features/tags/presentation/pages/tags_page.dart
@@ -85,8 +85,7 @@ class _TagsPageState extends ConsumerState<TagsPage> {
       'scenes_size' => _TagSortOption.scenesSize,
       'gallery_count' || 'galleries_count' => _TagSortOption.galleryCount,
       'image_count' || 'images_count' => _TagSortOption.imageCount,
-      'performer_count' || 'performers_count' =>
-        _TagSortOption.performerCount,
+      'performer_count' || 'performers_count' => _TagSortOption.performerCount,
       'scenes_count' => _TagSortOption.sceneCount,
       'group_count' || 'groups_count' => _TagSortOption.groupCount,
       'marker_count' || 'scene_markers_count' => _TagSortOption.markerCount,
@@ -311,32 +310,36 @@ class _TagsPageState extends ConsumerState<TagsPage> {
         activeFilterCount: favoritesOnly ? 1 : 0,
         defaultSortLabel: 'name',
         saveSuccessMessage: 'Tag filter saved to server',
-        loadPresets: () => ref.read(savedFilterRepositoryProvider).findAll(
-          mode: 'TAGS',
-          fromRaw: (raw) => TagSavedFilterConfig.fromServerPayload(
-            id: raw['id'] as String,
-            name: raw['name'] as String,
-            findFilter: raw['find_filter'],
-            objectFilter: raw['object_filter'],
-          ),
-        ),
-        savePreset: ({required String name, String? existingId}) {
-          return ref.read(savedFilterRepositoryProvider).save(
-            input: TagSavedFilterConfig.current(
-              id: existingId,
-              name: name,
-              searchQuery: ref.read(tagSearchQueryProvider),
-              sort: sortConfig.sort,
-              descending: sortConfig.descending,
-              favorite: ref.read(tagFavoritesOnlyProvider),
-            ).toSaveInput(),
-            fromRaw: (raw) => TagSavedFilterConfig.fromServerPayload(
-              id: raw['id'] as String,
-              name: raw['name'] as String,
-              findFilter: raw['find_filter'],
-              objectFilter: raw['object_filter'],
+        loadPresets: () => ref
+            .read(savedFilterRepositoryProvider)
+            .findAll(
+              mode: 'TAGS',
+              fromRaw: (raw) => TagSavedFilterConfig.fromServerPayload(
+                id: raw['id'] as String,
+                name: raw['name'] as String,
+                findFilter: raw['find_filter'],
+                objectFilter: raw['object_filter'],
+              ),
             ),
-          );
+        savePreset: ({required String name, String? existingId}) {
+          return ref
+              .read(savedFilterRepositoryProvider)
+              .save(
+                input: TagSavedFilterConfig.current(
+                  id: existingId,
+                  name: name,
+                  searchQuery: ref.read(tagSearchQueryProvider),
+                  sort: sortConfig.sort,
+                  descending: sortConfig.descending,
+                  favorite: ref.read(tagFavoritesOnlyProvider),
+                ).toSaveInput(),
+                fromRaw: (raw) => TagSavedFilterConfig.fromServerPayload(
+                  id: raw['id'] as String,
+                  name: raw['name'] as String,
+                  findFilter: raw['find_filter'],
+                  objectFilter: raw['object_filter'],
+                ),
+              );
         },
         onLoad: _applySavedFilterConfig,
       ),
@@ -440,7 +443,7 @@ class _TagsPageState extends ConsumerState<TagsPage> {
           ],
         ),
         IconButton(
-          tooltip: 'Saved filters',
+          tooltip: context.l10n.common_saved_filters,
           icon: const Icon(Icons.bookmarks_outlined),
           onPressed: _showSavedFilterDialog,
         ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -950,5 +950,6 @@
   },
   "settings_security_title": "Sicherheit",
   "settings_security_app_lock": "App-Sperre",
-  "settings_security_app_lock_subtitle": "Schützen Sie den Zugriff nach dem Hintergrundbetrieb mit einem Passcode."
+  "settings_security_app_lock_subtitle": "Schützen Sie den Zugriff nach dem Hintergrundbetrieb mit einem Passcode.",
+  "common_saved_filters": "Gespeicherte Filter"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1049,5 +1049,6 @@
   },
   "settings_security_title": "Security",
   "settings_security_app_lock": "App lock",
-  "settings_security_app_lock_subtitle": "Protect access with a passcode after backgrounding."
+  "settings_security_app_lock_subtitle": "Protect access with a passcode after backgrounding.",
+  "common_saved_filters": "Saved filters"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -929,5 +929,6 @@
   },
   "settings_security_title": "Seguridad",
   "settings_security_app_lock": "Bloqueo de aplicaciones",
-  "settings_security_app_lock_subtitle": "Proteja el acceso con una contraseña después de ponerlo en segundo plano."
+  "settings_security_app_lock_subtitle": "Proteja el acceso con una contraseña después de ponerlo en segundo plano.",
+  "common_saved_filters": "Filtros guardados"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -929,5 +929,6 @@
   },
   "settings_security_title": "Sécurité",
   "settings_security_app_lock": "Verrouillage d'application",
-  "settings_security_app_lock_subtitle": "Protégez l’accès avec un mot de passe après la mise en arrière-plan."
+  "settings_security_app_lock_subtitle": "Protégez l’accès avec un mot de passe après la mise en arrière-plan.",
+  "common_saved_filters": "Filtres enregistrés"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -934,5 +934,6 @@
   },
   "settings_security_title": "Sicurezza",
   "settings_security_app_lock": "Blocco dell'app",
-  "settings_security_app_lock_subtitle": "Proteggi l'accesso con un passcode dopo il background."
+  "settings_security_app_lock_subtitle": "Proteggi l'accesso con un passcode dopo il background.",
+  "common_saved_filters": "Filtri salvati"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -929,5 +929,6 @@
   },
   "settings_security_title": "安全",
   "settings_security_app_lock": "アプリロック",
-  "settings_security_app_lock_subtitle": "バックグラウンド化後はパスコードでアクセスを保護します。"
+  "settings_security_app_lock_subtitle": "バックグラウンド化後はパスコードでアクセスを保護します。",
+  "common_saved_filters": "保存されたフィルター"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -929,5 +929,6 @@
   },
   "settings_security_title": "보안",
   "settings_security_app_lock": "앱 잠금",
-  "settings_security_app_lock_subtitle": "백그라운드 후 비밀번호로 접근을 보호하세요."
+  "settings_security_app_lock_subtitle": "백그라운드 후 비밀번호로 접근을 보호하세요.",
+  "common_saved_filters": "저장된 필터"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4697,6 +4697,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Protect access with a passcode after backgrounding.'**
   String get settings_security_app_lock_subtitle;
+
+  /// No description provided for @common_saved_filters.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved filters'**
+  String get common_saved_filters;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2565,4 +2565,7 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get settings_security_app_lock_subtitle =>
       'Schützen Sie den Zugriff nach dem Hintergrundbetrieb mit einem Passcode.';
+
+  @override
+  String get common_saved_filters => 'Gespeicherte Filter';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2523,4 +2523,7 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get settings_security_app_lock_subtitle =>
       'Protect access with a passcode after backgrounding.';
+
+  @override
+  String get common_saved_filters => 'Saved filters';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2590,4 +2590,7 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get settings_security_app_lock_subtitle =>
       'Proteja el acceso con una contraseña después de ponerlo en segundo plano.';
+
+  @override
+  String get common_saved_filters => 'Filtros guardados';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2580,4 +2580,7 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get settings_security_app_lock_subtitle =>
       'Protégez l’accès avec un mot de passe après la mise en arrière-plan.';
+
+  @override
+  String get common_saved_filters => 'Filtres enregistrés';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2582,4 +2582,7 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get settings_security_app_lock_subtitle =>
       'Proteggi l\'accesso con un passcode dopo il background.';
+
+  @override
+  String get common_saved_filters => 'Filtri salvati';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2473,4 +2473,7 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get settings_security_app_lock_subtitle =>
       'バックグラウンド化後はパスコードでアクセスを保護します。';
+
+  @override
+  String get common_saved_filters => '保存されたフィルター';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2472,4 +2472,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get settings_security_app_lock_subtitle => '백그라운드 후 비밀번호로 접근을 보호하세요.';
+
+  @override
+  String get common_saved_filters => '저장된 필터';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2558,4 +2558,7 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get settings_security_app_lock_subtitle =>
       'Защитите доступ с помощью пароля после фонового режима.';
+
+  @override
+  String get common_saved_filters => 'Сохраненные фильтры';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2446,6 +2446,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settings_security_app_lock_subtitle => '后台运行后使用密码保护访问。';
+
+  @override
+  String get common_saved_filters => '保存的筛选';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -929,5 +929,6 @@
   },
   "settings_security_title": "Безопасность",
   "settings_security_app_lock": "Блокировка приложения",
-  "settings_security_app_lock_subtitle": "Защитите доступ с помощью пароля после фонового режима."
+  "settings_security_app_lock_subtitle": "Защитите доступ с помощью пароля после фонового режима.",
+  "common_saved_filters": "Сохраненные фильтры"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -929,5 +929,6 @@
   },
   "settings_security_title": "安全",
   "settings_security_app_lock": "应用锁",
-  "settings_security_app_lock_subtitle": "后台运行后使用密码保护访问。"
+  "settings_security_app_lock_subtitle": "后台运行后使用密码保护访问。",
+  "common_saved_filters": "保存的筛选"
 }


### PR DESCRIPTION
💡 What: Replaced hardcoded "Saved filters" tooltips with localized `context.l10n.common_saved_filters` keys across 6 main pages (Scenes, Images, Studios, Galleries, Performers, Tags).
🎯 Why: Hardcoded strings harm accessibility for non-English users, especially those using screen readers who rely on tooltips for icon-only buttons.
📸 Before/After: Before, changing language did not translate these specific tooltips. After, they match the selected app locale correctly.
♿ Accessibility: Improved screen reader support for non-English users by providing accurate localized labels for the saved filter bookmark icons.

---
*PR created automatically by Jules for task [2968079225416299102](https://jules.google.com/task/2968079225416299102) started by @Alchemist-Aloha*