### PR TITLE
⚡ Bolt: Throttle pagination API calls during rapid scrolling

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,6 @@
 ## 2024-05-30 - [Hoist textTheme and dimensions from ListView itemBuilder]
 **Learning:** Performing invariant lookups like `context.textTheme` and `context.dimensions.fontSizeFactor` inside a `ListView.builder`'s `itemBuilder` callback forces redundant O(1) inherited widget lookups on every single rendered item during scroll.
 **Action:** Always hoist these layout and styling variables out of the `itemBuilder` and into the parent widget's `build` (or builder) method to reduce GC pressure and ensure optimal rendering performance.
+## 2026-06-19 - [Throttling ScrollNotification API calls]
+**Learning:** The `NotificationListener<ScrollNotification>` inside `ListPageScaffold` triggers rapidly on every single frame during scrolling. This could lead to multiple simultaneous pagination requests being fired when the user scrolls near the end of the list.
+**Action:** Throttle the `onFetchNextPage` callback inside `NotificationListener` by storing a `_lastFetchTime` and comparing it against `DateTime.now()` with a 500ms threshold to prevent redundant network requests.

--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -169,6 +169,8 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
   DateTime? _lastHorizontalSwipeTime;
   static const _horizontalSwipeThreshold = Duration(milliseconds: 500);
 
+  DateTime? _lastFetchTime;
+
   @override
   void initState() {
     super.initState();
@@ -756,7 +758,15 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                       return NotificationListener<ScrollNotification>(
                         onNotification: (ScrollNotification scrollInfo) {
                           if (shouldLoadNextPage(scrollInfo.metrics)) {
-                            widget.onFetchNextPage?.call();
+                            // ⚡ Bolt: Throttle pagination fetch calls during rapid scrolling.
+                            // Why: scrollInfo metrics trigger continuously at the end of the list.
+                            // Impact: Prevents firing multiple simultaneous network requests.
+                            final now = DateTime.now();
+                            if (_lastFetchTime == null ||
+                                now.difference(_lastFetchTime!) > const Duration(milliseconds: 500)) {
+                              _lastFetchTime = now;
+                              widget.onFetchNextPage?.call();
+                            }
                           }
                           return false;
                         },


### PR DESCRIPTION
💡 What: Throttles the `onFetchNextPage` callback triggered by `NotificationListener<ScrollNotification>` inside `ListPageScaffold` using a 500ms `DateTime` check.
🎯 Why: `NotificationListener` triggers rapidly on every single frame during scrolling. When the user hits the bottom threshold of a long list or grid, it can cause multiple simultaneous network requests for the next page to fire before the first request finishes, placing excessive load on the UI thread and the server.
📊 Impact: Prevents redundant pagination API calls, reducing network traffic and avoiding UI thread stutter during deep infinite scrolling. 
🔬 Measurement: Observe network traffic while rapidly scrolling to the bottom of the Scenes or Galleries page. The fetch request will only fire at most once every 500ms.

---
*PR created automatically by Jules for task [5931003881803855569](https://jules.google.com/task/5931003881803855569) started by @Alchemist-Aloha*