### PR TITLE
🎨 Palette: Add accessible states to custom video playback speed button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Custom Video Playback Speed Button Accessibility
+**Learning:** Custom interactive video playback controls implemented using raw `GestureDetector` widgets lack essential accessibility features like screen reader labels, keyboard focus states, and visual hover feedback.
+**Action:** When designing custom controls that act like buttons, wrap the inner content in a `Tooltip` (or `Semantics`) and use an `InkWell` combined with a `Material` widget (with transparent background and appropriate `clipBehavior`) rather than a simple `GestureDetector`. This ensures the UI is accessible via screen readers, operable by keyboard, and provides proper visual feedback upon interaction.

--- a/lib/features/scenes/presentation/widgets/video_controls/video_playback_controls.dart
+++ b/lib/features/scenes/presentation/widgets/video_controls/video_playback_controls.dart
@@ -339,37 +339,45 @@ class VideoPlaybackControls extends ConsumerWidget {
                               )
                               .toList();
                         },
-                        child: GestureDetector(
-                          onTap: onSpeedTap,
-                          child: ConstrainedBox(
-                            constraints: BoxConstraints(
-                              minWidth: buttonMinSize,
-                              minHeight: buttonMinSize,
-                            ),
-                            child: DecoratedBox(
-                              decoration: BoxDecoration(
-                                color: Colors.transparent,
-                                borderRadius: BorderRadius.circular(999),
-                                border: isSpeedSliderVisible
-                                    ? Border.all(
-                                        color: colorScheme.primary,
-                                        width: 1.5,
-                                      )
-                                    : null,
-                              ),
-                              child: Padding(
-                                padding: const EdgeInsets.all(4),
-                                child: Center(
-                                  child: Text(
-                                    _formatSpeed(playbackSpeed),
-                                    style: context.textTheme.bodyMedium
-                                        ?.copyWith(
-                                          color: isSpeedSliderVisible
-                                              ? colorScheme.primary
-                                              : Colors.white,
-                                          fontSize: context.fontSizes.small,
-                                          fontWeight: FontWeight.w700,
-                                        ),
+                        child: Tooltip(
+                          message: context.l10n.common_playback_speed,
+                          child: Material(
+                            color: Colors.transparent,
+                            borderRadius: BorderRadius.circular(999),
+                            clipBehavior: Clip.antiAlias,
+                            child: InkWell(
+                              onTap: onSpeedTap,
+                              child: ConstrainedBox(
+                                constraints: BoxConstraints(
+                                  minWidth: buttonMinSize,
+                                  minHeight: buttonMinSize,
+                                ),
+                                child: DecoratedBox(
+                                  decoration: BoxDecoration(
+                                    color: Colors.transparent,
+                                    borderRadius: BorderRadius.circular(999),
+                                    border: isSpeedSliderVisible
+                                        ? Border.all(
+                                            color: colorScheme.primary,
+                                            width: 1.5,
+                                          )
+                                        : null,
+                                  ),
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(4),
+                                    child: Center(
+                                      child: Text(
+                                        _formatSpeed(playbackSpeed),
+                                        style: context.textTheme.bodyMedium
+                                            ?.copyWith(
+                                              color: isSpeedSliderVisible
+                                                  ? colorScheme.primary
+                                                  : Colors.white,
+                                              fontSize: context.fontSizes.small,
+                                              fontWeight: FontWeight.w700,
+                                            ),
+                                      ),
+                                    ),
                                   ),
                                 ),
                               ),


### PR DESCRIPTION
💡 What: Refactored the custom video playback speed button in `video_playback_controls.dart` to use an `InkWell` wrapped in a `Material` and `Tooltip` instead of a raw `GestureDetector`.

🎯 Why: Custom controls built with raw `GestureDetector` widgets lack essential accessibility features like screen reader labels (tooltips), keyboard navigability (focus states), and visual interactive feedback (ripple effects), degrading the experience for desktop and accessibility users.

📸 Before/After: The visual layout is identical (the Material widget uses a transparent background and matches the previous border radius), but it now supports tooltips on hover and ripple animations on click.

♿ Accessibility: Added proper focus states for keyboard users, semantic labeling (`common_playback_speed`) for screen readers, and hover tooltips for mouse users.

---
*PR created automatically by Jules for task [11898745269330764011](https://jules.google.com/task/11898745269330764011) started by @Alchemist-Aloha*