### PR TITLE
🎨 Palette: [UX improvement] Add accessible semantics and feedback to video speed control

### DIFF
--- a/lib/features/scenes/presentation/widgets/video_controls/video_playback_controls.dart
+++ b/lib/features/scenes/presentation/widgets/video_controls/video_playback_controls.dart
@@ -339,37 +339,50 @@ class VideoPlaybackControls extends ConsumerWidget {
                               )
                               .toList();
                         },
-                        child: GestureDetector(
-                          onTap: onSpeedTap,
-                          child: ConstrainedBox(
-                            constraints: BoxConstraints(
-                              minWidth: buttonMinSize,
-                              minHeight: buttonMinSize,
-                            ),
-                            child: DecoratedBox(
-                              decoration: BoxDecoration(
-                                color: Colors.transparent,
-                                borderRadius: BorderRadius.circular(999),
-                                border: isSpeedSliderVisible
-                                    ? Border.all(
-                                        color: colorScheme.primary,
-                                        width: 1.5,
-                                      )
-                                    : null,
-                              ),
-                              child: Padding(
-                                padding: const EdgeInsets.all(4),
-                                child: Center(
-                                  child: Text(
-                                    _formatSpeed(playbackSpeed),
-                                    style: context.textTheme.bodyMedium
-                                        ?.copyWith(
-                                          color: isSpeedSliderVisible
-                                              ? colorScheme.primary
-                                              : Colors.white,
-                                          fontSize: context.fontSizes.small,
-                                          fontWeight: FontWeight.w700,
+                        child: Semantics(
+                          button: true,
+                          label: context.l10n.common_playback_speed,
+                          child: Tooltip(
+                            message: context.l10n.common_playback_speed,
+                            child: Material(
+                              color: Colors.transparent,
+                              shape: const CircleBorder(),
+                              clipBehavior: Clip.hardEdge,
+                              child: InkWell(
+                                onTap: onSpeedTap,
+                                child: ConstrainedBox(
+                                  constraints: BoxConstraints(
+                                    minWidth: buttonMinSize,
+                                    minHeight: buttonMinSize,
+                                  ),
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(
+                                      color: Colors.transparent,
+                                      borderRadius: BorderRadius.circular(999),
+                                      border: isSpeedSliderVisible
+                                          ? Border.all(
+                                              color: colorScheme.primary,
+                                              width: 1.5,
+                                            )
+                                          : null,
+                                    ),
+                                    child: Padding(
+                                      padding: const EdgeInsets.all(4),
+                                      child: Center(
+                                        child: Text(
+                                          _formatSpeed(playbackSpeed),
+                                          style: context.textTheme.bodyMedium
+                                              ?.copyWith(
+                                                color: isSpeedSliderVisible
+                                                    ? colorScheme.primary
+                                                    : Colors.white,
+                                                fontSize:
+                                                    context.fontSizes.small,
+                                                fontWeight: FontWeight.w700,
+                                              ),
                                         ),
+                                      ),
+                                    ),
                                   ),
                                 ),
                               ),


### PR DESCRIPTION
Replaces a plain `GestureDetector` with an accessible `InkWell` wrapped in `Semantics` and `Tooltip` for the video playback speed control. This provides standard keyboard focusability, screen reader announcements (using the existing `common_playback_speed` localization key), and touch ripples, enhancing both usability and accessibility.

---
*PR created automatically by Jules for task [13824972534911656891](https://jules.google.com/task/13824972534911656891) started by @Alchemist-Aloha*