### PR TITLE
⚡ Bolt: [Performance] Defer expensive lookups and deduplicate scroll prefetching in ListPageScaffold

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,7 @@
 ## 2024-05-18 - Throttle ScrollNotification by Index
 **Learning:** `NotificationListener<ScrollNotification>` fires rapidly on every single frame during scrolling. Without throttling, complex processing like loop iterations and hash lookups inside the callback create significant GC pressure and stutter. Using the `visibleIndex` calculation to throttle the callback ensures logic only executes when new content is actually coming into view.
 **Action:** Always capture a `var lastVisibleIndex = -1;` within the `build` method closure (which resets securely on rebuilds) and short-circuit the scroll callback (`if (visibleIndex == lastVisibleIndex) return false;`) before executing heavy operations.
+
+## 2024-05-18 - Defer expensive scroll prefetch lookups
+**Learning:** During rapid scroll events (`NotificationListener<ScrollNotification>`), calculating the visible index and applying an early return *before* executing expensive lookups (like `ref.read` or layout constraints) drastically reduces per-frame overhead.
+**Action:** Always short-circuit scroll listeners using index tracking at the very top of the callback.

--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -338,8 +338,40 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
 
     final offset = scrollInfo.metrics.pixels;
     final isGrid = widget.gridDelegate != null;
-    final headers = ref.read(mediaHeadersProvider);
+    int visibleIndex;
 
+    // ⚡ Bolt: Calculate visible index FIRST and short-circuit early.
+    // This prevents expensive provider reads (ref.read), memory cache width calculations,
+    // and loop iterations if the scroll hasn't actually advanced to a new item.
+    if (isGrid) {
+      final delegate =
+          responsiveDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+      final crossAxisCount = delegate.crossAxisCount;
+      final padding = widget.padding is EdgeInsets
+          ? (widget.padding as EdgeInsets).horizontal
+          : 0.0;
+      final availableWidth = screenWidth - padding;
+      final itemWidth =
+          (availableWidth -
+              (delegate.crossAxisSpacing * (crossAxisCount - 1))) /
+          crossAxisCount;
+
+      final itemHeight =
+          delegate.mainAxisExtent ?? (itemWidth / delegate.childAspectRatio);
+      final stride = itemHeight + delegate.mainAxisSpacing;
+
+      final visibleRow = (offset / stride).floor().clamp(0, items.length - 1);
+      visibleIndex = (visibleRow * crossAxisCount).clamp(0, items.length - 1);
+    } else {
+      final stride = widget.itemExtent ?? _measuredItemExtent ?? 300.0;
+      visibleIndex = (offset / stride).floor().clamp(0, items.length - 1);
+    }
+
+    if (visibleIndex == _lastVisibleIndexPrefetched) return;
+    _lastVisibleIndexPrefetched = visibleIndex;
+
+    // Now perform the slightly more expensive operations only when needed
+    final headers = ref.read(mediaHeadersProvider);
     final prefetchDistance = _memoizedPrefetchDistance ??=
         _getEffectivePrefetchDistance(context, responsiveDelegate);
 
@@ -359,89 +391,29 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
       _memoizedMemCacheWidth = memCacheWidth;
     }
 
-    if (isGrid) {
-      final delegate =
-          responsiveDelegate as SliverGridDelegateWithFixedCrossAxisCount;
-      final crossAxisCount = delegate.crossAxisCount;
-      final padding = widget.padding is EdgeInsets
-          ? (widget.padding as EdgeInsets).horizontal
-          : 0.0;
-      final availableWidth = screenWidth - padding;
-      final itemWidth =
-          (availableWidth -
-              (delegate.crossAxisSpacing * (crossAxisCount - 1))) /
-          crossAxisCount;
-
-      final itemHeight =
-          delegate.mainAxisExtent ?? (itemWidth / delegate.childAspectRatio);
-      final stride = itemHeight + delegate.mainAxisSpacing;
-
-      final visibleRow = (offset / stride).floor().clamp(0, items.length - 1);
-      final visibleIndex = (visibleRow * crossAxisCount).clamp(
-        0,
-        items.length - 1,
-      );
-
-      if (visibleIndex == _lastVisibleIndexPrefetched) return;
-      _lastVisibleIndexPrefetched = visibleIndex;
-
-      for (var i = 1; i <= prefetchDistance; i++) {
-        final ahead = visibleIndex + i;
-        if (ahead < items.length) {
-          final url = widget.imageUrlBuilder!(items[ahead]);
-          if (url != null) {
-            StashImage.prefetch(
-              context,
-              imageUrl: url,
-              headers: headers,
-              memCacheWidth: memCacheWidth,
-            );
-          }
-        }
-        final behind = visibleIndex - i;
-        if (behind >= 0) {
-          final url = widget.imageUrlBuilder!(items[behind]);
-          if (url != null) {
-            StashImage.prefetch(
-              context,
-              imageUrl: url,
-              headers: headers,
-              memCacheWidth: memCacheWidth,
-            );
-          }
+    for (var i = 1; i <= prefetchDistance; i++) {
+      final ahead = visibleIndex + i;
+      if (ahead < items.length) {
+        final url = widget.imageUrlBuilder!(items[ahead]);
+        if (url != null) {
+          StashImage.prefetch(
+            context,
+            imageUrl: url,
+            headers: headers,
+            memCacheWidth: memCacheWidth,
+          );
         }
       }
-    } else {
-      final stride = widget.itemExtent ?? _measuredItemExtent ?? 300.0;
-      final visibleIndex = (offset / stride).floor().clamp(0, items.length - 1);
-
-      if (visibleIndex == _lastVisibleIndexPrefetched) return;
-      _lastVisibleIndexPrefetched = visibleIndex;
-
-      for (var i = 1; i <= prefetchDistance; i++) {
-        final ahead = visibleIndex + i;
-        if (ahead < items.length) {
-          final url = widget.imageUrlBuilder!(items[ahead]);
-          if (url != null) {
-            StashImage.prefetch(
-              context,
-              imageUrl: url,
-              headers: headers,
-              memCacheWidth: memCacheWidth,
-            );
-          }
-        }
-        final behind = visibleIndex - i;
-        if (behind >= 0) {
-          final url = widget.imageUrlBuilder!(items[behind]);
-          if (url != null) {
-            StashImage.prefetch(
-              context,
-              imageUrl: url,
-              headers: headers,
-              memCacheWidth: memCacheWidth,
-            );
-          }
+      final behind = visibleIndex - i;
+      if (behind >= 0) {
+        final url = widget.imageUrlBuilder!(items[behind]);
+        if (url != null) {
+          StashImage.prefetch(
+            context,
+            imageUrl: url,
+            headers: headers,
+            memCacheWidth: memCacheWidth,
+          );
         }
       }
     }


### PR DESCRIPTION
⚡ Bolt: [Performance] Defer expensive lookups and deduplicate scroll prefetching in ListPageScaffold

**What:**
Refactored `_handleScrollPrefetch` in `ListPageScaffold` to calculate the visible index earlier and apply short-circuit returns before executing expensive operations like `ref.read` and layout mathematics. Identical loop logic from the grid and list branches were also deduplicated.

**Why:**
During fast scrolling, `NotificationListener<ScrollNotification>` fires incredibly rapidly (once per frame). Previously, this executed provider reads (`ref.read(mediaHeadersProvider)`) and multiple layout width calculations on every scroll frame before eventually checking if the `visibleIndex` had actually changed to warrant prefetching.

**Impact:**
Eliminates hundreds of redundant `ref.read` calls and hash/width calculations per second during rapid flings and scrolls through grid views, yielding lower CPU overhead and reducing UI thread contention.

**Measurement:**
Can be verified via the Flutter Performance/Timeline overlay during fast scrolling of the Scenes or Galleries page. The reduced time spent in the UI frame for the scroll notification event is measurable when tracing Dart executions.

---
*PR created automatically by Jules for task [7095425020516192706](https://jules.google.com/task/7095425020516192706) started by @Alchemist-Aloha*