### PR TITLE
🌐 Localization: Extract hardcoded marker strings to ARB

### DIFF
--- a/lib/features/scenes/presentation/pages/scene_details_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_details_page.dart
@@ -308,12 +308,12 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
       if (mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showSnackBar(const SnackBar(content: Text('Marker created')));
+        ).showSnackBar(SnackBar(content: Text(context.l10n.scene_details_marker_created)));
       }
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to create marker: ${e.toString()}')),
+          SnackBar(content: Text(context.l10n.scene_details_failed_to_create_marker(e.toString()))),
         );
       }
     }
@@ -328,8 +328,8 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
       builder: (dialogContext) {
         return AlertDialog(
           icon: Icon(Icons.delete_outline, color: dialogContext.colors.error),
-          title: const Text('Delete marker'),
-          content: Text('Delete marker "${marker.title}"?'),
+          title: Text(context.l10n.scene_details_delete_marker_title),
+          content: Text(context.l10n.scene_details_delete_marker_content(marker.title)),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(dialogContext).pop(false),
@@ -358,12 +358,12 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
       if (mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showSnackBar(const SnackBar(content: Text('Marker deleted')));
+        ).showSnackBar(SnackBar(content: Text(context.l10n.scene_details_marker_deleted)));
       }
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to delete marker: ${e.toString()}')),
+          SnackBar(content: Text(context.l10n.scene_details_failed_to_delete_marker(e.toString()))),
         );
       }
     }
@@ -910,7 +910,7 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
           children: [
             IconButton(
               key: const Key('scene_action_add_marker'),
-              tooltip: 'Add marker',
+              tooltip: context.l10n.scene_details_add_marker,
               icon: const Icon(Icons.bookmark_add_outlined),
               onPressed: () => _showAddMarkerDialog(
                 scene,
@@ -1177,7 +1177,7 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
           ),
         ),
         IconButton(
-          tooltip: 'Delete marker ${marker.title}',
+          tooltip: context.l10n.scene_details_delete_marker_tooltip(marker.title),
           icon: const Icon(Icons.delete_outline),
           color: context.colors.error,
           onPressed: () =>
@@ -1394,7 +1394,7 @@ class _AddMarkerDialogState extends State<_AddMarkerDialog> {
   Widget build(BuildContext context) {
     return AlertDialog(
       icon: const Icon(Icons.bookmark_add_outlined),
-      title: const Text('Add marker'),
+      title: Text(context.l10n.scene_details_add_marker),
       content: TextField(
         controller: _controller,
         autofocus: true,
@@ -1407,7 +1407,7 @@ class _AddMarkerDialogState extends State<_AddMarkerDialog> {
           onPressed: () => Navigator.of(context).pop(),
           child: Text(widget.cancelLabel),
         ),
-        FilledButton(onPressed: _submit, child: const Text('Create')),
+        FilledButton(onPressed: _submit, child: Text(context.l10n.scene_details_create_marker)),
       ],
     );
   }

--- a/lib/features/scenes/presentation/pages/scenes_page.dart
+++ b/lib/features/scenes/presentation/pages/scenes_page.dart
@@ -512,7 +512,7 @@ class _ScenesPageState extends ConsumerState<ScenesPage> {
           onPressed: _showSavedFilterDialog,
         ),
         IconButton(
-          tooltip: 'Markers',
+          tooltip: context.l10n.scenes_page_markers_tooltip,
           icon: const Icon(Icons.sell_outlined),
           onPressed: () => context.push('/scenes/markers'),
         ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1072,5 +1072,15 @@
   "settings_security_subtitle": "App-Sperre und Passcode-Einstellungen",
   "tools_section_subtitle": "Wartungs- und Metadaten-Workflows für Szenen.",
   "tools_scene_deduplication_subtitle": "Duplikate finden und verwalten.",
-  "tools_scene_tagger_subtitle": "Aktuelle Szenenseiten mit Stash-box scrapen."
+  "tools_scene_tagger_subtitle": "Aktuelle Szenenseiten mit Stash-box scrapen.",
+  "scene_details_marker_created": "Markierung erstellt",
+  "scene_details_failed_to_create_marker": "Markierung konnte nicht erstellt werden: {error}",
+  "scene_details_delete_marker_title": "Markierungen löschen",
+  "scene_details_delete_marker_content": "Markierung „{title}“ löschen?",
+  "scene_details_marker_deleted": "Markierung gelöscht",
+  "scene_details_failed_to_delete_marker": "Markierung konnte nicht gelöscht werden: {error}",
+  "scene_details_add_marker": "Markierung hinzufügen",
+  "scene_details_create_marker": "Erstellen",
+  "scene_details_delete_marker_tooltip": "Markierung {title} löschen",
+  "scenes_page_markers_tooltip": "Markierungen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1360,7 +1360,7 @@
       }
     }
   },
-  "scene_tagger_checked_matches_summary": "{checked} checked • {matches} matches",
+  "scene_tagger_checked_matches_summary": "{checked} checked \u2022 {matches} matches",
   "@scene_tagger_checked_matches_summary": {
     "placeholders": {
       "checked": {
@@ -1400,5 +1400,43 @@
       }
     }
   },
-  "stats_library_stats_tooltip": "Long press for library stats"
+  "stats_library_stats_tooltip": "Long press for library stats",
+  "scene_details_marker_created": "Marker created",
+  "scene_details_failed_to_create_marker": "Failed to create marker: {error}",
+  "@scene_details_failed_to_create_marker": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "scene_details_delete_marker_title": "Delete marker",
+  "scene_details_delete_marker_content": "Delete marker \"{title}\"?",
+  "@scene_details_delete_marker_content": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "scene_details_marker_deleted": "Marker deleted",
+  "scene_details_failed_to_delete_marker": "Failed to delete marker: {error}",
+  "@scene_details_failed_to_delete_marker": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "scene_details_add_marker": "Add marker",
+  "scene_details_create_marker": "Create",
+  "scene_details_delete_marker_tooltip": "Delete marker {title}",
+  "@scene_details_delete_marker_tooltip": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "scenes_page_markers_tooltip": "Markers"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1051,5 +1051,15 @@
   "settings_security_subtitle": "Configuración de bloqueo de aplicación y contraseña",
   "tools_section_subtitle": "Flujos de trabajo de mantenimiento y metadatos para escenas.",
   "tools_scene_deduplication_subtitle": "Buscar y gestionar escenas duplicadas.",
-  "tools_scene_tagger_subtitle": "Extraer páginas de escenas actuales con Stash-box."
+  "tools_scene_tagger_subtitle": "Extraer páginas de escenas actuales con Stash-box.",
+  "scene_details_marker_created": "Marcador creado",
+  "scene_details_failed_to_create_marker": "No se pudo crear el marcador: {error}",
+  "scene_details_delete_marker_title": "Eliminar marcadores",
+  "scene_details_delete_marker_content": "¿Eliminar el marcador \"{title}\"?",
+  "scene_details_marker_deleted": "Marcador eliminado",
+  "scene_details_failed_to_delete_marker": "No se pudo eliminar el marcador: {error}",
+  "scene_details_add_marker": "Agregar marcador",
+  "scene_details_create_marker": "Crear",
+  "scene_details_delete_marker_tooltip": "Eliminar marcador {title}",
+  "scenes_page_markers_tooltip": "Marcadores"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1051,5 +1051,15 @@
   "settings_security_subtitle": "Paramètres de verrouillage de l'application et du code",
   "tools_section_subtitle": "Flux de travail de maintenance et de métadonnées pour les scènes.",
   "tools_scene_deduplication_subtitle": "Rechercher et gérer les scènes en double.",
-  "tools_scene_tagger_subtitle": "Scraper les pages de scènes actuelles avec Stash-box."
+  "tools_scene_tagger_subtitle": "Scraper les pages de scènes actuelles avec Stash-box.",
+  "scene_details_marker_created": "Marqueur créé",
+  "scene_details_failed_to_create_marker": "Échec de la création du marqueur : {error}",
+  "scene_details_delete_marker_title": "Supprimer des marqueurs",
+  "scene_details_delete_marker_content": "Supprimer le marqueur \"{title}\" ?",
+  "scene_details_marker_deleted": "Marqueur supprimé",
+  "scene_details_failed_to_delete_marker": "Échec de la suppression du marqueur : {error}",
+  "scene_details_add_marker": "Ajouter un marqueur",
+  "scene_details_create_marker": "Créer",
+  "scene_details_delete_marker_tooltip": "Supprimer le marqueur {title}",
+  "scenes_page_markers_tooltip": "Marqueurs"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1056,5 +1056,15 @@
   "settings_security_subtitle": "Impostazioni del blocco dell'applicazione e del passcode",
   "tools_section_subtitle": "Flussi di lavoro di manutenzione e metadati per le scene.",
   "tools_scene_deduplication_subtitle": "Trova e gestisci le scene duplicate.",
-  "tools_scene_tagger_subtitle": "Scrape delle pagine delle scene correnti con Stash-box."
+  "tools_scene_tagger_subtitle": "Scrape delle pagine delle scene correnti con Stash-box.",
+  "scene_details_marker_created": "Marcatore creato",
+  "scene_details_failed_to_create_marker": "Impossibile creare l'indicatore: {error}",
+  "scene_details_delete_marker_title": "Elimina marcatori",
+  "scene_details_delete_marker_content": "Eliminare l'indicatore \"{title}\"?",
+  "scene_details_marker_deleted": "Indicatore eliminato",
+  "scene_details_failed_to_delete_marker": "Impossibile eliminare l'indicatore: {error}",
+  "scene_details_add_marker": "Aggiungi marcatore",
+  "scene_details_create_marker": "Creare",
+  "scene_details_delete_marker_tooltip": "Elimina indicatore {title}",
+  "scenes_page_markers_tooltip": "Marcatori"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1051,5 +1051,15 @@
   "settings_security_subtitle": "アプリロックとパスコードの設定",
   "tools_section_subtitle": "シーンのメンテナンスとメタデータのワークフロー。",
   "tools_scene_deduplication_subtitle": "重複するシーンを見つけて管理します。",
-  "tools_scene_tagger_subtitle": "Stash-boxを使用して現在のシーンページをスクレイピングします。"
+  "tools_scene_tagger_subtitle": "Stash-boxを使用して現在のシーンページをスクレイピングします。",
+  "scene_details_marker_created": "マーカーが作成されました",
+  "scene_details_failed_to_create_marker": "マーカーの作成に失敗しました: {error}",
+  "scene_details_delete_marker_title": "マーカーの削除",
+  "scene_details_delete_marker_content": "マーカー「{title}」を削除しますか?",
+  "scene_details_marker_deleted": "マーカーが削除されました",
+  "scene_details_failed_to_delete_marker": "マーカーの削除に失敗しました: {error}",
+  "scene_details_add_marker": "マーカーを追加する",
+  "scene_details_create_marker": "作成する",
+  "scene_details_delete_marker_tooltip": "マーカー {title} を削除",
+  "scenes_page_markers_tooltip": "マーカー"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1051,5 +1051,15 @@
   "settings_security_subtitle": "앱 잠금 및 비밀번호 설정",
   "tools_section_subtitle": "씬에 대한 유지 관리 및 메타데이터 워크플로.",
   "tools_scene_deduplication_subtitle": "중복된 씬을 찾아 관리합니다.",
-  "tools_scene_tagger_subtitle": "Stash-box로 현재 씬 페이지를 스크랩합니다."
+  "tools_scene_tagger_subtitle": "Stash-box로 현재 씬 페이지를 스크랩합니다.",
+  "scene_details_marker_created": "마커가 생성되었습니다.",
+  "scene_details_failed_to_create_marker": "마커 생성 실패: {error}",
+  "scene_details_delete_marker_title": "마커 삭제",
+  "scene_details_delete_marker_content": "마커 '{title}'을 삭제하시겠습니까?",
+  "scene_details_marker_deleted": "마커가 삭제되었습니다.",
+  "scene_details_failed_to_delete_marker": "마커 삭제 실패: {error}",
+  "scene_details_add_marker": "마커 추가",
+  "scene_details_create_marker": "만들다",
+  "scene_details_delete_marker_tooltip": "마커 {title} 삭제",
+  "scenes_page_markers_tooltip": "마커"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5429,6 +5429,66 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Long press for library stats'**
   String get stats_library_stats_tooltip;
+
+  /// No description provided for @scene_details_marker_created.
+  ///
+  /// In en, this message translates to:
+  /// **'Marker created'**
+  String get scene_details_marker_created;
+
+  /// No description provided for @scene_details_failed_to_create_marker.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to create marker: {error}'**
+  String scene_details_failed_to_create_marker(String error);
+
+  /// No description provided for @scene_details_delete_marker_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete marker'**
+  String get scene_details_delete_marker_title;
+
+  /// No description provided for @scene_details_delete_marker_content.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete marker \"{title}\"?'**
+  String scene_details_delete_marker_content(String title);
+
+  /// No description provided for @scene_details_marker_deleted.
+  ///
+  /// In en, this message translates to:
+  /// **'Marker deleted'**
+  String get scene_details_marker_deleted;
+
+  /// No description provided for @scene_details_failed_to_delete_marker.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to delete marker: {error}'**
+  String scene_details_failed_to_delete_marker(String error);
+
+  /// No description provided for @scene_details_add_marker.
+  ///
+  /// In en, this message translates to:
+  /// **'Add marker'**
+  String get scene_details_add_marker;
+
+  /// No description provided for @scene_details_create_marker.
+  ///
+  /// In en, this message translates to:
+  /// **'Create'**
+  String get scene_details_create_marker;
+
+  /// No description provided for @scene_details_delete_marker_tooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete marker {title}'**
+  String scene_details_delete_marker_tooltip(String title);
+
+  /// No description provided for @scenes_page_markers_tooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Markers'**
+  String get scenes_page_markers_tooltip;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3053,4 +3053,42 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Lange drücken für Bibliotheksstatistiken';
+
+  @override
+  String get scene_details_marker_created => 'Markierung erstellt';
+
+  @override
+  String scene_details_failed_to_create_marker(String error) {
+    return 'Markierung konnte nicht erstellt werden: $error';
+  }
+
+  @override
+  String get scene_details_delete_marker_title => 'Markierungen löschen';
+
+  @override
+  String scene_details_delete_marker_content(String title) {
+    return 'Markierung „$title“ löschen?';
+  }
+
+  @override
+  String get scene_details_marker_deleted => 'Markierung gelöscht';
+
+  @override
+  String scene_details_failed_to_delete_marker(String error) {
+    return 'Markierung konnte nicht gelöscht werden: $error';
+  }
+
+  @override
+  String get scene_details_add_marker => 'Markierung hinzufügen';
+
+  @override
+  String get scene_details_create_marker => 'Erstellen';
+
+  @override
+  String scene_details_delete_marker_tooltip(String title) {
+    return 'Markierung $title löschen';
+  }
+
+  @override
+  String get scenes_page_markers_tooltip => 'Markierungen';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3007,4 +3007,42 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get stats_library_stats_tooltip => 'Long press for library stats';
+
+  @override
+  String get scene_details_marker_created => 'Marker created';
+
+  @override
+  String scene_details_failed_to_create_marker(String error) {
+    return 'Failed to create marker: $error';
+  }
+
+  @override
+  String get scene_details_delete_marker_title => 'Delete marker';
+
+  @override
+  String scene_details_delete_marker_content(String title) {
+    return 'Delete marker \"$title\"?';
+  }
+
+  @override
+  String get scene_details_marker_deleted => 'Marker deleted';
+
+  @override
+  String scene_details_failed_to_delete_marker(String error) {
+    return 'Failed to delete marker: $error';
+  }
+
+  @override
+  String get scene_details_add_marker => 'Add marker';
+
+  @override
+  String get scene_details_create_marker => 'Create';
+
+  @override
+  String scene_details_delete_marker_tooltip(String title) {
+    return 'Delete marker $title';
+  }
+
+  @override
+  String get scenes_page_markers_tooltip => 'Markers';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3080,4 +3080,42 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Mantén pulsado para ver las estadísticas de la biblioteca';
+
+  @override
+  String get scene_details_marker_created => 'Marcador creado';
+
+  @override
+  String scene_details_failed_to_create_marker(String error) {
+    return 'No se pudo crear el marcador: $error';
+  }
+
+  @override
+  String get scene_details_delete_marker_title => 'Eliminar marcadores';
+
+  @override
+  String scene_details_delete_marker_content(String title) {
+    return '¿Eliminar el marcador \"$title\"?';
+  }
+
+  @override
+  String get scene_details_marker_deleted => 'Marcador eliminado';
+
+  @override
+  String scene_details_failed_to_delete_marker(String error) {
+    return 'No se pudo eliminar el marcador: $error';
+  }
+
+  @override
+  String get scene_details_add_marker => 'Agregar marcador';
+
+  @override
+  String get scene_details_create_marker => 'Crear';
+
+  @override
+  String scene_details_delete_marker_tooltip(String title) {
+    return 'Eliminar marcador $title';
+  }
+
+  @override
+  String get scenes_page_markers_tooltip => 'Marcadores';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3072,4 +3072,42 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Appui long pour les statistiques de la bibliothèque';
+
+  @override
+  String get scene_details_marker_created => 'Marqueur créé';
+
+  @override
+  String scene_details_failed_to_create_marker(String error) {
+    return 'Échec de la création du marqueur : $error';
+  }
+
+  @override
+  String get scene_details_delete_marker_title => 'Supprimer des marqueurs';
+
+  @override
+  String scene_details_delete_marker_content(String title) {
+    return 'Supprimer le marqueur \"$title\" ?';
+  }
+
+  @override
+  String get scene_details_marker_deleted => 'Marqueur supprimé';
+
+  @override
+  String scene_details_failed_to_delete_marker(String error) {
+    return 'Échec de la suppression du marqueur : $error';
+  }
+
+  @override
+  String get scene_details_add_marker => 'Ajouter un marqueur';
+
+  @override
+  String get scene_details_create_marker => 'Créer';
+
+  @override
+  String scene_details_delete_marker_tooltip(String title) {
+    return 'Supprimer le marqueur $title';
+  }
+
+  @override
+  String get scenes_page_markers_tooltip => 'Marqueurs';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3071,4 +3071,42 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Tieni premuto per le statistiche della libreria';
+
+  @override
+  String get scene_details_marker_created => 'Marcatore creato';
+
+  @override
+  String scene_details_failed_to_create_marker(String error) {
+    return 'Impossibile creare l\'indicatore: $error';
+  }
+
+  @override
+  String get scene_details_delete_marker_title => 'Elimina marcatori';
+
+  @override
+  String scene_details_delete_marker_content(String title) {
+    return 'Eliminare l\'indicatore \"$title\"?';
+  }
+
+  @override
+  String get scene_details_marker_deleted => 'Indicatore eliminato';
+
+  @override
+  String scene_details_failed_to_delete_marker(String error) {
+    return 'Impossibile eliminare l\'indicatore: $error';
+  }
+
+  @override
+  String get scene_details_add_marker => 'Aggiungi marcatore';
+
+  @override
+  String get scene_details_create_marker => 'Creare';
+
+  @override
+  String scene_details_delete_marker_tooltip(String title) {
+    return 'Elimina indicatore $title';
+  }
+
+  @override
+  String get scenes_page_markers_tooltip => 'Marcatori';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2951,4 +2951,42 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get stats_library_stats_tooltip => '長押しでライブラリ統計を表示';
+
+  @override
+  String get scene_details_marker_created => 'マーカーが作成されました';
+
+  @override
+  String scene_details_failed_to_create_marker(String error) {
+    return 'マーカーの作成に失敗しました: $error';
+  }
+
+  @override
+  String get scene_details_delete_marker_title => 'マーカーの削除';
+
+  @override
+  String scene_details_delete_marker_content(String title) {
+    return 'マーカー「$title」を削除しますか?';
+  }
+
+  @override
+  String get scene_details_marker_deleted => 'マーカーが削除されました';
+
+  @override
+  String scene_details_failed_to_delete_marker(String error) {
+    return 'マーカーの削除に失敗しました: $error';
+  }
+
+  @override
+  String get scene_details_add_marker => 'マーカーを追加する';
+
+  @override
+  String get scene_details_create_marker => '作成する';
+
+  @override
+  String scene_details_delete_marker_tooltip(String title) {
+    return 'マーカー $title を削除';
+  }
+
+  @override
+  String get scenes_page_markers_tooltip => 'マーカー';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2949,4 +2949,42 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get stats_library_stats_tooltip => '길게 눌러 라이브러리 통계 보기';
+
+  @override
+  String get scene_details_marker_created => '마커가 생성되었습니다.';
+
+  @override
+  String scene_details_failed_to_create_marker(String error) {
+    return '마커 생성 실패: $error';
+  }
+
+  @override
+  String get scene_details_delete_marker_title => '마커 삭제';
+
+  @override
+  String scene_details_delete_marker_content(String title) {
+    return '마커 \'$title\'을 삭제하시겠습니까?';
+  }
+
+  @override
+  String get scene_details_marker_deleted => '마커가 삭제되었습니다.';
+
+  @override
+  String scene_details_failed_to_delete_marker(String error) {
+    return '마커 삭제 실패: $error';
+  }
+
+  @override
+  String get scene_details_add_marker => '마커 추가';
+
+  @override
+  String get scene_details_create_marker => '만들다';
+
+  @override
+  String scene_details_delete_marker_tooltip(String title) {
+    return '마커 $title 삭제';
+  }
+
+  @override
+  String get scenes_page_markers_tooltip => '마커';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3048,4 +3048,42 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get stats_library_stats_tooltip =>
       'Удерживайте для статистики библиотеки';
+
+  @override
+  String get scene_details_marker_created => 'Маркер создан';
+
+  @override
+  String scene_details_failed_to_create_marker(String error) {
+    return 'Не удалось создать маркер: $error.';
+  }
+
+  @override
+  String get scene_details_delete_marker_title => 'Удалить маркеры';
+
+  @override
+  String scene_details_delete_marker_content(String title) {
+    return 'Удалить маркер \"$title\"?';
+  }
+
+  @override
+  String get scene_details_marker_deleted => 'Маркер удален.';
+
+  @override
+  String scene_details_failed_to_delete_marker(String error) {
+    return 'Не удалось удалить маркер: $error.';
+  }
+
+  @override
+  String get scene_details_add_marker => 'Добавить маркер';
+
+  @override
+  String get scene_details_create_marker => 'Создавать';
+
+  @override
+  String scene_details_delete_marker_tooltip(String title) {
+    return 'Удалить маркер $title';
+  }
+
+  @override
+  String get scenes_page_markers_tooltip => 'Маркеры';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2895,6 +2895,44 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get stats_library_stats_tooltip => '长按查看资料库统计';
+
+  @override
+  String get scene_details_marker_created => '标记已创建';
+
+  @override
+  String scene_details_failed_to_create_marker(String error) {
+    return '无法创建标记：$error';
+  }
+
+  @override
+  String get scene_details_delete_marker_title => '删除标记';
+
+  @override
+  String scene_details_delete_marker_content(String title) {
+    return '删除标记“$title”吗？';
+  }
+
+  @override
+  String get scene_details_marker_deleted => '标记已删除';
+
+  @override
+  String scene_details_failed_to_delete_marker(String error) {
+    return '无法删除标记：$error';
+  }
+
+  @override
+  String get scene_details_add_marker => '添加标记';
+
+  @override
+  String get scene_details_create_marker => '创造';
+
+  @override
+  String scene_details_delete_marker_tooltip(String title) {
+    return '删除标记 $title';
+  }
+
+  @override
+  String get scenes_page_markers_tooltip => '标记';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -5787,6 +5825,44 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get stats_library_stats_tooltip => '长按查看资料库统计';
+
+  @override
+  String get scene_details_marker_created => '标记已创建';
+
+  @override
+  String scene_details_failed_to_create_marker(String error) {
+    return '无法创建标记：$error';
+  }
+
+  @override
+  String get scene_details_delete_marker_title => '删除标记';
+
+  @override
+  String scene_details_delete_marker_content(String title) {
+    return '删除标记“$title”吗？';
+  }
+
+  @override
+  String get scene_details_marker_deleted => '标记已删除';
+
+  @override
+  String scene_details_failed_to_delete_marker(String error) {
+    return '无法删除标记：$error';
+  }
+
+  @override
+  String get scene_details_add_marker => '添加标记';
+
+  @override
+  String get scene_details_create_marker => '创造';
+
+  @override
+  String scene_details_delete_marker_tooltip(String title) {
+    return '删除标记 $title';
+  }
+
+  @override
+  String get scenes_page_markers_tooltip => '标记';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -8683,4 +8759,42 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get stats_library_stats_tooltip => '長按查看資料庫統計';
+
+  @override
+  String get scene_details_marker_created => '標記已建立';
+
+  @override
+  String scene_details_failed_to_create_marker(String error) {
+    return '無法建立標記：$error';
+  }
+
+  @override
+  String get scene_details_delete_marker_title => '刪除標記';
+
+  @override
+  String scene_details_delete_marker_content(String title) {
+    return '刪除標記“$title”嗎？';
+  }
+
+  @override
+  String get scene_details_marker_deleted => '標記已刪除';
+
+  @override
+  String scene_details_failed_to_delete_marker(String error) {
+    return '無法刪除標記：$error';
+  }
+
+  @override
+  String get scene_details_add_marker => '添加標記';
+
+  @override
+  String get scene_details_create_marker => '創造';
+
+  @override
+  String scene_details_delete_marker_tooltip(String title) {
+    return '刪除標記 $title';
+  }
+
+  @override
+  String get scenes_page_markers_tooltip => '標記';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1051,5 +1051,15 @@
   "settings_security_subtitle": "Настройки блокировки приложения и пароля",
   "tools_section_subtitle": "Рабочие процессы обслуживания и метаданных для сцен.",
   "tools_scene_deduplication_subtitle": "Поиск и управление дубликатами сцен.",
-  "tools_scene_tagger_subtitle": "Скрапинг страниц текущих сцен с помощью Stash-box."
+  "tools_scene_tagger_subtitle": "Скрапинг страниц текущих сцен с помощью Stash-box.",
+  "scene_details_marker_created": "Маркер создан",
+  "scene_details_failed_to_create_marker": "Не удалось создать маркер: {error}.",
+  "scene_details_delete_marker_title": "Удалить маркеры",
+  "scene_details_delete_marker_content": "Удалить маркер \"{title}\"?",
+  "scene_details_marker_deleted": "Маркер удален.",
+  "scene_details_failed_to_delete_marker": "Не удалось удалить маркер: {error}.",
+  "scene_details_add_marker": "Добавить маркер",
+  "scene_details_create_marker": "Создавать",
+  "scene_details_delete_marker_tooltip": "Удалить маркер {title}",
+  "scenes_page_markers_tooltip": "Маркеры"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1051,5 +1051,15 @@
   "settings_security_subtitle": "应用锁和密码设置",
   "tools_section_subtitle": "场景的维护和元数据工作流。",
   "tools_scene_deduplication_subtitle": "查找并管理重复的场景。",
-  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削当前场景页面。"
+  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削当前场景页面。",
+  "scene_details_marker_created": "标记已创建",
+  "scene_details_failed_to_create_marker": "无法创建标记：{error}",
+  "scene_details_delete_marker_title": "删除标记",
+  "scene_details_delete_marker_content": "删除标记“{title}”吗？",
+  "scene_details_marker_deleted": "标记已删除",
+  "scene_details_failed_to_delete_marker": "无法删除标记：{error}",
+  "scene_details_add_marker": "添加标记",
+  "scene_details_create_marker": "创造",
+  "scene_details_delete_marker_tooltip": "删除标记 {title}",
+  "scenes_page_markers_tooltip": "标记"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1037,5 +1037,15 @@
   "settings_security_subtitle": "应用锁和密码设置",
   "tools_section_subtitle": "场景的维护和元数据工作流。",
   "tools_scene_deduplication_subtitle": "查找并管理重复场景。",
-  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削当前场景页面。"
+  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削当前场景页面。",
+  "scene_details_marker_created": "标记已创建",
+  "scene_details_failed_to_create_marker": "无法创建标记：{error}",
+  "scene_details_delete_marker_title": "删除标记",
+  "scene_details_delete_marker_content": "删除标记“{title}”吗？",
+  "scene_details_marker_deleted": "标记已删除",
+  "scene_details_failed_to_delete_marker": "无法删除标记：{error}",
+  "scene_details_add_marker": "添加标记",
+  "scene_details_create_marker": "创造",
+  "scene_details_delete_marker_tooltip": "删除标记 {title}",
+  "scenes_page_markers_tooltip": "标记"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1037,5 +1037,15 @@
   "settings_security_subtitle": "應用鎖和密碼設定",
   "tools_section_subtitle": "場景的維護和元數據工作流。",
   "tools_scene_deduplication_subtitle": "查找並管理重複的場景。",
-  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削當前場景頁面。"
+  "tools_scene_tagger_subtitle": "使用 Stash-box 刮削當前場景頁面。",
+  "scene_details_marker_created": "標記已建立",
+  "scene_details_failed_to_create_marker": "無法建立標記：{error}",
+  "scene_details_delete_marker_title": "刪除標記",
+  "scene_details_delete_marker_content": "刪除標記“{title}”嗎？",
+  "scene_details_marker_deleted": "標記已刪除",
+  "scene_details_failed_to_delete_marker": "無法刪除標記：{error}",
+  "scene_details_add_marker": "添加標記",
+  "scene_details_create_marker": "創造",
+  "scene_details_delete_marker_tooltip": "刪除標記 {title}",
+  "scenes_page_markers_tooltip": "標記"
 }


### PR DESCRIPTION
## What
Extracted hardcoded strings related to markers in `scene_details_page.dart` and `scenes_page.dart` into localization keys.

## Why
To ensure the app fully supports internationalization for all newly added marker features and avoids shipping plain English strings to end users.

## Impact
Better i18n support across all supported locales.

## Measurement
Generated via `flutter gen-l10n` and machine-translated via googletrans.

---
*PR created automatically by Jules for task [107788328240096706](https://jules.google.com/task/107788328240096706) started by @Alchemist-Aloha*