### PR TITLE
🌐 Localization: Replace hardcoded strings with l10n keys

### DIFF
--- a/lib/features/groups/presentation/widgets/group_filter_panel.dart
+++ b/lib/features/groups/presentation/widgets/group_filter_panel.dart
@@ -71,7 +71,7 @@ class _GroupFilterPanelState extends ConsumerState<GroupFilterPanel> {
                 },
               ),
               IntCriterionInput(
-                label: 'Sub-group Count',
+                label: context.l10n.scenes_field_sub_group_count,
                 value: _tempFilter.subGroupCount,
                 onChanged: (value) {
                   setState(() {

--- a/lib/features/navigation/presentation/widgets/mini_player.dart
+++ b/lib/features/navigation/presentation/widgets/mini_player.dart
@@ -32,7 +32,7 @@ class MiniPlayer extends ConsumerWidget {
 
     return Semantics(
       button: true,
-      label: 'Now playing: $displayTitle. Tap to open scene details.',
+      label: context.l10n.mini_player_now_playing(displayTitle),
       child: Container(
         height: 66, // Increased height by 10% (from 60)
         decoration: BoxDecoration(

--- a/lib/features/scenes/presentation/pages/scene_details_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_details_page.dart
@@ -235,7 +235,9 @@ class _SceneDetailsPageState extends ConsumerState<SceneDetailsPage> {
                               ScaffoldMessenger.of(dialogContext).showSnackBar(
                                 SnackBar(
                                   content: Text(
-                                    'Failed to delete scene: ${e.toString()}',
+                                    context.l10n.scenes_delete_failed(
+                                      e.toString(),
+                                    ),
                                   ),
                                 ),
                               );

--- a/lib/features/scenes/presentation/widgets/scene_marker_filter_panel.dart
+++ b/lib/features/scenes/presentation/widgets/scene_marker_filter_panel.dart
@@ -74,7 +74,7 @@ class _SceneMarkerFilterPanelState
           true,
         ),
         IntCriterionInput(
-          label: 'Duration',
+          label: context.l10n.scenes_sort_duration,
           value: _tempFilter.duration,
           onChanged: (value) => setState(
             () => _tempFilter = _tempFilter.copyWith(
@@ -136,7 +136,7 @@ class _SceneMarkerFilterPanelState
       title: 'Dates',
       children: [
         DateCriterionInput(
-          label: 'Created At',
+          label: context.l10n.sort_created_at,
           value: _tempFilter.createdAt,
           onChanged: (value) => setState(
             () => _tempFilter = _tempFilter.copyWith(
@@ -146,7 +146,7 @@ class _SceneMarkerFilterPanelState
           ),
         ),
         DateCriterionInput(
-          label: 'Updated At',
+          label: context.l10n.sort_updated_at,
           value: _tempFilter.updatedAt,
           onChanged: (value) => setState(
             () => _tempFilter = _tempFilter.copyWith(
@@ -156,7 +156,7 @@ class _SceneMarkerFilterPanelState
           ),
         ),
         DateCriterionInput(
-          label: 'Scene Date',
+          label: context.l10n.scenes_field_scene_date,
           value: _tempFilter.sceneDate,
           onChanged: (value) => setState(
             () => _tempFilter = _tempFilter.copyWith(
@@ -166,7 +166,7 @@ class _SceneMarkerFilterPanelState
           ),
         ),
         DateCriterionInput(
-          label: 'Scene Created At',
+          label: context.l10n.scenes_field_scene_created_at,
           value: _tempFilter.sceneCreatedAt,
           onChanged: (value) => setState(
             () => _tempFilter = _tempFilter.copyWith(
@@ -176,7 +176,7 @@ class _SceneMarkerFilterPanelState
           ),
         ),
         DateCriterionInput(
-          label: 'Scene Updated At',
+          label: context.l10n.scenes_field_scene_updated_at,
           value: _tempFilter.sceneUpdatedAt,
           onChanged: (value) => setState(
             () => _tempFilter = _tempFilter.copyWith(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1088,5 +1088,11 @@
   "settings_interface_entity_image_filtering_direct": "Direkte Entität",
   "settings_interface_entity_image_filtering_galleries": "Zugehörige Galerien",
   "auto_marker_name": "Markierungsname",
-  "auto_missing_field": "Fehlendes Feld"
+  "auto_missing_field": "Fehlendes Feld",
+  "scenes_field_scene_date": "Szenendatum",
+  "scenes_field_scene_created_at": "Szene erstellt am",
+  "scenes_field_scene_updated_at": "Szene aktualisiert um",
+  "scenes_field_sub_group_count": "Anzahl der Untergruppen",
+  "mini_player_now_playing": "Spielt gerade: {title}. Tippen Sie hier, um Szenendetails zu öffnen.",
+  "scenes_delete_failed": "Szene konnte nicht gelöscht werden: {error}"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1444,5 +1444,26 @@
   },
   "scenes_page_markers_tooltip": "Markers",
   "auto_marker_name": "Marker name",
-  "auto_missing_field": "Missing Field"
+  "auto_missing_field": "Missing Field",
+  "scenes_field_scene_date": "Scene Date",
+  "scenes_field_scene_created_at": "Scene Created At",
+  "scenes_field_scene_updated_at": "Scene Updated At",
+  "scenes_field_sub_group_count": "Sub-group Count",
+  "mini_player_now_playing": "Now playing: {title}. Tap to open scene details.",
+  "@mini_player_now_playing": {
+    "description": "Accessibility label for the mini player",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "scenes_delete_failed": "Failed to delete scene: {error}",
+  "@scenes_delete_failed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1067,5 +1067,11 @@
   "settings_interface_entity_image_filtering_direct": "Entidad directa",
   "settings_interface_entity_image_filtering_galleries": "Galerías relacionadas",
   "auto_marker_name": "Nombre del marcador",
-  "auto_missing_field": "Campo faltante"
+  "auto_missing_field": "Campo faltante",
+  "scenes_field_scene_date": "Escena Fecha",
+  "scenes_field_scene_created_at": "Escena creada en",
+  "scenes_field_scene_updated_at": "Escena actualizada en",
+  "scenes_field_sub_group_count": "Recuento de subgrupos",
+  "mini_player_now_playing": "Reproduciendo ahora: {title}. Toque para abrir los detalles de la escena.",
+  "scenes_delete_failed": "No se pudo eliminar la escena: {error}"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1067,5 +1067,11 @@
   "settings_interface_entity_image_filtering_direct": "Entité directe",
   "settings_interface_entity_image_filtering_galleries": "Galeries associées",
   "auto_marker_name": "Nom du marqueur",
-  "auto_missing_field": "Champ manquant"
+  "auto_missing_field": "Champ manquant",
+  "scenes_field_scene_date": "Date de la scène",
+  "scenes_field_scene_created_at": "Scène créée à",
+  "scenes_field_scene_updated_at": "Scène mise à jour à",
+  "scenes_field_sub_group_count": "Nombre de sous-groupes",
+  "mini_player_now_playing": "Lecture en cours : {title}. Appuyez pour ouvrir les détails de la scène.",
+  "scenes_delete_failed": "Échec de la suppression de la scène : {error}"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1072,5 +1072,11 @@
   "settings_interface_entity_image_filtering_direct": "Entità diretta",
   "settings_interface_entity_image_filtering_galleries": "Gallerie correlate",
   "auto_marker_name": "Nome del marcatore",
-  "auto_missing_field": "Campo mancante"
+  "auto_missing_field": "Campo mancante",
+  "scenes_field_scene_date": "Data della scena",
+  "scenes_field_scene_created_at": "Scena creata a",
+  "scenes_field_scene_updated_at": "Scena aggiornata a",
+  "scenes_field_sub_group_count": "Conteggio sottogruppi",
+  "mini_player_now_playing": "Ora in riproduzione: {title}. Tocca per aprire i dettagli della scena.",
+  "scenes_delete_failed": "Impossibile eliminare la scena: {error}"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1067,5 +1067,11 @@
   "settings_interface_entity_image_filtering_direct": "直接エンティティ",
   "settings_interface_entity_image_filtering_galleries": "関連ギャラリー",
   "auto_marker_name": "マーカー名",
-  "auto_missing_field": "不足しているフィールド"
+  "auto_missing_field": "不足しているフィールド",
+  "scenes_field_scene_date": "シーンの日付",
+  "scenes_field_scene_created_at": "シーンの作成日",
+  "scenes_field_scene_updated_at": "シーンの更新日時",
+  "scenes_field_sub_group_count": "サブグループ数",
+  "mini_player_now_playing": "現在再生中: {title}。タップしてシーンの詳細を開きます。",
+  "scenes_delete_failed": "シーンの削除に失敗しました: {error}"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1067,5 +1067,11 @@
   "settings_interface_entity_image_filtering_direct": "직접 엔티티",
   "settings_interface_entity_image_filtering_galleries": "관련 갤러리",
   "auto_marker_name": "마커 이름",
-  "auto_missing_field": "누락된 필드"
+  "auto_missing_field": "누락된 필드",
+  "scenes_field_scene_date": "장면 날짜",
+  "scenes_field_scene_created_at": "장면 생성 시간",
+  "scenes_field_scene_updated_at": "장면 업데이트 시간",
+  "scenes_field_sub_group_count": "하위 그룹 수",
+  "mini_player_now_playing": "지금 재생 중: {title}. 장면 세부정보를 열려면 탭하세요.",
+  "scenes_delete_failed": "장면을 삭제하지 못했습니다: {error}"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5525,6 +5525,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Missing Field'**
   String get auto_missing_field;
+
+  /// No description provided for @scenes_field_scene_date.
+  ///
+  /// In en, this message translates to:
+  /// **'Scene Date'**
+  String get scenes_field_scene_date;
+
+  /// No description provided for @scenes_field_scene_created_at.
+  ///
+  /// In en, this message translates to:
+  /// **'Scene Created At'**
+  String get scenes_field_scene_created_at;
+
+  /// No description provided for @scenes_field_scene_updated_at.
+  ///
+  /// In en, this message translates to:
+  /// **'Scene Updated At'**
+  String get scenes_field_scene_updated_at;
+
+  /// No description provided for @scenes_field_sub_group_count.
+  ///
+  /// In en, this message translates to:
+  /// **'Sub-group Count'**
+  String get scenes_field_sub_group_count;
+
+  /// Accessibility label for the mini player
+  ///
+  /// In en, this message translates to:
+  /// **'Now playing: {title}. Tap to open scene details.'**
+  String mini_player_now_playing(String title);
+
+  /// No description provided for @scenes_delete_failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to delete scene: {error}'**
+  String scenes_delete_failed(String error);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3113,4 +3113,26 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get auto_missing_field => 'Fehlendes Feld';
+
+  @override
+  String get scenes_field_scene_date => 'Szenendatum';
+
+  @override
+  String get scenes_field_scene_created_at => 'Szene erstellt am';
+
+  @override
+  String get scenes_field_scene_updated_at => 'Szene aktualisiert um';
+
+  @override
+  String get scenes_field_sub_group_count => 'Anzahl der Untergruppen';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return 'Spielt gerade: $title. Tippen Sie hier, um Szenendetails zu öffnen.';
+  }
+
+  @override
+  String scenes_delete_failed(String error) {
+    return 'Szene konnte nicht gelöscht werden: $error';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3067,4 +3067,26 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get auto_missing_field => 'Missing Field';
+
+  @override
+  String get scenes_field_scene_date => 'Scene Date';
+
+  @override
+  String get scenes_field_scene_created_at => 'Scene Created At';
+
+  @override
+  String get scenes_field_scene_updated_at => 'Scene Updated At';
+
+  @override
+  String get scenes_field_sub_group_count => 'Sub-group Count';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return 'Now playing: $title. Tap to open scene details.';
+  }
+
+  @override
+  String scenes_delete_failed(String error) {
+    return 'Failed to delete scene: $error';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3140,4 +3140,26 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get auto_missing_field => 'Campo faltante';
+
+  @override
+  String get scenes_field_scene_date => 'Escena Fecha';
+
+  @override
+  String get scenes_field_scene_created_at => 'Escena creada en';
+
+  @override
+  String get scenes_field_scene_updated_at => 'Escena actualizada en';
+
+  @override
+  String get scenes_field_sub_group_count => 'Recuento de subgrupos';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return 'Reproduciendo ahora: $title. Toque para abrir los detalles de la escena.';
+  }
+
+  @override
+  String scenes_delete_failed(String error) {
+    return 'No se pudo eliminar la escena: $error';
+  }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3132,4 +3132,26 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get auto_missing_field => 'Champ manquant';
+
+  @override
+  String get scenes_field_scene_date => 'Date de la scène';
+
+  @override
+  String get scenes_field_scene_created_at => 'Scène créée à';
+
+  @override
+  String get scenes_field_scene_updated_at => 'Scène mise à jour à';
+
+  @override
+  String get scenes_field_sub_group_count => 'Nombre de sous-groupes';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return 'Lecture en cours : $title. Appuyez pour ouvrir les détails de la scène.';
+  }
+
+  @override
+  String scenes_delete_failed(String error) {
+    return 'Échec de la suppression de la scène : $error';
+  }
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3131,4 +3131,26 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get auto_missing_field => 'Campo mancante';
+
+  @override
+  String get scenes_field_scene_date => 'Data della scena';
+
+  @override
+  String get scenes_field_scene_created_at => 'Scena creata a';
+
+  @override
+  String get scenes_field_scene_updated_at => 'Scena aggiornata a';
+
+  @override
+  String get scenes_field_sub_group_count => 'Conteggio sottogruppi';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return 'Ora in riproduzione: $title. Tocca per aprire i dettagli della scena.';
+  }
+
+  @override
+  String scenes_delete_failed(String error) {
+    return 'Impossibile eliminare la scena: $error';
+  }
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -3008,4 +3008,26 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get auto_missing_field => '不足しているフィールド';
+
+  @override
+  String get scenes_field_scene_date => 'シーンの日付';
+
+  @override
+  String get scenes_field_scene_created_at => 'シーンの作成日';
+
+  @override
+  String get scenes_field_scene_updated_at => 'シーンの更新日時';
+
+  @override
+  String get scenes_field_sub_group_count => 'サブグループ数';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return '現在再生中: $title。タップしてシーンの詳細を開きます。';
+  }
+
+  @override
+  String scenes_delete_failed(String error) {
+    return 'シーンの削除に失敗しました: $error';
+  }
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -3006,4 +3006,26 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get auto_missing_field => '누락된 필드';
+
+  @override
+  String get scenes_field_scene_date => '장면 날짜';
+
+  @override
+  String get scenes_field_scene_created_at => '장면 생성 시간';
+
+  @override
+  String get scenes_field_scene_updated_at => '장면 업데이트 시간';
+
+  @override
+  String get scenes_field_sub_group_count => '하위 그룹 수';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return '지금 재생 중: $title. 장면 세부정보를 열려면 탭하세요.';
+  }
+
+  @override
+  String scenes_delete_failed(String error) {
+    return '장면을 삭제하지 못했습니다: $error';
+  }
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3108,4 +3108,26 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get auto_missing_field => 'Отсутствует поле';
+
+  @override
+  String get scenes_field_scene_date => 'Дата сцены';
+
+  @override
+  String get scenes_field_scene_created_at => 'Сцена создана в';
+
+  @override
+  String get scenes_field_scene_updated_at => 'Сцена обновлена ​​в';
+
+  @override
+  String get scenes_field_sub_group_count => 'Количество подгрупп';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return 'Сейчас играет: $title. Нажмите, чтобы открыть сведения о сцене.';
+  }
+
+  @override
+  String scenes_delete_failed(String error) {
+    return 'Не удалось удалить сцену: $error';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2951,6 +2951,28 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get auto_missing_field => '缺失字段';
+
+  @override
+  String get scenes_field_scene_date => '场景日期';
+
+  @override
+  String get scenes_field_scene_created_at => '场景创建于';
+
+  @override
+  String get scenes_field_scene_updated_at => '场景更新于';
+
+  @override
+  String get scenes_field_sub_group_count => '子组计数';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return '正在播放：$title。点击可打开场景详细信息。';
+  }
+
+  @override
+  String scenes_delete_failed(String error) {
+    return '无法删除场景：$error';
+  }
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -5900,6 +5922,28 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get auto_missing_field => '缺失字段';
+
+  @override
+  String get scenes_field_scene_date => '场景日期';
+
+  @override
+  String get scenes_field_scene_created_at => '场景创建于';
+
+  @override
+  String get scenes_field_scene_updated_at => '场景更新于';
+
+  @override
+  String get scenes_field_sub_group_count => '子组计数';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return '正在播放：$title。点击可打开场景详细信息。';
+  }
+
+  @override
+  String scenes_delete_failed(String error) {
+    return '无法删除场景：$error';
+  }
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -8853,4 +8897,26 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get auto_missing_field => '缺失字段';
+
+  @override
+  String get scenes_field_scene_date => '場景日期';
+
+  @override
+  String get scenes_field_scene_created_at => '場景創建於';
+
+  @override
+  String get scenes_field_scene_updated_at => '場景更新於';
+
+  @override
+  String get scenes_field_sub_group_count => '子組計數';
+
+  @override
+  String mini_player_now_playing(String title) {
+    return '正在播放：$title。點擊可開啟場景詳細資訊。';
+  }
+
+  @override
+  String scenes_delete_failed(String error) {
+    return '無法刪除場景：$error';
+  }
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1067,5 +1067,11 @@
   "settings_interface_entity_image_filtering_direct": "Прямая сущность",
   "settings_interface_entity_image_filtering_galleries": "Связанные галереи",
   "auto_marker_name": "Имя маркера",
-  "auto_missing_field": "Отсутствует поле"
+  "auto_missing_field": "Отсутствует поле",
+  "scenes_field_scene_date": "Дата сцены",
+  "scenes_field_scene_created_at": "Сцена создана в",
+  "scenes_field_scene_updated_at": "Сцена обновлена ​​в",
+  "scenes_field_sub_group_count": "Количество подгрупп",
+  "mini_player_now_playing": "Сейчас играет: {title}. Нажмите, чтобы открыть сведения о сцене.",
+  "scenes_delete_failed": "Не удалось удалить сцену: {error}"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1067,5 +1067,11 @@
   "settings_interface_entity_image_filtering_direct": "直接实体",
   "settings_interface_entity_image_filtering_galleries": "关联图库",
   "auto_marker_name": "标记名称",
-  "auto_missing_field": "缺失字段"
+  "auto_missing_field": "缺失字段",
+  "scenes_field_scene_date": "场景日期",
+  "scenes_field_scene_created_at": "场景创建于",
+  "scenes_field_scene_updated_at": "场景更新于",
+  "scenes_field_sub_group_count": "子组计数",
+  "mini_player_now_playing": "正在播放：{title}。点击可打开场景详细信息。",
+  "scenes_delete_failed": "无法删除场景：{error}"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1053,5 +1053,11 @@
   "settings_interface_entity_image_filtering_direct": "直接实体",
   "settings_interface_entity_image_filtering_galleries": "关联图库",
   "auto_marker_name": "标记名称",
-  "auto_missing_field": "缺失字段"
+  "auto_missing_field": "缺失字段",
+  "scenes_field_scene_date": "场景日期",
+  "scenes_field_scene_created_at": "场景创建于",
+  "scenes_field_scene_updated_at": "场景更新于",
+  "scenes_field_sub_group_count": "子组计数",
+  "mini_player_now_playing": "正在播放：{title}。点击可打开场景详细信息。",
+  "scenes_delete_failed": "无法删除场景：{error}"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1053,5 +1053,11 @@
   "settings_interface_entity_image_filtering_direct": "直接實體",
   "settings_interface_entity_image_filtering_galleries": "關聯圖庫",
   "auto_marker_name": "標記名稱",
-  "auto_missing_field": "缺失字段"
+  "auto_missing_field": "缺失字段",
+  "scenes_field_scene_date": "場景日期",
+  "scenes_field_scene_created_at": "場景創建於",
+  "scenes_field_scene_updated_at": "場景更新於",
+  "scenes_field_sub_group_count": "子組計數",
+  "mini_player_now_playing": "正在播放：{title}。點擊可開啟場景詳細資訊。",
+  "scenes_delete_failed": "無法刪除場景：{error}"
 }


### PR DESCRIPTION
## What
Replaced hardcoded user-facing strings across the app with appropriate l10n keys and generated translations for all supported locales.

## Why
To ensure the app is fully localized and accessible to users in different languages.

## Impact
Users will now see localized text for Scene Date, Sub-group Count, mini player, and error messages.

## Measurement
All tests pass and the UI displays localized strings correctly.

---
*PR created automatically by Jules for task [5471931415425306196](https://jules.google.com/task/5471931415425306196) started by @Alchemist-Aloha*