### PR TITLE
⚡ Bolt: Throttle pagination data fetch in ListPageScaffold

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,6 @@
 ## 2024-05-30 - [Hoist textTheme and dimensions from ListView itemBuilder]
 **Learning:** Performing invariant lookups like `context.textTheme` and `context.dimensions.fontSizeFactor` inside a `ListView.builder`'s `itemBuilder` callback forces redundant O(1) inherited widget lookups on every single rendered item during scroll.
 **Action:** Always hoist these layout and styling variables out of the `itemBuilder` and into the parent widget's `build` (or builder) method to reduce GC pressure and ensure optimal rendering performance.
+## 2024-05-18 - Throttle Data Fetch in ScrollNotification
+**Learning:** `NotificationListener<ScrollNotification>` fires rapidly on every single frame during scrolling. Without throttling, `shouldLoadNextPage` evaluates to true multiple times, causing `onFetchNextPage` to trigger redundant data fetch operations, which creates significant performance and network overhead.
+**Action:** Always capture a `DateTime? _lastFetchTime;` within the state of the scrollable widget and apply a throttle (e.g. `const Duration(milliseconds: 500)`) before executing the fetch operation (`if (_lastFetchTime == null || now.difference(_lastFetchTime!) > _fetchThrottle)`).

--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -169,6 +169,9 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
   DateTime? _lastHorizontalSwipeTime;
   static const _horizontalSwipeThreshold = Duration(milliseconds: 500);
 
+  DateTime? _lastFetchTime;
+  static const _fetchThrottle = Duration(milliseconds: 500);
+
   @override
   void initState() {
     super.initState();
@@ -756,7 +759,13 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                       return NotificationListener<ScrollNotification>(
                         onNotification: (ScrollNotification scrollInfo) {
                           if (shouldLoadNextPage(scrollInfo.metrics)) {
-                            widget.onFetchNextPage?.call();
+                            final now = DateTime.now();
+                            if (_lastFetchTime == null ||
+                                now.difference(_lastFetchTime!) >
+                                    _fetchThrottle) {
+                              _lastFetchTime = now;
+                              widget.onFetchNextPage?.call();
+                            }
                           }
                           return false;
                         },


### PR DESCRIPTION
💡 What: Added a 500ms throttle to the onFetchNextPage callback inside the NotificationListener of ListPageScaffold.
🎯 Why: The ScrollNotification fires on every frame during scrolling. When reaching the end of the list, shouldLoadNextPage evaluates to true repeatedly, causing redundant pagination fetches that overload the network and degrade scroll performance.
📊 Impact: Eliminates redundant O(N) fetch calls during rapid scrolling, significantly reducing GC pressure and preventing UI stutter.
🔬 Measurement: Run the app and scroll rapidly through a paginated list; observe network requests or console logs to verify that pagination fetches are throttled.

---
*PR created automatically by Jules for task [10542026604926738281](https://jules.google.com/task/10542026604926738281) started by @Alchemist-Aloha*