### PR TITLE
⚡ Bolt: Throttle pagination data fetch on scroll

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,6 @@
 ## 2024-05-30 - [Hoist textTheme and dimensions from ListView itemBuilder]
 **Learning:** Performing invariant lookups like `context.textTheme` and `context.dimensions.fontSizeFactor` inside a `ListView.builder`'s `itemBuilder` callback forces redundant O(1) inherited widget lookups on every single rendered item during scroll.
 **Action:** Always hoist these layout and styling variables out of the `itemBuilder` and into the parent widget's `build` (or builder) method to reduce GC pressure and ensure optimal rendering performance.
+## 2024-05-14 - Throttle rapid scroll events for pagination
+**Learning:** `NotificationListener<ScrollNotification>` fires incredibly rapidly. When checking `metrics.pixels >= maxScrollExtent - threshold` (like our `shouldLoadNextPage` function), a single scroll gesture near the bottom can trigger the `onFetchNextPage` callback dozens of times before the state has a chance to update or debounce it, leading to massive redundant API calls.
+**Action:** Always throttle pagination data fetches hooked to raw scroll notifications (e.g., using a `DateTime` comparison to limit executions to once per ~500ms) to prevent UI thread lockup and backend spam.

--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -169,6 +169,9 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
   DateTime? _lastHorizontalSwipeTime;
   static const _horizontalSwipeThreshold = Duration(milliseconds: 500);
 
+  DateTime? _lastFetchNextPageTime;
+  static const _fetchNextPageThrottle = Duration(milliseconds: 500);
+
   @override
   void initState() {
     super.initState();
@@ -756,7 +759,13 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                       return NotificationListener<ScrollNotification>(
                         onNotification: (ScrollNotification scrollInfo) {
                           if (shouldLoadNextPage(scrollInfo.metrics)) {
-                            widget.onFetchNextPage?.call();
+                            final now = DateTime.now();
+                            if (_lastFetchNextPageTime == null ||
+                                now.difference(_lastFetchNextPageTime!) >
+                                    _fetchNextPageThrottle) {
+                              _lastFetchNextPageTime = now;
+                              widget.onFetchNextPage?.call();
+                            }
                           }
                           return false;
                         },


### PR DESCRIPTION
💡 What: Added throttling to `onFetchNextPage` callback in `ListPageScaffold` using `NotificationListener<ScrollNotification>`.
🎯 Why: Prevent redundant, expensive pagination API calls when scroll events rapidly hit the end threshold.
📊 Impact: Significantly reduces network requests and backend load during rapid scrolling, preventing duplicate requests for the same next page.
🔬 Measurement: Check network tab or logs to confirm only one fetch request occurs when hitting the bottom threshold.

---
*PR created automatically by Jules for task [4645366353620487121](https://jules.google.com/task/4645366353620487121) started by @Alchemist-Aloha*