### PR TITLE
⚡ Bolt: Throttle pagination data fetches in ListPageScaffold

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,6 @@
 ## 2024-05-30 - [Hoist textTheme and dimensions from ListView itemBuilder]
 **Learning:** Performing invariant lookups like `context.textTheme` and `context.dimensions.fontSizeFactor` inside a `ListView.builder`'s `itemBuilder` callback forces redundant O(1) inherited widget lookups on every single rendered item during scroll.
 **Action:** Always hoist these layout and styling variables out of the `itemBuilder` and into the parent widget's `build` (or builder) method to reduce GC pressure and ensure optimal rendering performance.
+## 2024-05-18 - Throttle Pagination Data Fetches
+**Learning:** `NotificationListener<ScrollNotification>` fires rapidly on every single frame during scrolling. Without throttling, functions like `widget.onFetchNextPage?.call()` triggered inside the `onNotification` callback can be executed redundantly, causing excessive API or database calls in rapid succession.
+**Action:** Always wrap pagination or heavy data-fetching callbacks inside a `NotificationListener<ScrollNotification>` with a time-based throttle check (e.g., using `DateTime.now().difference(_lastFetchTime) > threshold`) to ensure the operation is only triggered once within the defined window.

--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -169,6 +169,9 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
   DateTime? _lastHorizontalSwipeTime;
   static const _horizontalSwipeThreshold = Duration(milliseconds: 500);
 
+  DateTime? _lastFetchNextPageTime;
+  static const _fetchNextPageThreshold = Duration(milliseconds: 500);
+
   @override
   void initState() {
     super.initState();
@@ -756,7 +759,13 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                       return NotificationListener<ScrollNotification>(
                         onNotification: (ScrollNotification scrollInfo) {
                           if (shouldLoadNextPage(scrollInfo.metrics)) {
-                            widget.onFetchNextPage?.call();
+                            final now = DateTime.now();
+                            if (_lastFetchNextPageTime == null ||
+                                now.difference(_lastFetchNextPageTime!) >
+                                    _fetchNextPageThreshold) {
+                              _lastFetchNextPageTime = now;
+                              widget.onFetchNextPage?.call();
+                            }
                           }
                           return false;
                         },


### PR DESCRIPTION
**💡 What:** Implemented a 500ms time-based throttle for pagination requests triggered by scrolling in `ListPageScaffold`.
**🎯 Why:** `NotificationListener<ScrollNotification>` fires on every frame during a scroll. When the user hits the bottom threshold, `shouldLoadNextPage` evaluates to true repeatedly, causing the app to spam redundant pagination requests before the new data has time to load and update the scroll metrics.
**📊 Impact:** Prevents multiple redundant network or database calls, improving backend/database efficiency and reducing potential jank on the UI thread during list pagination.
**🔬 Measurement:** Observe network traffic or database query logs while aggressively scrolling to the bottom of any long list (e.g., scenes, galleries). Previously, multiple requests might fire within milliseconds; now, requests are strictly separated by at least 500ms.

---
*PR created automatically by Jules for task [11416765271236999212](https://jules.google.com/task/11416765271236999212) started by @Alchemist-Aloha*