### PR TITLE
⚡ Bolt: [performance improvement] Optimize horizontal list layout to O(1) via itemExtent

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -42,3 +42,7 @@
 ## 2026-06-06 - [Hoist Scroll Calculations]
 **Learning:** In Dart/Flutter, `pubspec.lock` files can be unintentionally downgraded or modified by running `flutter test` or `flutter pub get` when the local environment SDK doesn't strictly match the locked versions. Agent operations must always verify `git status` post-testing to catch and revert these side-effects (`git restore pubspec.lock`) before proposing a PR.
 **Action:** Always run `git status` and revert any unintended changes to `pubspec.lock` after running Flutter tests or analyzer in the agent sandbox.
+
+## 2026-06-16 - [O(N) to O(1) ListView Rendering]
+**Learning:** When using `ListView.separated` in Flutter, the framework must dynamically calculate the size of every item and separator during scrolling, creating O(N) layout complexity. For lists where all items share the exact same width (like horizontal image strips), this dynamic calculation is pure overhead.
+**Action:** Convert `ListView.separated` to `ListView.builder`, and explicitly set the `itemExtent` property to the fixed item width + separator width (the `stride`). Pad the child inside the `itemBuilder` to account for the separator. This forces Flutter into O(1) layout math, significantly improving scroll performance.

--- a/lib/core/presentation/widgets/media_strip.dart
+++ b/lib/core/presentation/widgets/media_strip.dart
@@ -112,14 +112,13 @@ class MediaStrip extends StatelessWidget {
           return false;
         },
         child: Scrollbar(
-          child: ListView.separated(
+          child: ListView.builder(
             padding: EdgeInsets.symmetric(
               horizontal: context.dimensions.spacingMedium,
             ),
             scrollDirection: Axis.horizontal,
+            itemExtent: stride,
             itemCount: items.length,
-            separatorBuilder: (_, _) =>
-                SizedBox(width: context.dimensions.spacingSmall),
             itemBuilder: (context, index) {
               final item = items[index];
 
@@ -128,40 +127,45 @@ class MediaStrip extends StatelessWidget {
               // The initial and scroll-based prefetching accurately handle warming
               // the cache with memCacheWidth constraints.
 
-              return RepaintBoundary(
-                child: InkWell(
-                  onTap: item.onTap,
-                  borderRadius: BorderRadius.circular(
-                    AppTheme.radiusMedium * context.dimensions.fontSizeFactor,
-                  ),
-                  child: SizedBox(
-                    width: effectiveItemWidth,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        ClipRRect(
-                          borderRadius: BorderRadius.circular(
-                            AppTheme.radiusMedium *
-                                context.dimensions.fontSizeFactor,
+              return Padding(
+                padding: EdgeInsets.only(
+                  right: index == items.length - 1 ? 0 : separatorWidth,
+                ),
+                child: RepaintBoundary(
+                  child: InkWell(
+                    onTap: item.onTap,
+                    borderRadius: BorderRadius.circular(
+                      AppTheme.radiusMedium * context.dimensions.fontSizeFactor,
+                    ),
+                    child: SizedBox(
+                      width: effectiveItemWidth,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          ClipRRect(
+                            borderRadius: BorderRadius.circular(
+                              AppTheme.radiusMedium *
+                                  context.dimensions.fontSizeFactor,
+                            ),
+                            child: StashImage(
+                              imageUrl: item.thumbnailUrl,
+                              width: effectiveItemWidth,
+                              height: effectiveItemWidth * (9 / 16),
+                              fit: BoxFit.cover,
+                              memCacheWidth: (effectiveItemWidth * 2).toInt(),
+                            ),
                           ),
-                          child: StashImage(
-                            imageUrl: item.thumbnailUrl,
-                            width: effectiveItemWidth,
-                            height: effectiveItemWidth * (9 / 16),
-                            fit: BoxFit.cover,
-                            memCacheWidth: (effectiveItemWidth * 2).toInt(),
+                          SizedBox(height: context.dimensions.spacingSmall),
+                          Text(
+                            item.title,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: context.textTheme.bodySmall?.copyWith(
+                              color: context.colors.onSurface,
+                            ),
                           ),
-                        ),
-                        SizedBox(height: context.dimensions.spacingSmall),
-                        Text(
-                          item.title,
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                          style: context.textTheme.bodySmall?.copyWith(
-                            color: context.colors.onSurface,
-                          ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/lib/features/galleries/presentation/widgets/gallery_strip.dart
+++ b/lib/features/galleries/presentation/widgets/gallery_strip.dart
@@ -95,23 +95,27 @@ class GalleryStrip extends ConsumerWidget {
           return false;
         },
         child: Scrollbar(
-          child: ListView.separated(
+          child: ListView.builder(
             padding: EdgeInsets.symmetric(
               horizontal: context.dimensions.spacingMedium,
             ),
             scrollDirection: Axis.horizontal,
+            itemExtent: stride,
             itemCount: galleries.length,
-            separatorBuilder: (_, _) =>
-                SizedBox(width: context.dimensions.spacingSmall),
             itemBuilder: (context, index) {
               final gallery = galleries[index];
 
-              return SizedBox(
-                width: effectiveItemWidth,
-                child: GalleryCard(
-                  gallery: gallery,
-                  isGrid: true,
-                  onTap: onTap != null ? () => onTap!(gallery) : null,
+              return Padding(
+                padding: EdgeInsets.only(
+                  right: index == galleries.length - 1 ? 0 : separatorWidth,
+                ),
+                child: SizedBox(
+                  width: effectiveItemWidth,
+                  child: GalleryCard(
+                    gallery: gallery,
+                    isGrid: true,
+                    onTap: onTap != null ? () => onTap!(gallery) : null,
+                  ),
                 ),
               );
             },

--- a/lib/features/scenes/presentation/widgets/scene_strip.dart
+++ b/lib/features/scenes/presentation/widgets/scene_strip.dart
@@ -95,39 +95,43 @@ class SceneStrip extends ConsumerWidget {
           return false;
         },
         child: Scrollbar(
-          child: ListView.separated(
+          child: ListView.builder(
             padding: EdgeInsets.symmetric(
               horizontal: context.dimensions.spacingMedium,
             ),
             scrollDirection: Axis.horizontal,
+            itemExtent: stride,
             itemCount: scenes.length,
-            separatorBuilder: (_, _) =>
-                SizedBox(width: context.dimensions.spacingSmall),
             itemBuilder: (context, index) {
               final scene = scenes[index];
 
-              return SizedBox(
-                width: effectiveItemWidth,
-                child: SceneCard(
-                  scene: scene,
-                  isGrid: true,
-                  showPerformers: false,
-                  useHero: false,
-                  onTap: queueId != null || onTap != null
-                      ? () {
-                          final playbackQueueId = queueId;
-                          if (playbackQueueId != null) {
-                            ref
-                                .read(playbackQueueProvider.notifier)
-                                .setSequence(
-                                  scenes,
-                                  index,
-                                  queueId: playbackQueueId,
-                                );
+              return Padding(
+                padding: EdgeInsets.only(
+                  right: index == scenes.length - 1 ? 0 : separatorWidth,
+                ),
+                child: SizedBox(
+                  width: effectiveItemWidth,
+                  child: SceneCard(
+                    scene: scene,
+                    isGrid: true,
+                    showPerformers: false,
+                    useHero: false,
+                    onTap: queueId != null || onTap != null
+                        ? () {
+                            final playbackQueueId = queueId;
+                            if (playbackQueueId != null) {
+                              ref
+                                  .read(playbackQueueProvider.notifier)
+                                  .setSequence(
+                                    scenes,
+                                    index,
+                                    queueId: playbackQueueId,
+                                  );
+                            }
+                            onTap?.call(scene);
                           }
-                          onTap?.call(scene);
-                        }
-                      : null,
+                        : null,
+                  ),
                 ),
               );
             },


### PR DESCRIPTION
💡 **What**: Converted horizontal `ListView.separated` implementations in `MediaStrip`, `SceneStrip`, and `GalleryStrip` to use `ListView.builder` with an explicit `itemExtent` equal to `stride` (item width + separator width). Trailing separators are now simulated using inline `Padding` inside the builder.
🎯 **Why**: In horizontal scroll strips containing dozens of items, Flutter's default `ListView.separated` must dynamically interrogate the dimensions of every item and separator as they enter the screen, leading to O(N) layout complexity. Because all items and separators in these strips share the exact same width (`effectiveItemWidth` + `separatorWidth`), this dynamic layout pass is unnecessary overhead.
📊 **Impact**: Reduces list layout complexity from O(N) to O(1). Forces the scrolling mechanism to rely purely on fixed math rather than dynamic box constraint calculations, smoothing out framerates when scrubbing rapidly.
🔬 **Measurement**: Rapidly scroll through a heavy horizontal list of cached scenes/galleries on a physical device. Observe improved 60fps consistency and lower CPU peak usage in DevTools during high-velocity scrolls.

---
*PR created automatically by Jules for task [13263504856607890467](https://jules.google.com/task/13263504856607890467) started by @Alchemist-Aloha*