### PR TITLE
🌐 L10n: Extract hardcoded strings and translate

### DIFF
--- a/lib/core/presentation/widgets/stats_floating_panel.dart
+++ b/lib/core/presentation/widgets/stats_floating_panel.dart
@@ -295,7 +295,7 @@ class StatsFloatingPanel extends ConsumerWidget {
             icon: Icons.play_lesson_rounded,
             label: l10n.stats_total_plays,
             value: '000',
-            subtitle: '0 unique items',
+            subtitle: context.l10n.stats_unique_items(0),
           ),
           _StatItem(
             icon: Icons.favorite_rounded,

--- a/lib/features/navigation/presentation/widgets/mini_player.dart
+++ b/lib/features/navigation/presentation/widgets/mini_player.dart
@@ -32,7 +32,7 @@ class MiniPlayer extends ConsumerWidget {
 
     return Semantics(
       button: true,
-      label: 'Now playing: $displayTitle. Tap to open scene details.',
+      label: context.l10n.mini_player_now_playing(displayTitle),
       child: Container(
         height: 66, // Increased height by 10% (from 60)
         decoration: BoxDecoration(

--- a/lib/features/scenes/presentation/pages/scene_tagger_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_tagger_page.dart
@@ -790,7 +790,7 @@ class _TaggerSceneCard extends StatelessWidget {
                   sceneId: scene.id,
                   scraped: scraped,
                   error: result?.error,
-                  title: 'Scraped metadata',
+                  title: context.l10n.scene_tagger_scraped_metadata,
                 ),
               ),
             ],
@@ -808,7 +808,7 @@ class _TaggerSceneCard extends StatelessWidget {
                 sceneId: scene.id,
                 scraped: scraped,
                 error: result?.error,
-                title: 'Scraped metadata',
+                title: context.l10n.scene_tagger_scraped_metadata,
               ),
             ],
           );
@@ -899,7 +899,7 @@ class _LocalSceneSummary extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return _MetadataPanel(
-      title: 'Local scene',
+      title: context.l10n.scene_tagger_local_scene,
       media: _ScenePreviewPlayer(
         key: ValueKey('scene_preview_player_${scene.id}'),
         scene: scene,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1072,5 +1072,8 @@
   "settings_security_subtitle": "App-Sperre und Passcode-Einstellungen",
   "tools_section_subtitle": "Wartungs- und Metadaten-Workflows für Szenen.",
   "tools_scene_deduplication_subtitle": "Duplikate finden und verwalten.",
-  "tools_scene_tagger_subtitle": "Aktuelle Szenenseiten mit Stash-box scrapen."
+  "tools_scene_tagger_subtitle": "Aktuelle Szenenseiten mit Stash-box scrapen.",
+  "scene_tagger_scraped_metadata": "Gekratzte Metadaten",
+  "scene_tagger_local_scene": "Lokale Szene",
+  "mini_player_now_playing": "Spielt gerade: {title}. Tippen Sie hier, um Szenendetails zu öffnen."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1360,7 +1360,7 @@
       }
     }
   },
-  "scene_tagger_checked_matches_summary": "{checked} checked • {matches} matches",
+  "scene_tagger_checked_matches_summary": "{checked} checked \u2022 {matches} matches",
   "@scene_tagger_checked_matches_summary": {
     "placeholders": {
       "checked": {
@@ -1400,5 +1400,15 @@
       }
     }
   },
-  "stats_library_stats_tooltip": "Long press for library stats"
+  "stats_library_stats_tooltip": "Long press for library stats",
+  "scene_tagger_scraped_metadata": "Scraped metadata",
+  "scene_tagger_local_scene": "Local scene",
+  "mini_player_now_playing": "Now playing: {title}. Tap to open scene details.",
+  "@mini_player_now_playing": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1051,5 +1051,8 @@
   "settings_security_subtitle": "Configuración de bloqueo de aplicación y contraseña",
   "tools_section_subtitle": "Flujos de trabajo de mantenimiento y metadatos para escenas.",
   "tools_scene_deduplication_subtitle": "Buscar y gestionar escenas duplicadas.",
-  "tools_scene_tagger_subtitle": "Extraer páginas de escenas actuales con Stash-box."
+  "tools_scene_tagger_subtitle": "Extraer páginas de escenas actuales con Stash-box.",
+  "scene_tagger_scraped_metadata": "Metadatos eliminados",
+  "scene_tagger_local_scene": "escena local",
+  "mini_player_now_playing": "En reproducción: {title}. Toque para abrir los detalles de la escena."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1051,5 +1051,8 @@
   "settings_security_subtitle": "Paramètres de verrouillage de l'application et du code",
   "tools_section_subtitle": "Flux de travail de maintenance et de métadonnées pour les scènes.",
   "tools_scene_deduplication_subtitle": "Rechercher et gérer les scènes en double.",
-  "tools_scene_tagger_subtitle": "Scraper les pages de scènes actuelles avec Stash-box."
+  "tools_scene_tagger_subtitle": "Scraper les pages de scènes actuelles avec Stash-box.",
+  "scene_tagger_scraped_metadata": "Métadonnées grattées",
+  "scene_tagger_local_scene": "Scène locale",
+  "mini_player_now_playing": "Lecture en cours : {title}. Appuyez pour ouvrir les détails de la scène."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1056,5 +1056,8 @@
   "settings_security_subtitle": "Impostazioni del blocco dell'applicazione e del passcode",
   "tools_section_subtitle": "Flussi di lavoro di manutenzione e metadati per le scene.",
   "tools_scene_deduplication_subtitle": "Trova e gestisci le scene duplicate.",
-  "tools_scene_tagger_subtitle": "Scrape delle pagine delle scene correnti con Stash-box."
+  "tools_scene_tagger_subtitle": "Scrape delle pagine delle scene correnti con Stash-box.",
+  "scene_tagger_scraped_metadata": "Metadati raschiati",
+  "scene_tagger_local_scene": "Scena locale",
+  "mini_player_now_playing": "Ora in riproduzione: {title}. Tocca per aprire i dettagli della scena."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1051,5 +1051,8 @@
   "settings_security_subtitle": "アプリロックとパスコードの設定",
   "tools_section_subtitle": "シーンのメンテナンスとメタデータのワークフロー。",
   "tools_scene_deduplication_subtitle": "重複するシーンを見つけて管理します。",
-  "tools_scene_tagger_subtitle": "Stash-boxを使用して現在のシーンページをスクレイピングします。"
+  "tools_scene_tagger_subtitle": "Stash-boxを使用して現在のシーンページをスクレイピングします。",
+  "scene_tagger_scraped_metadata": "スクレイピングされたメタデータ",
+  "scene_tagger_local_scene": "現地の様子",
+  "mini_player_now_playing": "現在再生中: {title}。タップしてシーンの詳細を開きます。"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1051,5 +1051,8 @@
   "settings_security_subtitle": "앱 잠금 및 비밀번호 설정",
   "tools_section_subtitle": "씬에 대한 유지 관리 및 메타데이터 워크플로.",
   "tools_scene_deduplication_subtitle": "중복된 씬을 찾아 관리합니다.",
-  "tools_scene_tagger_subtitle": "Stash-box로 현재 씬 페이지를 스크랩합니다."
+  "tools_scene_tagger_subtitle": "Stash-box로 현재 씬 페이지를 스크랩합니다.",
+  "scene_tagger_scraped_metadata": "스크랩된 메타데이터",
+  "scene_tagger_local_scene": "지역 현장",
+  "mini_player_now_playing": "현재 플레이 중: {title}. 장면 세부정보를 열려면 탭하세요."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5429,6 +5429,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Long press for library stats'**
   String get stats_library_stats_tooltip;
+
+  /// No description provided for @scene_tagger_scraped_metadata.
+  ///
+  /// In en, this message translates to:
+  /// **'Scraped metadata'**
+  String get scene_tagger_scraped_metadata;
+
+  /// No description provided for @scene_tagger_local_scene.
+  ///
+  /// In en, this message translates to:
+  /// **'Local scene'**
+  String get scene_tagger_local_scene;
+
+  /// No description provided for @mini_player_now_playing.
+  ///
+  /// In en, this message translates to:
+  /// **'Now playing: {title}. Tap to open scene details.'**
+  String mini_player_now_playing(String title);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3053,4 +3053,15 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Lange drücken für Bibliotheksstatistiken';
+
+  @override
+  String get scene_tagger_scraped_metadata => 'Gekratzte Metadaten';
+
+  @override
+  String get scene_tagger_local_scene => 'Lokale Szene';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return 'Spielt gerade: $title. Tippen Sie hier, um Szenendetails zu öffnen.';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3007,4 +3007,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get stats_library_stats_tooltip => 'Long press for library stats';
+
+  @override
+  String get scene_tagger_scraped_metadata => 'Scraped metadata';
+
+  @override
+  String get scene_tagger_local_scene => 'Local scene';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return 'Now playing: $title. Tap to open scene details.';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3080,4 +3080,15 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Mantén pulsado para ver las estadísticas de la biblioteca';
+
+  @override
+  String get scene_tagger_scraped_metadata => 'Metadatos eliminados';
+
+  @override
+  String get scene_tagger_local_scene => 'escena local';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return 'En reproducción: $title. Toque para abrir los detalles de la escena.';
+  }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3072,4 +3072,15 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Appui long pour les statistiques de la bibliothèque';
+
+  @override
+  String get scene_tagger_scraped_metadata => 'Métadonnées grattées';
+
+  @override
+  String get scene_tagger_local_scene => 'Scène locale';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return 'Lecture en cours : $title. Appuyez pour ouvrir les détails de la scène.';
+  }
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3071,4 +3071,15 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Tieni premuto per le statistiche della libreria';
+
+  @override
+  String get scene_tagger_scraped_metadata => 'Metadati raschiati';
+
+  @override
+  String get scene_tagger_local_scene => 'Scena locale';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return 'Ora in riproduzione: $title. Tocca per aprire i dettagli della scena.';
+  }
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2951,4 +2951,15 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get stats_library_stats_tooltip => '長押しでライブラリ統計を表示';
+
+  @override
+  String get scene_tagger_scraped_metadata => 'スクレイピングされたメタデータ';
+
+  @override
+  String get scene_tagger_local_scene => '現地の様子';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return '現在再生中: $title。タップしてシーンの詳細を開きます。';
+  }
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2949,4 +2949,15 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get stats_library_stats_tooltip => '길게 눌러 라이브러리 통계 보기';
+
+  @override
+  String get scene_tagger_scraped_metadata => '스크랩된 메타데이터';
+
+  @override
+  String get scene_tagger_local_scene => '지역 현장';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return '현재 플레이 중: $title. 장면 세부정보를 열려면 탭하세요.';
+  }
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3048,4 +3048,15 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Удерживайте для статистики библиотеки';
+
+  @override
+  String get scene_tagger_scraped_metadata => 'Удаленные метаданные';
+
+  @override
+  String get scene_tagger_local_scene => 'Местная сцена';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return 'Сейчас воспроизводится: $title. Нажмите, чтобы открыть сведения о сцене.';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2895,6 +2895,17 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get stats_library_stats_tooltip => '长按查看资料库统计';
+
+  @override
+  String get scene_tagger_scraped_metadata => '抓取的元数据';
+
+  @override
+  String get scene_tagger_local_scene => '当地场景';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return '正在播放：$title。点击可打开场景详细信息。';
+  }
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -5787,6 +5798,17 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get stats_library_stats_tooltip => '长按查看资料库统计';
+
+  @override
+  String get scene_tagger_scraped_metadata => '抓取的元数据';
+
+  @override
+  String get scene_tagger_local_scene => '当地场景';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return '正在播放：$title。点击可打开场景详细信息。';
+  }
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -8683,4 +8705,15 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get stats_library_stats_tooltip => '長按查看資料庫統計';
+
+  @override
+  String get scene_tagger_scraped_metadata => '抓取的元數據';
+
+  @override
+  String get scene_tagger_local_scene => '當地場景';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return '正在播放：$title。點擊可開啟場景詳細資訊。';
+  }
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1051,5 +1051,8 @@
   "settings_security_subtitle": "Настройки блокировки приложения и пароля",
   "tools_section_subtitle": "Рабочие процессы обслуживания и метаданных для сцен.",
   "tools_scene_deduplication_subtitle": "Поиск и управление дубликатами сцен.",
-  "tools_scene_tagger_subtitle": "Скрапинг страниц текущих сцен с помощью Stash-box."
+  "tools_scene_tagger_subtitle": "Скрапинг страниц текущих сцен с помощью Stash-box.",
+  "scene_tagger_scraped_metadata": "Удаленные метаданные",
+  "scene_tagger_local_scene": "Местная сцена",
+  "mini_player_now_playing": "Сейчас воспроизводится: {title}. Нажмите, чтобы открыть сведения о сцене."
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1051,5 +1051,8 @@
   "settings_security_subtitle": "应用锁和密码设置",
   "tools_section_subtitle": "场景的维护和元数据工作流。",
   "tools_scene_deduplication_subtitle": "查找并管理重复的场景。",
-  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削当前场景页面。"
+  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削当前场景页面。",
+  "scene_tagger_scraped_metadata": "抓取的元数据",
+  "scene_tagger_local_scene": "当地场景",
+  "mini_player_now_playing": "正在播放：{title}。点击可打开场景详细信息。"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1037,5 +1037,8 @@
   "settings_security_subtitle": "应用锁和密码设置",
   "tools_section_subtitle": "场景的维护和元数据工作流。",
   "tools_scene_deduplication_subtitle": "查找并管理重复场景。",
-  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削当前场景页面。"
+  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削当前场景页面。",
+  "scene_tagger_scraped_metadata": "抓取的元数据",
+  "scene_tagger_local_scene": "当地场景",
+  "mini_player_now_playing": "正在播放：{title}。点击可打开场景详细信息。"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1037,5 +1037,8 @@
   "settings_security_subtitle": "應用鎖和密碼設定",
   "tools_section_subtitle": "場景的維護和元數據工作流。",
   "tools_scene_deduplication_subtitle": "查找並管理重複的場景。",
-  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削當前場景頁面。"
+  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削當前場景頁面。",
+  "scene_tagger_scraped_metadata": "抓取的元數據",
+  "scene_tagger_local_scene": "當地場景",
+  "mini_player_now_playing": "正在播放：{title}。點擊可開啟場景詳細資訊。"
 }


### PR DESCRIPTION
What: Extracted hardcoded strings 'Scraped metadata', 'Local scene', and 'Now playing...' to l10n keys. Translated the new keys for all supported locales.
Why: To provide a fully localized experience for international users and remove hardcoded English strings from the UI.
Impact: Users will now see these specific texts in their native language based on their locale.
Measurement: Verified translations are generated and available in the .arb files and UI widgets.

---
*PR created automatically by Jules for task [15319835150745627598](https://jules.google.com/task/15319835150745627598) started by @Alchemist-Aloha*