### PR TITLE
🌐 L10n: Localize hardcoded text and translate

### DIFF
--- a/lib/features/groups/presentation/widgets/group_filter_panel.dart
+++ b/lib/features/groups/presentation/widgets/group_filter_panel.dart
@@ -46,7 +46,7 @@ class _GroupFilterPanelState extends ConsumerState<GroupFilterPanel> {
             children: [
               DropdownButtonFormField<String?>(
                 initialValue: _tempFilter.isMissingField,
-                decoration: const InputDecoration(labelText: 'Missing Field'),
+                decoration: const InputDecoration(labelText: context.l10n.auto_missing_field),
                 items: [
                   DropdownMenuItem<String?>(
                     value: null,

--- a/lib/features/scenes/presentation/pages/scene_details_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_details_page.dart
@@ -150,7 +150,7 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    'Choose how this scene should be deleted. This action cannot be undone.',
+                    context.l10n.delete_scenes_help,
                     style: dialogContext.textTheme.bodyMedium,
                   ),
                   const SizedBox(height: AppTheme.spacingSmall),
@@ -1086,7 +1086,7 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Markers',
+            context.l10n.scenes_page_markers_tooltip,
             style: context.textTheme.titleMedium?.copyWith(
               fontWeight: FontWeight.w600,
             ),
@@ -1399,7 +1399,7 @@ class _AddMarkerDialogState extends State<_AddMarkerDialog> {
         controller: _controller,
         autofocus: true,
         textInputAction: TextInputAction.done,
-        decoration: const InputDecoration(labelText: 'Marker name'),
+        decoration: const InputDecoration(labelText: context.l10n.auto_marker_name),
         onSubmitted: (_) => _submit(),
       ),
       actions: [

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1086,5 +1086,7 @@
   "settings_interface_entity_image_filtering": "Entitätsbildfilterung",
   "settings_interface_entity_image_filtering_subtitle": "Wählen Sie, ob Entitätsbildseiten mit Bildmetadaten oder zugehörigen Galerien übereinstimmen sollen.",
   "settings_interface_entity_image_filtering_direct": "Direkte Entität",
-  "settings_interface_entity_image_filtering_galleries": "Zugehörige Galerien"
+  "settings_interface_entity_image_filtering_galleries": "Zugehörige Galerien",
+  "auto_marker_name": "Markierungsname",
+  "auto_missing_field": "Fehlendes Feld"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1364,7 +1364,7 @@
       }
     }
   },
-  "scene_tagger_checked_matches_summary": "{checked} checked \u2022 {matches} matches",
+  "scene_tagger_checked_matches_summary": "{checked} checked • {matches} matches",
   "@scene_tagger_checked_matches_summary": {
     "placeholders": {
       "checked": {
@@ -1442,5 +1442,7 @@
       }
     }
   },
-  "scenes_page_markers_tooltip": "Markers"
+  "scenes_page_markers_tooltip": "Markers",
+  "auto_marker_name": "Marker name",
+  "auto_missing_field": "Missing Field"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1065,5 +1065,7 @@
   "settings_interface_entity_image_filtering": "Filtrado de imágenes de entidad",
   "settings_interface_entity_image_filtering_subtitle": "Elige si las páginas de imágenes de entidad coinciden con los metadatos de imagen o las galerías relacionadas.",
   "settings_interface_entity_image_filtering_direct": "Entidad directa",
-  "settings_interface_entity_image_filtering_galleries": "Galerías relacionadas"
+  "settings_interface_entity_image_filtering_galleries": "Galerías relacionadas",
+  "auto_marker_name": "Nombre del marcador",
+  "auto_missing_field": "Campo faltante"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1065,5 +1065,7 @@
   "settings_interface_entity_image_filtering": "Filtrage d'images d'entité",
   "settings_interface_entity_image_filtering_subtitle": "Choisissez si les pages d'images d'entité correspondent aux métadonnées d'image ou aux galeries associées.",
   "settings_interface_entity_image_filtering_direct": "Entité directe",
-  "settings_interface_entity_image_filtering_galleries": "Galeries associées"
+  "settings_interface_entity_image_filtering_galleries": "Galeries associées",
+  "auto_marker_name": "Nom du marqueur",
+  "auto_missing_field": "Champ manquant"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1070,5 +1070,7 @@
   "settings_interface_entity_image_filtering": "Filtraggio immagini entità",
   "settings_interface_entity_image_filtering_subtitle": "Scegli se le pagine delle immagini dell'entità corrispondono ai metadati dell'immagine o alle gallerie correlate.",
   "settings_interface_entity_image_filtering_direct": "Entità diretta",
-  "settings_interface_entity_image_filtering_galleries": "Gallerie correlate"
+  "settings_interface_entity_image_filtering_galleries": "Gallerie correlate",
+  "auto_marker_name": "Nome del marcatore",
+  "auto_missing_field": "Campo mancante"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1065,5 +1065,7 @@
   "settings_interface_entity_image_filtering": "エンティティ画像フィルタリング",
   "settings_interface_entity_image_filtering_subtitle": "エンティティ画像ページが画像メタデータと一致するか、関連ギャラリーと一致するかを選択します。",
   "settings_interface_entity_image_filtering_direct": "直接エンティティ",
-  "settings_interface_entity_image_filtering_galleries": "関連ギャラリー"
+  "settings_interface_entity_image_filtering_galleries": "関連ギャラリー",
+  "auto_marker_name": "マーカー名",
+  "auto_missing_field": "不足しているフィールド"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1065,5 +1065,7 @@
   "settings_interface_entity_image_filtering": "엔티티 이미지 필터링",
   "settings_interface_entity_image_filtering_subtitle": "엔티티 이미지 페이지가 이미지 메타데이터와 일치하는지 관련 갤러리와 일치하는지 선택하세요.",
   "settings_interface_entity_image_filtering_direct": "직접 엔티티",
-  "settings_interface_entity_image_filtering_galleries": "관련 갤러리"
+  "settings_interface_entity_image_filtering_galleries": "관련 갤러리",
+  "auto_marker_name": "마커 이름",
+  "auto_missing_field": "누락된 필드"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5513,6 +5513,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Markers'**
   String get scenes_page_markers_tooltip;
+
+  /// No description provided for @auto_marker_name.
+  ///
+  /// In en, this message translates to:
+  /// **'Marker name'**
+  String get auto_marker_name;
+
+  /// No description provided for @auto_missing_field.
+  ///
+  /// In en, this message translates to:
+  /// **'Missing Field'**
+  String get auto_missing_field;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3107,4 +3107,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get scenes_page_markers_tooltip => 'Markierungen';
+
+  @override
+  String get auto_marker_name => 'Markierungsname';
+
+  @override
+  String get auto_missing_field => 'Fehlendes Feld';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3061,4 +3061,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get scenes_page_markers_tooltip => 'Markers';
+
+  @override
+  String get auto_marker_name => 'Marker name';
+
+  @override
+  String get auto_missing_field => 'Missing Field';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3134,4 +3134,10 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get scenes_page_markers_tooltip => 'Marcadores';
+
+  @override
+  String get auto_marker_name => 'Nombre del marcador';
+
+  @override
+  String get auto_missing_field => 'Campo faltante';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3126,4 +3126,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get scenes_page_markers_tooltip => 'Marqueurs';
+
+  @override
+  String get auto_marker_name => 'Nom du marqueur';
+
+  @override
+  String get auto_missing_field => 'Champ manquant';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3125,4 +3125,10 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get scenes_page_markers_tooltip => 'Marcatori';
+
+  @override
+  String get auto_marker_name => 'Nome del marcatore';
+
+  @override
+  String get auto_missing_field => 'Campo mancante';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -3002,4 +3002,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get scenes_page_markers_tooltip => 'マーカー';
+
+  @override
+  String get auto_marker_name => 'マーカー名';
+
+  @override
+  String get auto_missing_field => '不足しているフィールド';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -3000,4 +3000,10 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get scenes_page_markers_tooltip => '마커';
+
+  @override
+  String get auto_marker_name => '마커 이름';
+
+  @override
+  String get auto_missing_field => '누락된 필드';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3102,4 +3102,10 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get scenes_page_markers_tooltip => 'Маркеры';
+
+  @override
+  String get auto_marker_name => 'Имя маркера';
+
+  @override
+  String get auto_missing_field => 'Отсутствует поле';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2946,6 +2946,12 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get scenes_page_markers_tooltip => '标记';
+
+  @override
+  String get auto_marker_name => '标记名称';
+
+  @override
+  String get auto_missing_field => '缺失字段';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -5889,6 +5895,12 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get scenes_page_markers_tooltip => '标记';
+
+  @override
+  String get auto_marker_name => '标记名称';
+
+  @override
+  String get auto_missing_field => '缺失字段';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -8836,4 +8848,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get scenes_page_markers_tooltip => '標記';
+
+  @override
+  String get auto_marker_name => '標記名稱';
+
+  @override
+  String get auto_missing_field => '缺失字段';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1065,5 +1065,7 @@
   "settings_interface_entity_image_filtering": "Фильтрация изображений сущностей",
   "settings_interface_entity_image_filtering_subtitle": "Выберите, должны ли страницы изображений сущностей соответствовать метаданным изображений или связанным галереям.",
   "settings_interface_entity_image_filtering_direct": "Прямая сущность",
-  "settings_interface_entity_image_filtering_galleries": "Связанные галереи"
+  "settings_interface_entity_image_filtering_galleries": "Связанные галереи",
+  "auto_marker_name": "Имя маркера",
+  "auto_missing_field": "Отсутствует поле"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1065,5 +1065,7 @@
   "settings_interface_entity_image_filtering": "实体图像过滤",
   "settings_interface_entity_image_filtering_subtitle": "选择实体图像页面是匹配图像元数据还是关联图库。",
   "settings_interface_entity_image_filtering_direct": "直接实体",
-  "settings_interface_entity_image_filtering_galleries": "关联图库"
+  "settings_interface_entity_image_filtering_galleries": "关联图库",
+  "auto_marker_name": "标记名称",
+  "auto_missing_field": "缺失字段"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1051,5 +1051,7 @@
   "settings_interface_entity_image_filtering": "实体图像过滤",
   "settings_interface_entity_image_filtering_subtitle": "选择实体图像页面是匹配图像元数据还是关联图库。",
   "settings_interface_entity_image_filtering_direct": "直接实体",
-  "settings_interface_entity_image_filtering_galleries": "关联图库"
+  "settings_interface_entity_image_filtering_galleries": "关联图库",
+  "auto_marker_name": "标记名称",
+  "auto_missing_field": "缺失字段"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1051,5 +1051,7 @@
   "settings_interface_entity_image_filtering": "實體圖像過濾",
   "settings_interface_entity_image_filtering_subtitle": "選擇實體圖像頁面是匹配圖像元數據還是關聯圖庫。",
   "settings_interface_entity_image_filtering_direct": "直接實體",
-  "settings_interface_entity_image_filtering_galleries": "關聯圖庫"
+  "settings_interface_entity_image_filtering_galleries": "關聯圖庫",
+  "auto_marker_name": "標記名稱",
+  "auto_missing_field": "缺失字段"
 }


### PR DESCRIPTION
**What:** Localized hardcoded strings in scene details and group filter panels, generated translations for all target locales.
**Why:** Ensure consistent localization and eliminate English-only hardcoded text in the UI.

---
*PR created automatically by Jules for task [16303404097117047429](https://jules.google.com/task/16303404097117047429) started by @Alchemist-Aloha*