### PR TITLE
🎨 Palette: [Add accessibility labels to loading indicators]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Add SemanticsLabel to CircularProgressIndicator
+**Learning:** In Flutter, `CircularProgressIndicator` doesn't automatically announce itself to screen readers. Relying solely on the visual indicator excludes visually impaired users. By providing a `semanticsLabel`, screen readers can correctly announce the loading state.
+**Action:** Always add a localized `semanticsLabel` to `CircularProgressIndicator` instances. Remember that doing so requires dynamic context access, so you'll need to remove `const` modifiers from parent widgets where necessary.

--- a/lib/core/presentation/widgets/status_views.dart
+++ b/lib/core/presentation/widgets/status_views.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../theme/app_theme.dart';
+import '../../utils/l10n_extensions.dart';
 
 /// A centered loading indicator for asynchronous operations.
 class LoadingStateView extends StatelessWidget {
@@ -7,7 +8,7 @@ class LoadingStateView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Center(child: CircularProgressIndicator());
+    return Center(child: CircularProgressIndicator(semanticsLabel: context.l10n.common_loading));
   }
 }
 


### PR DESCRIPTION
💡 What: Added a `semanticsLabel` to the `CircularProgressIndicator` inside the global `LoadingStateView` component using the existing `common_loading` localized string.

🎯 Why: To ensure screen reader users are notified when an asynchronous operation is loading, providing equivalent context to the visual spinner.

📸 Before/After: Visuals are unchanged.

♿ Accessibility: Screen readers will now announce 'Loading' (localized) when a loading indicator is displayed, rather than staying silent.

---
*PR created automatically by Jules for task [11157233691960665892](https://jules.google.com/task/11157233691960665892) started by @Alchemist-Aloha*