### PR TITLE
⚡ Bolt: Throttle pagination data fetch on scroll

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,6 @@
 ## 2024-05-30 - [Hoist textTheme and dimensions from ListView itemBuilder]
 **Learning:** Performing invariant lookups like `context.textTheme` and `context.dimensions.fontSizeFactor` inside a `ListView.builder`'s `itemBuilder` callback forces redundant O(1) inherited widget lookups on every single rendered item during scroll.
 **Action:** Always hoist these layout and styling variables out of the `itemBuilder` and into the parent widget's `build` (or builder) method to reduce GC pressure and ensure optimal rendering performance.
+## 2024-06-29 - Throttle pagination data fetch on scroll
+**Learning:** The `NotificationListener<ScrollNotification>` callback in Flutter, when used for pagination (e.g. checking if `metrics.pixels >= maxScrollExtent - threshold`), will fire continuously on every frame while the user remains within the threshold zone at the bottom of the list. This leads to massive O(N) redundant network requests and synchronous evaluations in rapid succession if not throttled.
+**Action:** Always maintain a throttle (e.g., a `DateTime` comparison tracking the last fetch execution to limit calls to once every ~500ms) or short-circuit logic based on tracking visible indexes when executing expensive operations inside scroll notification listeners.

--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -167,6 +167,7 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
   final GlobalKey _firstItemKey = GlobalKey();
 
   DateTime? _lastHorizontalSwipeTime;
+  DateTime? _lastFetchTime;
   static const _horizontalSwipeThreshold = Duration(milliseconds: 500);
 
   @override
@@ -762,7 +763,17 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                       return NotificationListener<ScrollNotification>(
                         onNotification: (ScrollNotification scrollInfo) {
                           if (shouldLoadNextPage(scrollInfo.metrics)) {
-                            widget.onFetchNextPage?.call();
+                            // ⚡ Bolt: Throttle pagination data fetch on scroll.
+                            // The scroll listener fires continuously when near the bottom.
+                            // We throttle fetching to once per 500ms to prevent massive O(N)
+                            // redundant requests and rebuilds.
+                            final now = DateTime.now();
+                            if (_lastFetchTime == null ||
+                                now.difference(_lastFetchTime!) >
+                                    const Duration(milliseconds: 500)) {
+                              _lastFetchTime = now;
+                              widget.onFetchNextPage?.call();
+                            }
                           }
                           return false;
                         },


### PR DESCRIPTION
💡 What: Throttled the `onFetchNextPage` callback in `ListPageScaffold` using a 500ms delay check via a new `DateTime? _lastFetchTime` state variable.

🎯 Why: Without throttling, `shouldLoadNextPage` evaluates to true for many frames while scrolling near the bottom of lists. This triggers redundant, expensive fetch operations that can degrade scrolling performance and strain backend resources, especially in continuous scroll views.

📊 Impact: Substantially reduces unnecessary duplicated network requests and synchronous evaluations when reaching the bottom of a list, ensuring smoother scroll performance.

🔬 Measurement: Verified locally that pulling to the end of a long list only triggers the pagination fetch once every 500ms rather than dozens of times in rapid succession.

---
*PR created automatically by Jules for task [8518274780424239379](https://jules.google.com/task/8518274780424239379) started by @Alchemist-Aloha*