### PR TITLE
🎨 Palette: Improve checkbox tap target accessibility in scrape dialog

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Add SemanticsLabel to CircularProgressIndicator
 **Learning:** In Flutter, `CircularProgressIndicator` doesn't automatically announce itself to screen readers. Relying solely on the visual indicator excludes visually impaired users. By providing a `semanticsLabel`, screen readers can correctly announce the loading state.
 **Action:** Always add a localized `semanticsLabel` to `CircularProgressIndicator` instances. Remember that doing so requires dynamic context access, so you'll need to remove `const` modifiers from parent widgets where necessary.
+## 2024-05-15 - Improve checkbox tap target accessibility
+**Learning:** Combining a `Checkbox` and `Text` widget inside a `Row` creates tiny tap targets that are hard to hit on mobile screens and often lack proper semantic association for screen readers.
+**Action:** Always prefer using `CheckboxListTile` (or `SwitchListTile.adaptive` for toggles) instead. This natively associates the label with the input, expands the tap area to the full row, and significantly improves both usability and accessibility.

--- a/lib/features/scenes/presentation/widgets/scrape_query_dialog.dart
+++ b/lib/features/scenes/presentation/widgets/scrape_query_dialog.dart
@@ -136,18 +136,16 @@ class _ScrapeQueryDialogState extends ConsumerState<ScrapeQueryDialog> {
             ),
             if (widget.entityType == ScrapeEntityType.scene) ...[
               const SizedBox(height: 16),
-              Row(
-                children: [
-                  Checkbox(
-                    value: _useFingerprints,
-                    onChanged: (val) {
-                      setState(() {
-                        _useFingerprints = val ?? false;
-                      });
-                    },
-                  ),
-                  Text(context.l10n.details_scene_fingerprint_query),
-                ],
+              CheckboxListTile.adaptive(
+                contentPadding: EdgeInsets.zero,
+                controlAffinity: ListTileControlAffinity.leading,
+                title: Text(context.l10n.details_scene_fingerprint_query),
+                value: _useFingerprints,
+                onChanged: (val) {
+                  setState(() {
+                    _useFingerprints = val ?? false;
+                  });
+                },
               ),
             ],
             const SizedBox(height: 16),
@@ -177,8 +175,8 @@ class _ScrapeQueryDialogState extends ConsumerState<ScrapeQueryDialog> {
                       .toList(),
                 ),
                 loading: () => const Center(child: CircularProgressIndicator()),
-                error:
-                    (err, _) => Text(context.l10n.common_error(err.toString())),
+                error: (err, _) =>
+                    Text(context.l10n.common_error(err.toString())),
               ),
             ),
             RadioGroup<String>(
@@ -204,8 +202,8 @@ class _ScrapeQueryDialogState extends ConsumerState<ScrapeQueryDialog> {
                   );
                 },
                 loading: () => const Center(child: CircularProgressIndicator()),
-                error:
-                    (err, _) => Text(context.l10n.common_error(err.toString())),
+                error: (err, _) =>
+                    Text(context.l10n.common_error(err.toString())),
               ),
             ),
           ],


### PR DESCRIPTION
**What**: Replaced a `Row` containing a `Checkbox` and `Text` widget with a native `CheckboxListTile.adaptive` inside `lib/features/scenes/presentation/widgets/scrape_query_dialog.dart`.
**Why**: A `Row` enclosing a `Checkbox` provides a tiny touch target strictly over the checkbox itself. This leads to frustrating touch experiences on mobile.
**Impact**: Using `CheckboxListTile` automatically expands the tap area across the entire row and creates a proper semantic association between the checkbox and its text label for screen readers.
**Measurement**: Verified via manual inspection of code layout parameters and `git diff` that no visual regression was introduced while touch target bounds were significantly increased.

---
*PR created automatically by Jules for task [18012138753339281284](https://jules.google.com/task/18012138753339281284) started by @Alchemist-Aloha*