### PR TITLE
⚡ Bolt: Throttle rapid pagination scroll events

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,6 @@
 ## 2024-05-30 - [Hoist textTheme and dimensions from ListView itemBuilder]
 **Learning:** Performing invariant lookups like `context.textTheme` and `context.dimensions.fontSizeFactor` inside a `ListView.builder`'s `itemBuilder` callback forces redundant O(1) inherited widget lookups on every single rendered item during scroll.
 **Action:** Always hoist these layout and styling variables out of the `itemBuilder` and into the parent widget's `build` (or builder) method to reduce GC pressure and ensure optimal rendering performance.
+## 2024-05-18 - Throttle Pagination Calls
+**Learning:** In Flutter, `NotificationListener<ScrollNotification>` fires incredibly rapidly during scrolling. If the `onNotification` callback performs any logic that calls an external function (like `widget.onFetchNextPage?.call()`) without debouncing or throttling, it can lead to massive redundant calls and performance drops, especially when fetching data.
+**Action:** Always wrap pagination or intensive operations triggered by scroll notifications with a throttle check (e.g., comparing `DateTime.now()` against a stored `_lastFetchTime`) to prevent them from executing repeatedly on every single scroll frame.

--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -168,6 +168,7 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
 
   DateTime? _lastHorizontalSwipeTime;
   static const _horizontalSwipeThreshold = Duration(milliseconds: 500);
+  DateTime? _lastFetchTime;
 
   @override
   void initState() {
@@ -762,7 +763,13 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                       return NotificationListener<ScrollNotification>(
                         onNotification: (ScrollNotification scrollInfo) {
                           if (shouldLoadNextPage(scrollInfo.metrics)) {
-                            widget.onFetchNextPage?.call();
+                            final now = DateTime.now();
+                            if (_lastFetchTime == null ||
+                                now.difference(_lastFetchTime!) >
+                                    const Duration(milliseconds: 500)) {
+                              _lastFetchTime = now;
+                              widget.onFetchNextPage?.call();
+                            }
                           }
                           return false;
                         },


### PR DESCRIPTION
💡 What: Throttled the `onFetchNextPage` callback in `ListPageScaffold`'s `NotificationListener<ScrollNotification>` to only trigger at most once every 500 milliseconds.
🎯 Why: `ScrollNotification` fires extremely rapidly during scrolling. When the user reached the end of the list, `shouldLoadNextPage` would return true continuously, leading to dozens of redundant pagination calls in quick succession.
📊 Impact: Significantly reduces unnecessary network requests, provider reads, and potential UI jank caused by spamming pagination logic.
🔬 Measurement: Scroll to the bottom of any list view (e.g., scenes list) and observe the network/console logs; pagination fetch should only trigger once per half-second threshold.

---
*PR created automatically by Jules for task [15759222073708111413](https://jules.google.com/task/15759222073708111413) started by @Alchemist-Aloha*