### PR TITLE
🎨 Palette: [UX improvement] Refactored Switch in TagFilterPanel

### DIFF
--- a/lib/features/tags/presentation/widgets/tag_filter_panel.dart
+++ b/lib/features/tags/presentation/widgets/tag_filter_panel.dart
@@ -141,19 +141,15 @@ class _TagFilterPanelState extends ConsumerState<TagFilterPanel> {
       title: context.l10n.filter_group_general,
       initiallyExpanded: true,
       children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(context.l10n.common_favorites_only),
-            Switch(
-              value: _tempFavoritesOnly,
-              onChanged: (value) {
-                setState(() {
-                  _tempFavoritesOnly = value;
-                });
-              },
-            ),
-          ],
+        SwitchListTile(
+          title: Text(context.l10n.common_favorites_only),
+          contentPadding: EdgeInsets.zero,
+          value: _tempFavoritesOnly,
+          onChanged: (value) {
+            setState(() {
+              _tempFavoritesOnly = value;
+            });
+          },
         ),
       ],
     );


### PR DESCRIPTION
Refactored the manual `Row` containing a `Text` and `Switch` in `TagFilterPanel` to use a native `SwitchListTile`.

- 💡 **What**: Replaced a row-wrapped Switch with a SwitchListTile in the general filter section.
- 🎯 **Why**: To expand the interactive hit area to the full row instead of requiring a precise tap directly on the tiny switch component.
- ♿ **Accessibility**: Improves touch target sizing and native semantics.

---
*PR created automatically by Jules for task [977904535031370637](https://jules.google.com/task/977904535031370637) started by @Alchemist-Aloha*