### PR TITLE
🎨 Palette: Add tooltip to Delete Profile button

### DIFF
--- a/lib/features/setup/presentation/widgets/server_profile_drawer.dart
+++ b/lib/features/setup/presentation/widgets/server_profile_drawer.dart
@@ -364,6 +364,7 @@ class _ServerProfileDrawerState extends ConsumerState<ServerProfileDrawer> {
                   children: [
                     if (widget.profile != null)
                       IconButton(
+                        tooltip: l10n.settings_server_profile_delete,
                         onPressed: _delete,
                         icon: Icon(
                           Icons.delete_outline,


### PR DESCRIPTION
💡 What: Added a tooltip to the Delete Profile icon button in the server profile drawer.
🎯 Why: An icon-only button without a tooltip or ARIA equivalent can be difficult for some users to understand. This improves accessibility.
📸 Before/After: Before, no tooltip was shown on hover/long press. Now, it shows 'Delete Profile'.
♿ Accessibility: The tooltip acts as a semantic label for screen readers.

---
*PR created automatically by Jules for task [15117010920820950809](https://jules.google.com/task/15117010920820950809) started by @Alchemist-Aloha*