### PR TITLE
🎨 Palette: Localize hardcoded strings

### DIFF
--- a/lib/core/presentation/widgets/stats_floating_panel.dart
+++ b/lib/core/presentation/widgets/stats_floating_panel.dart
@@ -16,22 +16,17 @@ class StatsFloatingPanel extends ConsumerWidget {
     showGeneralDialog(
       context: context,
       barrierDismissible: true,
-      barrierLabel: 'Stats',
+      barrierLabel: context.l10n.common_stats,
       barrierColor: colorScheme.scrim.withValues(alpha: 0.6),
       transitionDuration: const Duration(milliseconds: 300),
       pageBuilder: (context, anim1, anim2) {
-        return const Center(
-          child: StatsFloatingPanel(),
-        );
+        return const Center(child: StatsFloatingPanel());
       },
       transitionBuilder: (context, anim1, anim2, child) {
         final curve = Curves.easeOutBack.transform(anim1.value);
         return Transform.scale(
           scale: curve,
-          child: Opacity(
-            opacity: anim1.value,
-            child: child,
-          ),
+          child: Opacity(opacity: anim1.value, child: child),
         );
       },
     );
@@ -95,7 +90,11 @@ class StatsFloatingPanel extends ConsumerWidget {
     );
   }
 
-  Widget _buildHeader(BuildContext context, AppDimensions dims, ColorScheme colorScheme) {
+  Widget _buildHeader(
+    BuildContext context,
+    AppDimensions dims,
+    ColorScheme colorScheme,
+  ) {
     return Padding(
       padding: EdgeInsets.fromLTRB(
         dims.spacingMedium * 1.5,

--- a/lib/features/galleries/presentation/pages/galleries_page.dart
+++ b/lib/features/galleries/presentation/pages/galleries_page.dart
@@ -341,8 +341,8 @@ class _GalleriesPageState extends ConsumerState<GalleriesPage> {
         sort: sortConfig.sort,
         descending: sortConfig.descending,
         activeFilterCount: _activeFilterCount(effectiveFilter),
-        defaultSortLabel: 'path',
-        saveSuccessMessage: 'Gallery filter saved to server',
+        defaultSortLabel: context.l10n.common_path,
+        saveSuccessMessage: context.l10n.gallery_filter_saved_to_server,
         loadPresets: () => ref
             .read(savedFilterRepositoryProvider)
             .findAll(

--- a/lib/features/images/presentation/pages/images_page.dart
+++ b/lib/features/images/presentation/pages/images_page.dart
@@ -345,8 +345,8 @@ class _ImagesPageState extends ConsumerState<ImagesPage> {
         sort: sortConfig.sort,
         descending: sortConfig.descending,
         activeFilterCount: _activeFilterCount(effectiveFilter),
-        defaultSortLabel: 'path',
-        saveSuccessMessage: 'Image filter saved to server',
+        defaultSortLabel: context.l10n.common_path,
+        saveSuccessMessage: context.l10n.image_filter_saved_to_server,
         loadPresets: () => ref
             .read(savedFilterRepositoryProvider)
             .findAll(

--- a/lib/features/navigation/presentation/widgets/mini_player.dart
+++ b/lib/features/navigation/presentation/widgets/mini_player.dart
@@ -32,7 +32,7 @@ class MiniPlayer extends ConsumerWidget {
 
     return Semantics(
       button: true,
-      label: 'Now playing: $displayTitle. Tap to open scene details.',
+      label: context.l10n.mini_player_now_playing(displayTitle),
       child: Container(
         height: 66, // Increased height by 10% (from 60)
         decoration: BoxDecoration(

--- a/lib/features/performers/presentation/pages/performers_page.dart
+++ b/lib/features/performers/presentation/pages/performers_page.dart
@@ -388,8 +388,8 @@ class _PerformersPageState extends ConsumerState<PerformersPage> {
         sort: sortConfig.sort,
         descending: sortConfig.descending,
         activeFilterCount: _activeFilterCount(filter),
-        defaultSortLabel: 'name',
-        saveSuccessMessage: 'Performer filter saved to server',
+        defaultSortLabel: context.l10n.common_name,
+        saveSuccessMessage: context.l10n.performer_filter_saved_to_server,
         loadPresets: () => ref
             .read(savedFilterRepositoryProvider)
             .findAll(

--- a/lib/features/scenes/presentation/widgets/scene_saved_filter_dialog.dart
+++ b/lib/features/scenes/presentation/widgets/scene_saved_filter_dialog.dart
@@ -40,8 +40,8 @@ class _SceneSavedFilterDialogState
           .values
           .where((value) => value != null)
           .length,
-      defaultSortLabel: 'date',
-      saveSuccessMessage: 'Scene filter saved to server',
+      defaultSortLabel: context.l10n.common_date,
+      saveSuccessMessage: context.l10n.scene_filter_saved_to_server,
       loadPresets: () => ref.read(sceneSavedFilterRepositoryProvider).findAll(),
       savePreset: ({required String name, String? existingId}) {
         return ref

--- a/lib/features/setup/presentation/widgets/server_profile_drawer.dart
+++ b/lib/features/setup/presentation/widgets/server_profile_drawer.dart
@@ -15,7 +15,8 @@ class ServerProfileDrawer extends ConsumerStatefulWidget {
   const ServerProfileDrawer({super.key, this.profile});
 
   @override
-  ConsumerState<ServerProfileDrawer> createState() => _ServerProfileDrawerState();
+  ConsumerState<ServerProfileDrawer> createState() =>
+      _ServerProfileDrawerState();
 }
 
 class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
@@ -44,7 +45,8 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
     _authMode = widget.profile?.authMode ?? AuthMode.apiKey;
     _allowWebPasswordLogin = widget.profile?.allowWebPasswordLogin ?? false;
 
-    _showAdvancedAuth = _authMode == AuthMode.basic || _authMode == AuthMode.bearer;
+    _showAdvancedAuth =
+        _authMode == AuthMode.basic || _authMode == AuthMode.bearer;
 
     if (widget.profile != null) {
       _loadCredentials();
@@ -54,9 +56,15 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
   Future<void> _loadCredentials() async {
     final secureStorage = ref.read(secureStorageProvider);
     final profileId = widget.profile!.id;
-    final apiKey = await secureStorage.read(key: 'profile_${profileId}_api_key');
-    final username = await secureStorage.read(key: 'profile_${profileId}_username');
-    final password = await secureStorage.read(key: 'profile_${profileId}_password');
+    final apiKey = await secureStorage.read(
+      key: 'profile_${profileId}_api_key',
+    );
+    final username = await secureStorage.read(
+      key: 'profile_${profileId}_username',
+    );
+    final password = await secureStorage.read(
+      key: 'profile_${profileId}_password',
+    );
 
     if (mounted) {
       setState(() {
@@ -92,7 +100,10 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
       var cookieHeader = '';
 
       if (_authMode == AuthMode.password) {
-        setState(() => _testResult = 'Attempting login...');
+        setState(
+          () =>
+              _testResult = context.l10n.server_profile_drawer_attempting_login,
+        );
         final service = await ref.read(authServiceProvider.future);
         final endpointUri = Uri.parse(baseUrl);
         final loggedIn = await service.login(
@@ -102,13 +113,19 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
         );
 
         if (!loggedIn) {
-          setState(() => _testResult = 'Error: Login failed. Check credentials.');
+          setState(
+            () => _testResult =
+                context.l10n.server_profile_drawer_error_login_failed,
+          );
           return;
         }
 
         cookieHeader = await service.cookieHeaderFor(requestUri: endpointUri);
         if (cookieHeader.isEmpty) {
-          setState(() => _testResult = 'Error: Login failed. Check credentials.');
+          setState(
+            () => _testResult =
+                context.l10n.server_profile_drawer_error_login_failed,
+          );
           return;
         }
       }
@@ -133,13 +150,15 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
       // We only need to refresh the top-level status provider.
       // Riverpod will handle the invalidation chain for profileGraphqlClient
       // and its credential dependencies.
-      final result = await ref.refresh(connectionStatusProvider(tempProfile).future);
+      final result = await ref.refresh(
+        connectionStatusProvider(tempProfile).future,
+      );
       setState(() {
         _testResult = result;
       });
     } catch (e) {
       setState(() {
-        _testResult = 'Error: $e';
+        _testResult = context.l10n.server_profile_drawer_error(e.toString());
       });
     } finally {
       setState(() {
@@ -151,8 +170,9 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
   Future<void> _save() async {
     if (!_formKey.currentState!.validate()) return;
 
-    final id = widget.profile?.id ?? DateTime.now().millisecondsSinceEpoch.toString();
-    
+    final id =
+        widget.profile?.id ?? DateTime.now().millisecondsSinceEpoch.toString();
+
     final notifier = ref.read(serverProfilesProvider.notifier);
 
     // Write credentials FIRST to ensure they are available when the profile list updates
@@ -223,7 +243,9 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
     );
 
     if (confirm == true) {
-      await ref.read(serverProfilesProvider.notifier).removeProfile(widget.profile!.id);
+      await ref
+          .read(serverProfilesProvider.notifier)
+          .removeProfile(widget.profile!.id);
       if (mounted) {
         Navigator.of(context).pop();
       }
@@ -233,7 +255,7 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    
+
     return Container(
       padding: EdgeInsets.only(
         // Using MediaQuery.viewInsetsOf(context) instead of MediaQuery.of(context).viewInsets
@@ -250,7 +272,9 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 Text(
-                  widget.profile == null ? l10n.settings_server_profile_add : l10n.settings_server_profile_edit,
+                  widget.profile == null
+                      ? l10n.settings_server_profile_add
+                      : l10n.settings_server_profile_edit,
                   style: Theme.of(context).textTheme.headlineSmall,
                 ),
                 const SizedBox(height: 24),
@@ -274,7 +298,7 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
                   ),
                   validator: (value) {
                     if (value == null || value.isEmpty) {
-                      return 'URL is required';
+                      return context.l10n.server_profile_drawer_url_is_required;
                     }
                     return null;
                   },
@@ -318,7 +342,9 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
                             ? const SizedBox(
                                 width: 16,
                                 height: 16,
-                                child: CircularProgressIndicator(strokeWidth: 2),
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
                               )
                             : const Icon(Icons.sync),
                         label: Text(l10n.settings_server_test),
@@ -332,7 +358,10 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
                     if (widget.profile != null)
                       IconButton(
                         onPressed: _delete,
-                        icon: Icon(Icons.delete_outline, color: Theme.of(context).colorScheme.error),
+                        icon: Icon(
+                          Icons.delete_outline,
+                          color: Theme.of(context).colorScheme.error,
+                        ),
                         tooltip: l10n.settings_server_profile_delete,
                       ),
                     const Spacer(),
@@ -420,10 +449,14 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
         controller: _apiKeyController,
         textInputAction: TextInputAction.done,
         decoration: InputDecoration(
-          labelText: _authMode == AuthMode.apiKey ? l10n.settings_server_auth_apikey : l10n.common_token,
+          labelText: _authMode == AuthMode.apiKey
+              ? l10n.settings_server_auth_apikey
+              : l10n.common_token,
           border: const OutlineInputBorder(),
           suffixIcon: IconButton(
-            icon: Icon(_obscureApiKey ? Icons.visibility : Icons.visibility_off),
+            icon: Icon(
+              _obscureApiKey ? Icons.visibility : Icons.visibility_off,
+            ),
             tooltip: _obscureApiKey ? l10n.common_show : l10n.common_hide,
             onPressed: () => setState(() => _obscureApiKey = !_obscureApiKey),
           ),
@@ -449,9 +482,12 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
               labelText: l10n.settings_server_password,
               border: const OutlineInputBorder(),
               suffixIcon: IconButton(
-                icon: Icon(_obscurePassword ? Icons.visibility : Icons.visibility_off),
+                icon: Icon(
+                  _obscurePassword ? Icons.visibility : Icons.visibility_off,
+                ),
                 tooltip: _obscurePassword ? l10n.common_show : l10n.common_hide,
-                onPressed: () => setState(() => _obscurePassword = !_obscurePassword),
+                onPressed: () =>
+                    setState(() => _obscurePassword = !_obscurePassword),
               ),
             ),
             obscureText: _obscurePassword,

--- a/lib/features/studios/presentation/pages/studios_page.dart
+++ b/lib/features/studios/presentation/pages/studios_page.dart
@@ -317,8 +317,8 @@ class _StudiosPageState extends ConsumerState<StudiosPage> {
         sort: sortConfig.sort,
         descending: sortConfig.descending,
         activeFilterCount: _activeFilterCount(filter),
-        defaultSortLabel: 'name',
-        saveSuccessMessage: 'Studio filter saved to server',
+        defaultSortLabel: context.l10n.common_name,
+        saveSuccessMessage: context.l10n.studio_filter_saved_to_server,
         loadPresets: () => ref
             .read(savedFilterRepositoryProvider)
             .findAll(

--- a/lib/features/tags/presentation/pages/tags_page.dart
+++ b/lib/features/tags/presentation/pages/tags_page.dart
@@ -308,8 +308,8 @@ class _TagsPageState extends ConsumerState<TagsPage> {
         sort: sortConfig.sort,
         descending: sortConfig.descending,
         activeFilterCount: favoritesOnly ? 1 : 0,
-        defaultSortLabel: 'name',
-        saveSuccessMessage: 'Tag filter saved to server',
+        defaultSortLabel: context.l10n.common_name,
+        saveSuccessMessage: context.l10n.tag_filter_saved_to_server,
         loadPresets: () => ref
             .read(savedFilterRepositoryProvider)
             .findAll(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1072,5 +1072,17 @@
   "settings_security_subtitle": "App-Sperre und Passcode-Einstellungen",
   "tools_section_subtitle": "Wartungs- und Metadaten-Workflows für Szenen.",
   "tools_scene_deduplication_subtitle": "Duplikate finden und verwalten.",
-  "tools_scene_tagger_subtitle": "Aktuelle Szenenseiten mit Stash-box scrapen."
+  "tools_scene_tagger_subtitle": "Aktuelle Szenenseiten mit Stash-box scrapen.",
+  "common_stats": "Statistiken",
+  "image_filter_saved_to_server": "Bildfilter auf Server gespeichert",
+  "studio_filter_saved_to_server": "Studiofilter auf dem Server gespeichert",
+  "gallery_filter_saved_to_server": "Galeriefilter auf dem Server gespeichert",
+  "performer_filter_saved_to_server": "Darstellerfilter auf dem Server gespeichert",
+  "tag_filter_saved_to_server": "Tag-Filter auf dem Server gespeichert",
+  "mini_player_now_playing": "Wird gerade abgespielt: {displayTitle}. Tippen Sie hier, um Szenendetails zu öffnen.",
+  "server_profile_drawer_attempting_login": "Ich versuche mich anzumelden...",
+  "server_profile_drawer_error_login_failed": "Fehler: Anmeldung fehlgeschlagen. Überprüfen Sie die Anmeldeinformationen.",
+  "server_profile_drawer_error": "Fehler: {error}",
+  "server_profile_drawer_url_is_required": "URL ist erforderlich",
+  "scene_filter_saved_to_server": "Szenenfilter auf dem Server gespeichert"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1400,5 +1400,31 @@
       }
     }
   },
-  "stats_library_stats_tooltip": "Long press for library stats"
+  "stats_library_stats_tooltip": "Long press for library stats",
+  "common_stats": "Stats",
+  "image_filter_saved_to_server": "Image filter saved to server",
+  "studio_filter_saved_to_server": "Studio filter saved to server",
+  "gallery_filter_saved_to_server": "Gallery filter saved to server",
+  "performer_filter_saved_to_server": "Performer filter saved to server",
+  "tag_filter_saved_to_server": "Tag filter saved to server",
+  "mini_player_now_playing": "Now playing: {displayTitle}. Tap to open scene details.",
+  "@mini_player_now_playing": {
+    "placeholders": {
+      "displayTitle": {
+        "type": "String"
+      }
+    }
+  },
+  "server_profile_drawer_attempting_login": "Attempting login...",
+  "server_profile_drawer_error_login_failed": "Error: Login failed. Check credentials.",
+  "server_profile_drawer_error": "Error: {error}",
+  "@server_profile_drawer_error": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "server_profile_drawer_url_is_required": "URL is required",
+  "scene_filter_saved_to_server": "Scene filter saved to server"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1051,5 +1051,17 @@
   "settings_security_subtitle": "Configuración de bloqueo de aplicación y contraseña",
   "tools_section_subtitle": "Flujos de trabajo de mantenimiento y metadatos para escenas.",
   "tools_scene_deduplication_subtitle": "Buscar y gestionar escenas duplicadas.",
-  "tools_scene_tagger_subtitle": "Extraer páginas de escenas actuales con Stash-box."
+  "tools_scene_tagger_subtitle": "Extraer páginas de escenas actuales con Stash-box.",
+  "common_stats": "Estadísticas",
+  "image_filter_saved_to_server": "Filtro de imagen guardado en el servidor",
+  "studio_filter_saved_to_server": "Filtro de estudio guardado en el servidor",
+  "gallery_filter_saved_to_server": "Filtro de galería guardado en el servidor",
+  "performer_filter_saved_to_server": "Filtro de intérprete guardado en el servidor",
+  "tag_filter_saved_to_server": "Filtro de etiquetas guardado en el servidor",
+  "mini_player_now_playing": "Reproduciendo ahora: {displayTitle}. Toque para abrir los detalles de la escena.",
+  "server_profile_drawer_attempting_login": "Intentando iniciar sesión...",
+  "server_profile_drawer_error_login_failed": "Error: Error al iniciar sesión. Verificar credenciales.",
+  "server_profile_drawer_error": "Error: {error}",
+  "server_profile_drawer_url_is_required": "La URL es obligatoria",
+  "scene_filter_saved_to_server": "Filtro de escena guardado en el servidor"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1051,5 +1051,17 @@
   "settings_security_subtitle": "Paramètres de verrouillage de l'application et du code",
   "tools_section_subtitle": "Flux de travail de maintenance et de métadonnées pour les scènes.",
   "tools_scene_deduplication_subtitle": "Rechercher et gérer les scènes en double.",
-  "tools_scene_tagger_subtitle": "Scraper les pages de scènes actuelles avec Stash-box."
+  "tools_scene_tagger_subtitle": "Scraper les pages de scènes actuelles avec Stash-box.",
+  "common_stats": "Statistiques",
+  "image_filter_saved_to_server": "Filtre d'image enregistré sur le serveur",
+  "studio_filter_saved_to_server": "Filtre Studio enregistré sur le serveur",
+  "gallery_filter_saved_to_server": "Filtre de galerie enregistré sur le serveur",
+  "performer_filter_saved_to_server": "Filtre d'intervenant enregistré sur le serveur",
+  "tag_filter_saved_to_server": "Filtre de balises enregistré sur le serveur",
+  "mini_player_now_playing": "Lecture en cours : {displayTitle}. Appuyez pour ouvrir les détails de la scène.",
+  "server_profile_drawer_attempting_login": "Tentative de connexion...",
+  "server_profile_drawer_error_login_failed": "Erreur : La connexion a échoué. Vérifiez les informations d'identification.",
+  "server_profile_drawer_error": "Erreur : {error}",
+  "server_profile_drawer_url_is_required": "L'URL est obligatoire",
+  "scene_filter_saved_to_server": "Filtre de scène enregistré sur le serveur"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1056,5 +1056,17 @@
   "settings_security_subtitle": "Impostazioni del blocco dell'applicazione e del passcode",
   "tools_section_subtitle": "Flussi di lavoro di manutenzione e metadati per le scene.",
   "tools_scene_deduplication_subtitle": "Trova e gestisci le scene duplicate.",
-  "tools_scene_tagger_subtitle": "Scrape delle pagine delle scene correnti con Stash-box."
+  "tools_scene_tagger_subtitle": "Scrape delle pagine delle scene correnti con Stash-box.",
+  "common_stats": "Statistiche",
+  "image_filter_saved_to_server": "Filtro immagine salvato sul server",
+  "studio_filter_saved_to_server": "Filtro Studio salvato sul server",
+  "gallery_filter_saved_to_server": "Filtro della galleria salvato sul server",
+  "performer_filter_saved_to_server": "Filtro dell'esecutore salvato sul server",
+  "tag_filter_saved_to_server": "Filtro tag salvato sul server",
+  "mini_player_now_playing": "Ora in riproduzione: {displayTitle}. Tocca per aprire i dettagli della scena.",
+  "server_profile_drawer_attempting_login": "Tentativo di accesso...",
+  "server_profile_drawer_error_login_failed": "Errore: accesso non riuscito. Controlla le credenziali.",
+  "server_profile_drawer_error": "Errore: {error}",
+  "server_profile_drawer_url_is_required": "L'URL è obbligatorio",
+  "scene_filter_saved_to_server": "Filtro scena salvato sul server"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1051,5 +1051,17 @@
   "settings_security_subtitle": "アプリロックとパスコードの設定",
   "tools_section_subtitle": "シーンのメンテナンスとメタデータのワークフロー。",
   "tools_scene_deduplication_subtitle": "重複するシーンを見つけて管理します。",
-  "tools_scene_tagger_subtitle": "Stash-boxを使用して現在のシーンページをスクレイピングします。"
+  "tools_scene_tagger_subtitle": "Stash-boxを使用して現在のシーンページをスクレイピングします。",
+  "common_stats": "統計",
+  "image_filter_saved_to_server": "画像フィルターをサーバーに保存",
+  "studio_filter_saved_to_server": "スタジオフィルターがサーバーに保存されました",
+  "gallery_filter_saved_to_server": "ギャラリーフィルターがサーバーに保存されました",
+  "performer_filter_saved_to_server": "実行者フィルターがサーバーに保存されました",
+  "tag_filter_saved_to_server": "Tag filter saved to server",
+  "mini_player_now_playing": "現在再生中: {displayTitle}。タップしてシーンの詳細を開きます。",
+  "server_profile_drawer_attempting_login": "ログインを試みています...",
+  "server_profile_drawer_error_login_failed": "エラー: ログインに失敗しました。資格情報を確認します。",
+  "server_profile_drawer_error": "エラー: {error}",
+  "server_profile_drawer_url_is_required": "URLは必須です",
+  "scene_filter_saved_to_server": "シーンフィルターがサーバーに保存されました"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1051,5 +1051,17 @@
   "settings_security_subtitle": "앱 잠금 및 비밀번호 설정",
   "tools_section_subtitle": "씬에 대한 유지 관리 및 메타데이터 워크플로.",
   "tools_scene_deduplication_subtitle": "중복된 씬을 찾아 관리합니다.",
-  "tools_scene_tagger_subtitle": "Stash-box로 현재 씬 페이지를 스크랩합니다."
+  "tools_scene_tagger_subtitle": "Stash-box로 현재 씬 페이지를 스크랩합니다.",
+  "common_stats": "통계",
+  "image_filter_saved_to_server": "서버에 저장된 이미지 필터",
+  "studio_filter_saved_to_server": "서버에 Studio 필터가 저장되었습니다.",
+  "gallery_filter_saved_to_server": "서버에 갤러리 필터가 저장되었습니다.",
+  "performer_filter_saved_to_server": "서버에 저장된 수행자 필터",
+  "tag_filter_saved_to_server": "서버에 태그 필터가 저장됨",
+  "mini_player_now_playing": "현재 재생 중: {displayTitle}. 장면 세부정보를 열려면 탭하세요.",
+  "server_profile_drawer_attempting_login": "로그인을 시도하는 중...",
+  "server_profile_drawer_error_login_failed": "오류: 로그인에 실패했습니다. 자격 증명을 확인하세요.",
+  "server_profile_drawer_error": "오류: {error}",
+  "server_profile_drawer_url_is_required": "URL이 필요합니다",
+  "scene_filter_saved_to_server": "서버에 저장된 장면 필터"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5429,6 +5429,78 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Long press for library stats'**
   String get stats_library_stats_tooltip;
+
+  /// No description provided for @common_stats.
+  ///
+  /// In en, this message translates to:
+  /// **'Stats'**
+  String get common_stats;
+
+  /// No description provided for @image_filter_saved_to_server.
+  ///
+  /// In en, this message translates to:
+  /// **'Image filter saved to server'**
+  String get image_filter_saved_to_server;
+
+  /// No description provided for @studio_filter_saved_to_server.
+  ///
+  /// In en, this message translates to:
+  /// **'Studio filter saved to server'**
+  String get studio_filter_saved_to_server;
+
+  /// No description provided for @gallery_filter_saved_to_server.
+  ///
+  /// In en, this message translates to:
+  /// **'Gallery filter saved to server'**
+  String get gallery_filter_saved_to_server;
+
+  /// No description provided for @performer_filter_saved_to_server.
+  ///
+  /// In en, this message translates to:
+  /// **'Performer filter saved to server'**
+  String get performer_filter_saved_to_server;
+
+  /// No description provided for @tag_filter_saved_to_server.
+  ///
+  /// In en, this message translates to:
+  /// **'Tag filter saved to server'**
+  String get tag_filter_saved_to_server;
+
+  /// No description provided for @mini_player_now_playing.
+  ///
+  /// In en, this message translates to:
+  /// **'Now playing: {displayTitle}. Tap to open scene details.'**
+  String mini_player_now_playing(String displayTitle);
+
+  /// No description provided for @server_profile_drawer_attempting_login.
+  ///
+  /// In en, this message translates to:
+  /// **'Attempting login...'**
+  String get server_profile_drawer_attempting_login;
+
+  /// No description provided for @server_profile_drawer_error_login_failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Error: Login failed. Check credentials.'**
+  String get server_profile_drawer_error_login_failed;
+
+  /// No description provided for @server_profile_drawer_error.
+  ///
+  /// In en, this message translates to:
+  /// **'Error: {error}'**
+  String server_profile_drawer_error(String error);
+
+  /// No description provided for @server_profile_drawer_url_is_required.
+  ///
+  /// In en, this message translates to:
+  /// **'URL is required'**
+  String get server_profile_drawer_url_is_required;
+
+  /// No description provided for @scene_filter_saved_to_server.
+  ///
+  /// In en, this message translates to:
+  /// **'Scene filter saved to server'**
+  String get scene_filter_saved_to_server;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3053,4 +3053,52 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Lange drücken für Bibliotheksstatistiken';
+
+  @override
+  String get common_stats => 'Statistiken';
+
+  @override
+  String get image_filter_saved_to_server =>
+      'Bildfilter auf Server gespeichert';
+
+  @override
+  String get studio_filter_saved_to_server =>
+      'Studiofilter auf dem Server gespeichert';
+
+  @override
+  String get gallery_filter_saved_to_server =>
+      'Galeriefilter auf dem Server gespeichert';
+
+  @override
+  String get performer_filter_saved_to_server =>
+      'Darstellerfilter auf dem Server gespeichert';
+
+  @override
+  String get tag_filter_saved_to_server =>
+      'Tag-Filter auf dem Server gespeichert';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return 'Wird gerade abgespielt: $displayTitle. Tippen Sie hier, um Szenendetails zu öffnen.';
+  }
+
+  @override
+  String get server_profile_drawer_attempting_login =>
+      'Ich versuche mich anzumelden...';
+
+  @override
+  String get server_profile_drawer_error_login_failed =>
+      'Fehler: Anmeldung fehlgeschlagen. Überprüfen Sie die Anmeldeinformationen.';
+
+  @override
+  String server_profile_drawer_error(String error) {
+    return 'Fehler: $error';
+  }
+
+  @override
+  String get server_profile_drawer_url_is_required => 'URL ist erforderlich';
+
+  @override
+  String get scene_filter_saved_to_server =>
+      'Szenenfilter auf dem Server gespeichert';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3007,4 +3007,46 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get stats_library_stats_tooltip => 'Long press for library stats';
+
+  @override
+  String get common_stats => 'Stats';
+
+  @override
+  String get image_filter_saved_to_server => 'Image filter saved to server';
+
+  @override
+  String get studio_filter_saved_to_server => 'Studio filter saved to server';
+
+  @override
+  String get gallery_filter_saved_to_server => 'Gallery filter saved to server';
+
+  @override
+  String get performer_filter_saved_to_server =>
+      'Performer filter saved to server';
+
+  @override
+  String get tag_filter_saved_to_server => 'Tag filter saved to server';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return 'Now playing: $displayTitle. Tap to open scene details.';
+  }
+
+  @override
+  String get server_profile_drawer_attempting_login => 'Attempting login...';
+
+  @override
+  String get server_profile_drawer_error_login_failed =>
+      'Error: Login failed. Check credentials.';
+
+  @override
+  String server_profile_drawer_error(String error) {
+    return 'Error: $error';
+  }
+
+  @override
+  String get server_profile_drawer_url_is_required => 'URL is required';
+
+  @override
+  String get scene_filter_saved_to_server => 'Scene filter saved to server';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3080,4 +3080,52 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Mantén pulsado para ver las estadísticas de la biblioteca';
+
+  @override
+  String get common_stats => 'Estadísticas';
+
+  @override
+  String get image_filter_saved_to_server =>
+      'Filtro de imagen guardado en el servidor';
+
+  @override
+  String get studio_filter_saved_to_server =>
+      'Filtro de estudio guardado en el servidor';
+
+  @override
+  String get gallery_filter_saved_to_server =>
+      'Filtro de galería guardado en el servidor';
+
+  @override
+  String get performer_filter_saved_to_server =>
+      'Filtro de intérprete guardado en el servidor';
+
+  @override
+  String get tag_filter_saved_to_server =>
+      'Filtro de etiquetas guardado en el servidor';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return 'Reproduciendo ahora: $displayTitle. Toque para abrir los detalles de la escena.';
+  }
+
+  @override
+  String get server_profile_drawer_attempting_login =>
+      'Intentando iniciar sesión...';
+
+  @override
+  String get server_profile_drawer_error_login_failed =>
+      'Error: Error al iniciar sesión. Verificar credenciales.';
+
+  @override
+  String server_profile_drawer_error(String error) {
+    return 'Error: $error';
+  }
+
+  @override
+  String get server_profile_drawer_url_is_required => 'La URL es obligatoria';
+
+  @override
+  String get scene_filter_saved_to_server =>
+      'Filtro de escena guardado en el servidor';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3072,4 +3072,52 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Appui long pour les statistiques de la bibliothèque';
+
+  @override
+  String get common_stats => 'Statistiques';
+
+  @override
+  String get image_filter_saved_to_server =>
+      'Filtre d\'image enregistré sur le serveur';
+
+  @override
+  String get studio_filter_saved_to_server =>
+      'Filtre Studio enregistré sur le serveur';
+
+  @override
+  String get gallery_filter_saved_to_server =>
+      'Filtre de galerie enregistré sur le serveur';
+
+  @override
+  String get performer_filter_saved_to_server =>
+      'Filtre d\'intervenant enregistré sur le serveur';
+
+  @override
+  String get tag_filter_saved_to_server =>
+      'Filtre de balises enregistré sur le serveur';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return 'Lecture en cours : $displayTitle. Appuyez pour ouvrir les détails de la scène.';
+  }
+
+  @override
+  String get server_profile_drawer_attempting_login =>
+      'Tentative de connexion...';
+
+  @override
+  String get server_profile_drawer_error_login_failed =>
+      'Erreur : La connexion a échoué. Vérifiez les informations d\'identification.';
+
+  @override
+  String server_profile_drawer_error(String error) {
+    return 'Erreur : $error';
+  }
+
+  @override
+  String get server_profile_drawer_url_is_required => 'L\'URL est obligatoire';
+
+  @override
+  String get scene_filter_saved_to_server =>
+      'Filtre de scène enregistré sur le serveur';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3071,4 +3071,50 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Tieni premuto per le statistiche della libreria';
+
+  @override
+  String get common_stats => 'Statistiche';
+
+  @override
+  String get image_filter_saved_to_server =>
+      'Filtro immagine salvato sul server';
+
+  @override
+  String get studio_filter_saved_to_server =>
+      'Filtro Studio salvato sul server';
+
+  @override
+  String get gallery_filter_saved_to_server =>
+      'Filtro della galleria salvato sul server';
+
+  @override
+  String get performer_filter_saved_to_server =>
+      'Filtro dell\'esecutore salvato sul server';
+
+  @override
+  String get tag_filter_saved_to_server => 'Filtro tag salvato sul server';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return 'Ora in riproduzione: $displayTitle. Tocca per aprire i dettagli della scena.';
+  }
+
+  @override
+  String get server_profile_drawer_attempting_login =>
+      'Tentativo di accesso...';
+
+  @override
+  String get server_profile_drawer_error_login_failed =>
+      'Errore: accesso non riuscito. Controlla le credenziali.';
+
+  @override
+  String server_profile_drawer_error(String error) {
+    return 'Errore: $error';
+  }
+
+  @override
+  String get server_profile_drawer_url_is_required => 'L\'URL è obbligatorio';
+
+  @override
+  String get scene_filter_saved_to_server => 'Filtro scena salvato sul server';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2951,4 +2951,45 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get stats_library_stats_tooltip => '長押しでライブラリ統計を表示';
+
+  @override
+  String get common_stats => '統計';
+
+  @override
+  String get image_filter_saved_to_server => '画像フィルターをサーバーに保存';
+
+  @override
+  String get studio_filter_saved_to_server => 'スタジオフィルターがサーバーに保存されました';
+
+  @override
+  String get gallery_filter_saved_to_server => 'ギャラリーフィルターがサーバーに保存されました';
+
+  @override
+  String get performer_filter_saved_to_server => '実行者フィルターがサーバーに保存されました';
+
+  @override
+  String get tag_filter_saved_to_server => 'Tag filter saved to server';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return '現在再生中: $displayTitle。タップしてシーンの詳細を開きます。';
+  }
+
+  @override
+  String get server_profile_drawer_attempting_login => 'ログインを試みています...';
+
+  @override
+  String get server_profile_drawer_error_login_failed =>
+      'エラー: ログインに失敗しました。資格情報を確認します。';
+
+  @override
+  String server_profile_drawer_error(String error) {
+    return 'エラー: $error';
+  }
+
+  @override
+  String get server_profile_drawer_url_is_required => 'URLは必須です';
+
+  @override
+  String get scene_filter_saved_to_server => 'シーンフィルターがサーバーに保存されました';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2949,4 +2949,45 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get stats_library_stats_tooltip => '길게 눌러 라이브러리 통계 보기';
+
+  @override
+  String get common_stats => '통계';
+
+  @override
+  String get image_filter_saved_to_server => '서버에 저장된 이미지 필터';
+
+  @override
+  String get studio_filter_saved_to_server => '서버에 Studio 필터가 저장되었습니다.';
+
+  @override
+  String get gallery_filter_saved_to_server => '서버에 갤러리 필터가 저장되었습니다.';
+
+  @override
+  String get performer_filter_saved_to_server => '서버에 저장된 수행자 필터';
+
+  @override
+  String get tag_filter_saved_to_server => '서버에 태그 필터가 저장됨';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return '현재 재생 중: $displayTitle. 장면 세부정보를 열려면 탭하세요.';
+  }
+
+  @override
+  String get server_profile_drawer_attempting_login => '로그인을 시도하는 중...';
+
+  @override
+  String get server_profile_drawer_error_login_failed =>
+      '오류: 로그인에 실패했습니다. 자격 증명을 확인하세요.';
+
+  @override
+  String server_profile_drawer_error(String error) {
+    return '오류: $error';
+  }
+
+  @override
+  String get server_profile_drawer_url_is_required => 'URL이 필요합니다';
+
+  @override
+  String get scene_filter_saved_to_server => '서버에 저장된 장면 필터';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3048,4 +3048,49 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Удерживайте для статистики библиотеки';
+
+  @override
+  String get common_stats => 'Статистика';
+
+  @override
+  String get image_filter_saved_to_server =>
+      'Фильтр изображений сохранен на сервере';
+
+  @override
+  String get studio_filter_saved_to_server =>
+      'Фильтр Studio сохранен на сервере.';
+
+  @override
+  String get gallery_filter_saved_to_server =>
+      'Фильтр галереи сохранен на сервере.';
+
+  @override
+  String get performer_filter_saved_to_server =>
+      'Фильтр исполнителей сохранен на сервере';
+
+  @override
+  String get tag_filter_saved_to_server => 'Фильтр тегов сохранен на сервере.';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return 'Сейчас играет: $displayTitle. Нажмите, чтобы открыть сведения о сцене.';
+  }
+
+  @override
+  String get server_profile_drawer_attempting_login => 'Попытка входа...';
+
+  @override
+  String get server_profile_drawer_error_login_failed =>
+      'Ошибка: Не удалось войти. Проверьте учетные данные.';
+
+  @override
+  String server_profile_drawer_error(String error) {
+    return 'Ошибка: $error.';
+  }
+
+  @override
+  String get server_profile_drawer_url_is_required => 'URL-адрес необязателен.';
+
+  @override
+  String get scene_filter_saved_to_server => 'Фильтр сцен сохранен на сервере.';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2895,6 +2895,46 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get stats_library_stats_tooltip => '长按查看资料库统计';
+
+  @override
+  String get common_stats => '统计数据';
+
+  @override
+  String get image_filter_saved_to_server => '图像过滤器保存到服务器';
+
+  @override
+  String get studio_filter_saved_to_server => '工作室过滤器保存到服务器';
+
+  @override
+  String get gallery_filter_saved_to_server => '图库过滤器保存到服务器';
+
+  @override
+  String get performer_filter_saved_to_server => '表演者过滤器保存到服务器';
+
+  @override
+  String get tag_filter_saved_to_server => '标签过滤器保存到服务器';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return '正在播放：$displayTitle。点击可打开场景详细信息。';
+  }
+
+  @override
+  String get server_profile_drawer_attempting_login => '正在尝试登录...';
+
+  @override
+  String get server_profile_drawer_error_login_failed => '错误：登录失败。检查凭据。';
+
+  @override
+  String server_profile_drawer_error(String error) {
+    return '错误：$error';
+  }
+
+  @override
+  String get server_profile_drawer_url_is_required => '网址为必填项';
+
+  @override
+  String get scene_filter_saved_to_server => '场景滤镜保存到服务器';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -5787,6 +5827,46 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get stats_library_stats_tooltip => '长按查看资料库统计';
+
+  @override
+  String get common_stats => '统计数据';
+
+  @override
+  String get image_filter_saved_to_server => '图像过滤器保存到服务器';
+
+  @override
+  String get studio_filter_saved_to_server => '工作室过滤器保存到服务器';
+
+  @override
+  String get gallery_filter_saved_to_server => '图库过滤器保存到服务器';
+
+  @override
+  String get performer_filter_saved_to_server => '表演者过滤器保存到服务器';
+
+  @override
+  String get tag_filter_saved_to_server => '标签过滤器保存到服务器';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return '正在播放：$displayTitle。点击可打开场景详细信息。';
+  }
+
+  @override
+  String get server_profile_drawer_attempting_login => '正在尝试登录...';
+
+  @override
+  String get server_profile_drawer_error_login_failed => '错误：登录失败。检查凭据。';
+
+  @override
+  String server_profile_drawer_error(String error) {
+    return '错误：$error';
+  }
+
+  @override
+  String get server_profile_drawer_url_is_required => '网址为必填项';
+
+  @override
+  String get scene_filter_saved_to_server => '场景滤镜保存到服务器';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -8683,4 +8763,44 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get stats_library_stats_tooltip => '長按查看資料庫統計';
+
+  @override
+  String get common_stats => '統計數據';
+
+  @override
+  String get image_filter_saved_to_server => '影像過濾器保存到伺服器';
+
+  @override
+  String get studio_filter_saved_to_server => '工作室過濾器保存到伺服器';
+
+  @override
+  String get gallery_filter_saved_to_server => '圖庫過濾器保存到伺服器';
+
+  @override
+  String get performer_filter_saved_to_server => '表演者過濾器儲存到伺服器';
+
+  @override
+  String get tag_filter_saved_to_server => '標籤過濾器儲存到伺服器';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return '正在播放：$displayTitle。點擊可開啟場景詳細資訊。';
+  }
+
+  @override
+  String get server_profile_drawer_attempting_login => '正在嘗試登入...';
+
+  @override
+  String get server_profile_drawer_error_login_failed => '錯誤：登入失敗。檢查憑證。';
+
+  @override
+  String server_profile_drawer_error(String error) {
+    return '錯誤：$error';
+  }
+
+  @override
+  String get server_profile_drawer_url_is_required => '網址為必填項';
+
+  @override
+  String get scene_filter_saved_to_server => '場景濾鏡儲存到伺服器';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1051,5 +1051,17 @@
   "settings_security_subtitle": "Настройки блокировки приложения и пароля",
   "tools_section_subtitle": "Рабочие процессы обслуживания и метаданных для сцен.",
   "tools_scene_deduplication_subtitle": "Поиск и управление дубликатами сцен.",
-  "tools_scene_tagger_subtitle": "Скрапинг страниц текущих сцен с помощью Stash-box."
+  "tools_scene_tagger_subtitle": "Скрапинг страниц текущих сцен с помощью Stash-box.",
+  "common_stats": "Статистика",
+  "image_filter_saved_to_server": "Фильтр изображений сохранен на сервере",
+  "studio_filter_saved_to_server": "Фильтр Studio сохранен на сервере.",
+  "gallery_filter_saved_to_server": "Фильтр галереи сохранен на сервере.",
+  "performer_filter_saved_to_server": "Фильтр исполнителей сохранен на сервере",
+  "tag_filter_saved_to_server": "Фильтр тегов сохранен на сервере.",
+  "mini_player_now_playing": "Сейчас играет: {displayTitle}. Нажмите, чтобы открыть сведения о сцене.",
+  "server_profile_drawer_attempting_login": "Попытка входа...",
+  "server_profile_drawer_error_login_failed": "Ошибка: Не удалось войти. Проверьте учетные данные.",
+  "server_profile_drawer_error": "Ошибка: {error}.",
+  "server_profile_drawer_url_is_required": "URL-адрес необязателен.",
+  "scene_filter_saved_to_server": "Фильтр сцен сохранен на сервере."
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1051,5 +1051,17 @@
   "settings_security_subtitle": "应用锁和密码设置",
   "tools_section_subtitle": "场景的维护和元数据工作流。",
   "tools_scene_deduplication_subtitle": "查找并管理重复的场景。",
-  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削当前场景页面。"
+  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削当前场景页面。",
+  "common_stats": "统计数据",
+  "image_filter_saved_to_server": "图像过滤器保存到服务器",
+  "studio_filter_saved_to_server": "工作室过滤器保存到服务器",
+  "gallery_filter_saved_to_server": "图库过滤器保存到服务器",
+  "performer_filter_saved_to_server": "表演者过滤器保存到服务器",
+  "tag_filter_saved_to_server": "标签过滤器保存到服务器",
+  "mini_player_now_playing": "正在播放：{displayTitle}。点击可打开场景详细信息。",
+  "server_profile_drawer_attempting_login": "正在尝试登录...",
+  "server_profile_drawer_error_login_failed": "错误：登录失败。检查凭据。",
+  "server_profile_drawer_error": "错误：{error}",
+  "server_profile_drawer_url_is_required": "网址为必填项",
+  "scene_filter_saved_to_server": "场景滤镜保存到服务器"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1037,5 +1037,17 @@
   "settings_security_subtitle": "应用锁和密码设置",
   "tools_section_subtitle": "场景的维护和元数据工作流。",
   "tools_scene_deduplication_subtitle": "查找并管理重复场景。",
-  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削当前场景页面。"
+  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削当前场景页面。",
+  "common_stats": "统计数据",
+  "image_filter_saved_to_server": "图像过滤器保存到服务器",
+  "studio_filter_saved_to_server": "工作室过滤器保存到服务器",
+  "gallery_filter_saved_to_server": "图库过滤器保存到服务器",
+  "performer_filter_saved_to_server": "表演者过滤器保存到服务器",
+  "tag_filter_saved_to_server": "标签过滤器保存到服务器",
+  "mini_player_now_playing": "正在播放：{displayTitle}。点击可打开场景详细信息。",
+  "server_profile_drawer_attempting_login": "正在尝试登录...",
+  "server_profile_drawer_error_login_failed": "错误：登录失败。检查凭据。",
+  "server_profile_drawer_error": "错误：{error}",
+  "server_profile_drawer_url_is_required": "网址为必填项",
+  "scene_filter_saved_to_server": "场景滤镜保存到服务器"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1037,5 +1037,17 @@
   "settings_security_subtitle": "應用鎖和密碼設定",
   "tools_section_subtitle": "場景的維護和元數據工作流。",
   "tools_scene_deduplication_subtitle": "查找並管理重複的場景。",
-  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削當前場景頁面。"
+  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削當前場景頁面。",
+  "common_stats": "統計數據",
+  "image_filter_saved_to_server": "影像過濾器保存到伺服器",
+  "studio_filter_saved_to_server": "工作室過濾器保存到伺服器",
+  "gallery_filter_saved_to_server": "圖庫過濾器保存到伺服器",
+  "performer_filter_saved_to_server": "表演者過濾器儲存到伺服器",
+  "tag_filter_saved_to_server": "標籤過濾器儲存到伺服器",
+  "mini_player_now_playing": "正在播放：{displayTitle}。點擊可開啟場景詳細資訊。",
+  "server_profile_drawer_attempting_login": "正在嘗試登入...",
+  "server_profile_drawer_error_login_failed": "錯誤：登入失敗。檢查憑證。",
+  "server_profile_drawer_error": "錯誤：{error}",
+  "server_profile_drawer_url_is_required": "網址為必填項",
+  "scene_filter_saved_to_server": "場景濾鏡儲存到伺服器"
 }


### PR DESCRIPTION
## What
Scanned the project for hardcoded strings and replaced them with localization keys.

## Why
To support localization in the UI and ensure no strings are hardcoded in English, complying with localization guidelines.

## Before/After
Several components previously displayed raw English strings (like 'Stats', 'Now playing', and error messages). They now use `context.l10n.<key>`.

## Accessibility
No direct accessibility improvements, but ensures assistive tools can read localized text.

---
*PR created automatically by Jules for task [10214745237763783569](https://jules.google.com/task/10214745237763783569) started by @Alchemist-Aloha*