### PR TITLE
⚡ Bolt: Throttle pagination fetching in ListPageScaffold

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,6 @@
 ## 2024-05-30 - [Hoist textTheme and dimensions from ListView itemBuilder]
 **Learning:** Performing invariant lookups like `context.textTheme` and `context.dimensions.fontSizeFactor` inside a `ListView.builder`'s `itemBuilder` callback forces redundant O(1) inherited widget lookups on every single rendered item during scroll.
 **Action:** Always hoist these layout and styling variables out of the `itemBuilder` and into the parent widget's `build` (or builder) method to reduce GC pressure and ensure optimal rendering performance.
+## 2024-05-18 - Throttle Pagination in ScrollNotification
+**Learning:** The `ScrollNotification` callback runs extremely frequently during scrolling. If it contains a condition that checks whether to fetch the next page, calling `onFetchNextPage` without a throttle can trigger multiple fetch calls when the user reaches the end of the scroll, which degrades performance and can lead to duplicated content if not properly handled by the backend logic or the UI state. Throttling is critical for performance here.
+**Action:** When using `NotificationListener<ScrollNotification>` for pagination, throttle the callback (e.g., using `DateTime` comparison) to limit the frequency of triggers to an interval (like 500ms).

--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -169,6 +169,9 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
   DateTime? _lastHorizontalSwipeTime;
   static const _horizontalSwipeThreshold = Duration(milliseconds: 500);
 
+  DateTime? _lastFetchNextPageTime;
+  static const _fetchNextPageThrottle = Duration(milliseconds: 500);
+
   @override
   void initState() {
     super.initState();
@@ -762,7 +765,14 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                       return NotificationListener<ScrollNotification>(
                         onNotification: (ScrollNotification scrollInfo) {
                           if (shouldLoadNextPage(scrollInfo.metrics)) {
-                            widget.onFetchNextPage?.call();
+                            final now = DateTime.now();
+                            if (_lastFetchNextPageTime == null ||
+                                now.difference(_lastFetchNextPageTime!) >
+                                    _fetchNextPageThrottle) {
+                              _lastFetchNextPageTime = now;
+                              // ⚡ Bolt: Throttling pagination callback to prevent rapid redundant calls.
+                              widget.onFetchNextPage?.call();
+                            }
                           }
                           return false;
                         },


### PR DESCRIPTION
* 💡 What: Added a 500ms throttle to the `onFetchNextPage` callback within `NotificationListener<ScrollNotification>` in `ListPageScaffold`.
* 🎯 Why: Without throttling, the `ScrollNotification` callback fires on every frame during scrolling. When the user hits the threshold, this can trigger multiple `onFetchNextPage` calls in rapid succession, causing redundant work and potential performance degradation.
* 📊 Impact: Reduces redundant calls and improves scrolling performance.
* 🔬 Measurement: Monitored scroll events to observe reduced calls to the fetch page method.

---
*PR created automatically by Jules for task [13279568377143271526](https://jules.google.com/task/13279568377143271526) started by @Alchemist-Aloha*