### PR TITLE
⚡ Bolt: Throttle pagination data fetches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@
 ## 2024-05-30 - [Hoist textTheme and dimensions from ListView itemBuilder]
 **Learning:** Performing invariant lookups like `context.textTheme` and `context.dimensions.fontSizeFactor` inside a `ListView.builder`'s `itemBuilder` callback forces redundant O(1) inherited widget lookups on every single rendered item during scroll.
 **Action:** Always hoist these layout and styling variables out of the `itemBuilder` and into the parent widget's `build` (or builder) method to reduce GC pressure and ensure optimal rendering performance.
+
+## 2024-05-24 - Throttling Scroll Listeners for Pagination
+**Learning:** In Flutter, `NotificationListener<ScrollNotification>` fires on every frame during scrolling. When used for pagination (checking if scrolled past a threshold), this can trigger the `onFetchNextPage` callback dozens of times per second if the user scrolls quickly past the threshold. This causes massive redundant O(N) calls to backend fetch logic or provider reads, heavily degrading performance.
+**Action:** Always throttle the data fetch callback within `NotificationListener<ScrollNotification>` (e.g., using a `DateTime` comparison to limit executions to once per ~500ms) to prevent redundant executions during rapid scrolling.

--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -169,6 +169,9 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
   DateTime? _lastHorizontalSwipeTime;
   static const _horizontalSwipeThreshold = Duration(milliseconds: 500);
 
+  DateTime? _lastPaginationFetchTime;
+  static const _paginationThrottleThreshold = Duration(milliseconds: 500);
+
   @override
   void initState() {
     super.initState();
@@ -762,7 +765,15 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                       return NotificationListener<ScrollNotification>(
                         onNotification: (ScrollNotification scrollInfo) {
                           if (shouldLoadNextPage(scrollInfo.metrics)) {
-                            widget.onFetchNextPage?.call();
+                            // ⚡ Bolt: Throttle pagination callbacks to prevent O(N) redundant reads
+                            // during rapid scroll rebuilds, saving substantial CPU on long lists.
+                            final now = DateTime.now();
+                            if (_lastPaginationFetchTime == null ||
+                                now.difference(_lastPaginationFetchTime!) >
+                                    _paginationThrottleThreshold) {
+                              _lastPaginationFetchTime = now;
+                              widget.onFetchNextPage?.call();
+                            }
                           }
                           return false;
                         },


### PR DESCRIPTION
💡 What: Added a 500ms throttle to the `onFetchNextPage` callback in `NotificationListener<ScrollNotification>`.
🎯 Why: `NotificationListener<ScrollNotification>` fires on every frame during scrolling. When used for pagination (checking if scrolled past a threshold), this can trigger the `onFetchNextPage` callback dozens of times per second if the user scrolls quickly past the threshold.
📊 Impact: Prevents massive redundant O(N) calls to backend fetch logic or provider reads, heavily improving performance during rapid scrolling.
🔬 Measurement: Scroll rapidly in any grid or list view and observe network/provider read logs to verify the callback only triggers at most once every 500ms.

---
*PR created automatically by Jules for task [6047859112124308510](https://jules.google.com/task/6047859112124308510) started by @Alchemist-Aloha*