### PR TITLE
Fix hardcoded filter saved strings

### DIFF
--- a/lib/features/galleries/presentation/pages/galleries_page.dart
+++ b/lib/features/galleries/presentation/pages/galleries_page.dart
@@ -203,7 +203,7 @@ class _GalleriesPageState extends ConsumerState<GalleriesPage> {
         descending: sortConfig.descending,
         activeFilterCount: _activeFilterCount(effectiveFilter),
         defaultSortLabel: 'path',
-        saveSuccessMessage: 'Gallery filter saved to server',
+        saveSuccessMessage: context.l10n.saved_item('Gallery filter'),
         loadPresets: () => ref
             .read(savedFilterRepositoryProvider)
             .findAll(

--- a/lib/features/galleries/presentation/widgets/entity_gallery_grid.dart
+++ b/lib/features/galleries/presentation/widgets/entity_gallery_grid.dart
@@ -241,7 +241,7 @@ class _EntityGalleryGridState extends ConsumerState<EntityGalleryGrid> {
         descending: sortConfig.descending,
         activeFilterCount: _activeFilterCount(effectiveFilter),
         defaultSortLabel: 'path',
-        saveSuccessMessage: 'Gallery filter saved to server',
+        saveSuccessMessage: context.l10n.saved_item('Gallery filter'),
         loadPresets: () => ref
             .read(savedFilterRepositoryProvider)
             .findAll(

--- a/lib/features/groups/presentation/pages/groups_page.dart
+++ b/lib/features/groups/presentation/pages/groups_page.dart
@@ -152,7 +152,7 @@ class _GroupsPageState extends ConsumerState<GroupsPage> {
         descending: sortConfig.descending,
         activeFilterCount: _activeFilterCount(),
         defaultSortLabel: 'name',
-        saveSuccessMessage: 'Group filter saved to server',
+        saveSuccessMessage: context.l10n.saved_item('Group filter'),
         loadPresets: () => ref
             .read(savedFilterRepositoryProvider)
             .findAll(

--- a/lib/features/images/presentation/pages/images_page.dart
+++ b/lib/features/images/presentation/pages/images_page.dart
@@ -207,7 +207,7 @@ class _ImagesPageState extends ConsumerState<ImagesPage> {
         descending: sortConfig.descending,
         activeFilterCount: _activeFilterCount(effectiveFilter),
         defaultSortLabel: 'path',
-        saveSuccessMessage: 'Image filter saved to server',
+        saveSuccessMessage: context.l10n.saved_item('Image filter'),
         loadPresets: () => ref
             .read(savedFilterRepositoryProvider)
             .findAll(

--- a/lib/features/performers/presentation/pages/performers_page.dart
+++ b/lib/features/performers/presentation/pages/performers_page.dart
@@ -249,7 +249,7 @@ class _PerformersPageState extends ConsumerState<PerformersPage> {
         descending: sortConfig.descending,
         activeFilterCount: _activeFilterCount(filter),
         defaultSortLabel: 'name',
-        saveSuccessMessage: 'Performer filter saved to server',
+        saveSuccessMessage: context.l10n.saved_item('Performer filter'),
         loadPresets: () => ref
             .read(savedFilterRepositoryProvider)
             .findAll(

--- a/lib/features/scenes/presentation/widgets/scene_marker_filter_panel.dart
+++ b/lib/features/scenes/presentation/widgets/scene_marker_filter_panel.dart
@@ -52,7 +52,7 @@ class _SceneMarkerFilterPanelState
         ref.read(sceneMarkerFilterStateProvider.notifier).update(_tempFilter);
         await ref.read(sceneMarkerFilterStateProvider.notifier).saveAsDefault();
       },
-      saveDefaultSuccessMessage: 'Marker filter saved as default',
+      saveDefaultSuccessMessage: context.l10n.scenes_filter_saved,
     );
   }
 

--- a/lib/features/scenes/presentation/widgets/scene_marker_saved_filter_dialog.dart
+++ b/lib/features/scenes/presentation/widgets/scene_marker_saved_filter_dialog.dart
@@ -5,6 +5,7 @@ import '../../../../core/presentation/widgets/saved_filter_dialog.dart';
 import '../../domain/entities/scene_marker.dart';
 import '../../domain/entities/scene_marker_saved_filter_config.dart';
 import '../providers/scene_marker_list_provider.dart';
+import '../../../../core/utils/l10n_extensions.dart';
 
 class SceneMarkerSavedFilterDialog extends ConsumerStatefulWidget {
   const SceneMarkerSavedFilterDialog({
@@ -41,7 +42,7 @@ class _SceneMarkerSavedFilterDialogState
           .where((value) => value != null)
           .length,
       defaultSortLabel: 'created_at',
-      saveSuccessMessage: 'Marker filter saved to server',
+      saveSuccessMessage: context.l10n.saved_item('Marker filter'),
       loadPresets: () =>
           ref.read(sceneMarkerSavedFilterRepositoryProvider).findAll(),
       savePreset: ({required String name, String? existingId}) {

--- a/lib/features/scenes/presentation/widgets/scene_saved_filter_dialog.dart
+++ b/lib/features/scenes/presentation/widgets/scene_saved_filter_dialog.dart
@@ -5,6 +5,7 @@ import '../../../../core/presentation/widgets/saved_filter_dialog.dart';
 import '../../domain/entities/scene_filter.dart';
 import '../../domain/entities/scene_saved_filter_config.dart';
 import '../providers/scene_list_provider.dart';
+import '../../../../core/utils/l10n_extensions.dart';
 
 class SceneSavedFilterDialog extends ConsumerStatefulWidget {
   const SceneSavedFilterDialog({
@@ -41,7 +42,7 @@ class _SceneSavedFilterDialogState
           .where((value) => value != null)
           .length,
       defaultSortLabel: 'date',
-      saveSuccessMessage: 'Scene filter saved to server',
+      saveSuccessMessage: context.l10n.saved_item('Scene filter'),
       loadPresets: () => ref.read(sceneSavedFilterRepositoryProvider).findAll(),
       savePreset: ({required String name, String? existingId}) {
         return ref

--- a/lib/features/studios/presentation/pages/studios_page.dart
+++ b/lib/features/studios/presentation/pages/studios_page.dart
@@ -176,7 +176,7 @@ class _StudiosPageState extends ConsumerState<StudiosPage> {
         descending: sortConfig.descending,
         activeFilterCount: _activeFilterCount(filter),
         defaultSortLabel: 'name',
-        saveSuccessMessage: 'Studio filter saved to server',
+        saveSuccessMessage: context.l10n.saved_item('Studio filter'),
         loadPresets: () => ref
             .read(savedFilterRepositoryProvider)
             .findAll(

--- a/lib/features/tags/presentation/pages/tags_page.dart
+++ b/lib/features/tags/presentation/pages/tags_page.dart
@@ -170,7 +170,7 @@ class _TagsPageState extends ConsumerState<TagsPage> {
         descending: sortConfig.descending,
         activeFilterCount: favoritesOnly ? 1 : 0,
         defaultSortLabel: 'name',
-        saveSuccessMessage: 'Tag filter saved to server',
+        saveSuccessMessage: context.l10n.saved_item('Tag filter'),
         loadPresets: () => ref
             .read(savedFilterRepositoryProvider)
             .findAll(

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -69,8 +69,7 @@ import 'app_localizations_zh.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -78,8 +77,7 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate =
-      _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -91,27 +89,26 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
-      <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
+    Locale('de'),
     Locale('en'),
-    Locale('it'),
     Locale('es'),
     Locale('fr'),
-    Locale('de'),
-    Locale('ru'),
+    Locale('it'),
     Locale('ja'),
     Locale('ko'),
-    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'),
-    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'),
+    Locale('ru'),
     Locale('zh'),
+    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'),
+    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant')
   ];
 
   /// The name of the application
@@ -5527,8 +5524,7 @@ abstract class AppLocalizations {
   String get auto_missing_field;
 }
 
-class _AppLocalizationsDelegate
-    extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -5537,63 +5533,42 @@ class _AppLocalizationsDelegate
   }
 
   @override
-  bool isSupported(Locale locale) => <String>[
-    'de',
-    'en',
-    'es',
-    'fr',
-    'it',
-    'ja',
-    'ko',
-    'ru',
-    'zh',
-  ].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['de', 'en', 'es', 'fr', 'it', 'ja', 'ko', 'ru', 'zh'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
+
   // Lookup logic when language+script codes are specified.
   switch (locale.languageCode) {
-    case 'zh':
-      {
-        switch (locale.scriptCode) {
-          case 'Hans':
-            return AppLocalizationsZhHans();
-          case 'Hant':
-            return AppLocalizationsZhHant();
-        }
-        break;
-      }
+    case 'zh': {
+  switch (locale.scriptCode) {
+    case 'Hans': return AppLocalizationsZhHans();
+case 'Hant': return AppLocalizationsZhHant();
+   }
+  break;
+   }
   }
 
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'de':
-      return AppLocalizationsDe();
-    case 'en':
-      return AppLocalizationsEn();
-    case 'es':
-      return AppLocalizationsEs();
-    case 'fr':
-      return AppLocalizationsFr();
-    case 'it':
-      return AppLocalizationsIt();
-    case 'ja':
-      return AppLocalizationsJa();
-    case 'ko':
-      return AppLocalizationsKo();
-    case 'ru':
-      return AppLocalizationsRu();
-    case 'zh':
-      return AppLocalizationsZh();
+    case 'de': return AppLocalizationsDe();
+    case 'en': return AppLocalizationsEn();
+    case 'es': return AppLocalizationsEs();
+    case 'fr': return AppLocalizationsFr();
+    case 'it': return AppLocalizationsIt();
+    case 'ja': return AppLocalizationsJa();
+    case 'ko': return AppLocalizationsKo();
+    case 'ru': return AppLocalizationsRu();
+    case 'zh': return AppLocalizationsZh();
   }
 
   throw FlutterError(
     'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
     'an issue with the localizations generation tool. Please file an issue '
     'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
+    'that was used.'
   );
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -45,6 +45,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String nScenes(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -62,6 +63,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String nPerformers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -79,6 +81,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String nPlays(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -150,8 +153,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get common_hide => 'Ausblenden';
 
   @override
-  String get galleries_filter_saved =>
-      'Filtereinstellungen als Standard gespeichert';
+  String get galleries_filter_saved => 'Filtereinstellungen als Standard gespeichert';
 
   @override
   String get common_setup_required => 'Einrichtung erforderlich';
@@ -178,8 +180,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get studios_filter_title => 'Studios filtern';
 
   @override
-  String get studios_filter_saved =>
-      'Filtereinstellungen als Standard gespeichert';
+  String get studios_filter_saved => 'Filtereinstellungen als Standard gespeichert';
 
   @override
   String get sort_name => 'Name';
@@ -278,19 +279,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get sort_last_played_at => 'Zuletzt abgespielt am';
 
   @override
-  String get studios_sort_saved =>
-      'Sortiereinstellungen als Standard gespeichert';
+  String get studios_sort_saved => 'Sortiereinstellungen als Standard gespeichert';
 
   @override
-  String get studios_no_random =>
-      'Keine Studios für zufällige Navigation verfügbar';
+  String get studios_no_random => 'Keine Studios für zufällige Navigation verfügbar';
 
   @override
   String get tags_filter_title => 'Tags filtern';
 
   @override
-  String get tags_filter_saved =>
-      'Filtereinstellungen als Standard gespeichert';
+  String get tags_filter_saved => 'Filtereinstellungen als Standard gespeichert';
 
   @override
   String get tags_sort_title => 'Tags sortieren';
@@ -302,16 +300,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get tags_no_random => 'Keine Tags für zufällige Navigation verfügbar';
 
   @override
-  String get scenes_no_random =>
-      'Keine Szenen für zufällige Navigation verfügbar';
+  String get scenes_no_random => 'Keine Szenen für zufällige Navigation verfügbar';
 
   @override
-  String get performers_no_random =>
-      'Keine Darsteller für zufällige Navigation verfügbar';
+  String get performers_no_random => 'Keine Darsteller für zufällige Navigation verfügbar';
 
   @override
-  String get galleries_no_random =>
-      'Keine Galerien für zufällige Navigation verfügbar';
+  String get galleries_no_random => 'Keine Galerien für zufällige Navigation verfügbar';
 
   @override
   String common_error(String message) {
@@ -596,8 +591,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get scenes_filter_title => 'Szenen filtern';
 
   @override
-  String get scenes_filter_saved =>
-      'Filtereinstellungen als Standard gespeichert';
+  String get scenes_filter_saved => 'Filtereinstellungen als Standard gespeichert';
 
   @override
   String get scenes_watched => 'Gesehen';
@@ -678,8 +672,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get scenes_sort_code => 'Code';
 
   @override
-  String get scenes_sort_saved_default =>
-      'Sortiereinstellungen als Standard gespeichert';
+  String get scenes_sort_saved_default => 'Sortiereinstellungen als Standard gespeichert';
 
   @override
   String get scenes_sort_tooltip => 'Sortieroptionen';
@@ -950,8 +943,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_customize => 'StashFlow anpassen';
 
   @override
-  String get settings_customize_subtitle =>
-      'Wiedergabe, Aussehen, Layout und Support-Tools an einem Ort optimieren.';
+  String get settings_customize_subtitle => 'Wiedergabe, Aussehen, Layout und Support-Tools an einem Ort optimieren.';
 
   @override
   String get settings_core_section => 'Kern-Einstellungen';
@@ -975,8 +967,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_keyboard => 'Tastatur';
 
   @override
-  String get settings_keyboard_subtitle =>
-      'Anpassbare Verknüpfungen und Hotkeys';
+  String get settings_keyboard_subtitle => 'Anpassbare Verknüpfungen und Hotkeys';
 
   @override
   String get settings_keyboard_title => 'Tastaturkürzel';
@@ -1006,16 +997,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_keyboard_prev_scene => 'Vorherige Szene';
 
   @override
-  String get settings_keyboard_increase_speed =>
-      'Wiedergabegeschwindigkeit erhöhen';
+  String get settings_keyboard_increase_speed => 'Wiedergabegeschwindigkeit erhöhen';
 
   @override
-  String get settings_keyboard_decrease_speed =>
-      'Wiedergabegeschwindigkeit verringern';
+  String get settings_keyboard_decrease_speed => 'Wiedergabegeschwindigkeit verringern';
 
   @override
-  String get settings_keyboard_reset_speed =>
-      'Wiedergabegeschwindigkeit zurücksetzen';
+  String get settings_keyboard_reset_speed => 'Wiedergabegeschwindigkeit zurücksetzen';
 
   @override
   String get settings_keyboard_close_player => 'Player schließen';
@@ -1030,24 +1018,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_keyboard_go_back => 'Zurückgehen';
 
   @override
-  String get settings_keyboard_play_pause_desc =>
-      'Zwischen Wiedergabe und Pause umschalten';
+  String get settings_keyboard_play_pause_desc => 'Zwischen Wiedergabe und Pause umschalten';
 
   @override
-  String get settings_keyboard_seek_forward_5_desc =>
-      '5 Sekunden vorwärts springen';
+  String get settings_keyboard_seek_forward_5_desc => '5 Sekunden vorwärts springen';
 
   @override
-  String get settings_keyboard_seek_backward_5_desc =>
-      '5 Sekunden rückwärts springen';
+  String get settings_keyboard_seek_backward_5_desc => '5 Sekunden rückwärts springen';
 
   @override
-  String get settings_keyboard_seek_forward_10_desc =>
-      '10 Sekunden vorwärts springen';
+  String get settings_keyboard_seek_forward_10_desc => '10 Sekunden vorwärts springen';
 
   @override
-  String get settings_keyboard_seek_backward_10_desc =>
-      '10 Sekunden rückwärts springen';
+  String get settings_keyboard_seek_backward_10_desc => '10 Sekunden rückwärts springen';
 
   @override
   String get settings_appearance => 'Erscheinungsbild';
@@ -1080,8 +1063,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_appearance_theme_mode => 'Design-Modus';
 
   @override
-  String get settings_appearance_theme_mode_subtitle =>
-      'Wählen Sie, wie die App auf Helligkeitsänderungen reagiert';
+  String get settings_appearance_theme_mode_subtitle => 'Wählen Sie, wie die App auf Helligkeitsänderungen reagiert';
 
   @override
   String get settings_appearance_theme_system => 'System';
@@ -1096,36 +1078,31 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_appearance_primary_color => 'Primärfarbe';
 
   @override
-  String get settings_appearance_primary_color_subtitle =>
-      'Wählen Sie eine Ausgangsfarbe für die Material 3-Palette';
+  String get settings_appearance_primary_color_subtitle => 'Wählen Sie eine Ausgangsfarbe für die Material 3-Palette';
 
   @override
   String get settings_appearance_advanced_theming => 'Erweitertes Theming';
 
   @override
-  String get settings_appearance_advanced_theming_subtitle =>
-      'Optimierungen für spezifische Bildschirmtypen';
+  String get settings_appearance_advanced_theming_subtitle => 'Optimierungen für spezifische Bildschirmtypen';
 
   @override
   String get settings_appearance_true_black => 'Echtes Schwarz (AMOLED)';
 
   @override
-  String get settings_appearance_true_black_subtitle =>
-      'Verwenden Sie rein schwarze Hintergründe im dunklen Modus, um Akku bei OLED-Bildschirmen zu sparen';
+  String get settings_appearance_true_black_subtitle => 'Verwenden Sie rein schwarze Hintergründe im dunklen Modus, um Akku bei OLED-Bildschirmen zu sparen';
 
   @override
   String get settings_appearance_custom_hex => 'Benutzerdefinierte Hex-Farbe';
 
   @override
-  String get settings_appearance_custom_hex_helper =>
-      'Geben Sie einen 8-stelligen ARGB-Hex-Code ein';
+  String get settings_appearance_custom_hex_helper => 'Geben Sie einen 8-stelligen ARGB-Hex-Code ein';
 
   @override
   String get settings_appearance_font_size => 'Globale UI-Skala';
 
   @override
-  String get settings_appearance_font_size_subtitle =>
-      'Skalieren Sie Typografie und Abstände proportional';
+  String get settings_appearance_font_size_subtitle => 'Skalieren Sie Typografie und Abstände proportional';
 
   @override
   String get settings_interface_title => 'Interface-Einstellungen';
@@ -1134,8 +1111,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_interface_language => 'Sprache';
 
   @override
-  String get settings_interface_language_subtitle =>
-      'Die Standard-Systemsprache überschreiben';
+  String get settings_interface_language_subtitle => 'Die Standard-Systemsprache überschreiben';
 
   @override
   String get settings_interface_app_language => 'App-Sprache';
@@ -1144,103 +1120,82 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_interface_navigation => 'Navigation';
 
   @override
-  String get settings_interface_navigation_subtitle =>
-      'Sichtbarkeit globaler Navigationskürzel';
+  String get settings_interface_navigation_subtitle => 'Sichtbarkeit globaler Navigationskürzel';
 
   @override
-  String get settings_interface_show_random =>
-      'Zufalls-Navigationsschaltflächen anzeigen';
+  String get settings_interface_show_random => 'Zufalls-Navigationsschaltflächen anzeigen';
 
   @override
-  String get settings_interface_show_random_subtitle =>
-      'Aktivieren oder deaktivieren Sie die schwebenden Casino-Schaltflächen auf Listen- und Detailseiten';
+  String get settings_interface_show_random_subtitle => 'Aktivieren oder deaktivieren Sie die schwebenden Casino-Schaltflächen auf Listen- und Detailseiten';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation =>
-      'Schwerkraftgesteuerte Ausrichtung (Hauptseiten)';
+  String get settings_interface_main_pages_gravity_orientation => 'Schwerkraftgesteuerte Ausrichtung (Hauptseiten)';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation_subtitle =>
-      'Erlaube Hauptseiten, sich mithilfe des Gerätesensors zu drehen. Die Vollbild-Videowiedergabe verwendet eigene Ausrichtungseinstellungen.';
+  String get settings_interface_main_pages_gravity_orientation_subtitle => 'Erlaube Hauptseiten, sich mithilfe des Gerätesensors zu drehen. Die Vollbild-Videowiedergabe verwendet eigene Ausrichtungseinstellungen.';
 
   @override
   String get settings_interface_show_edit => 'Bearbeiten-Schaltfläche anzeigen';
 
   @override
-  String get settings_interface_show_edit_subtitle =>
-      'Aktivieren oder deaktivieren Sie die Bearbeiten-Schaltfläche auf der Szenendetailseite';
+  String get settings_interface_show_edit_subtitle => 'Aktivieren oder deaktivieren Sie die Bearbeiten-Schaltfläche auf der Szenendetailseite';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer =>
-      'Echtes Szenenvideo im Miniplayer verwenden';
+  String get settings_interface_use_actual_scene_video_miniplayer => 'Echtes Szenenvideo im Miniplayer verwenden';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer_subtitle =>
-      'Zeigt bei aktiver Wiedergabe die Live-Videofläche statt des Szenen-Screenshots an.';
+  String get settings_interface_use_actual_scene_video_miniplayer_subtitle => 'Zeigt bei aktiver Wiedergabe die Live-Videofläche statt des Szenen-Screenshots an.';
 
   @override
-  String get settings_interface_entity_image_filtering =>
-      'Entitätsbildfilterung';
+  String get settings_interface_entity_image_filtering => 'Entitätsbildfilterung';
 
   @override
-  String get settings_interface_entity_image_filtering_subtitle =>
-      'Wählen Sie, ob Entitätsbildseiten mit Bildmetadaten oder zugehörigen Galerien übereinstimmen sollen.';
+  String get settings_interface_entity_image_filtering_subtitle => 'Wählen Sie, ob Entitätsbildseiten mit Bildmetadaten oder zugehörigen Galerien übereinstimmen sollen.';
 
   @override
-  String get settings_interface_entity_image_filtering_direct =>
-      'Direkte Entität';
+  String get settings_interface_entity_image_filtering_direct => 'Direkte Entität';
 
   @override
-  String get settings_interface_entity_image_filtering_galleries =>
-      'Zugehörige Galerien';
+  String get settings_interface_entity_image_filtering_galleries => 'Zugehörige Galerien';
 
   @override
   String get settings_interface_customize_tabs => 'Tabs anpassen';
 
   @override
-  String get settings_interface_customize_tabs_subtitle =>
-      'Navigationselemente neu anordnen oder ausblenden';
+  String get settings_interface_customize_tabs_subtitle => 'Navigationselemente neu anordnen oder ausblenden';
 
   @override
   String get settings_interface_scenes_layout => 'Szenen-Layout';
 
   @override
-  String get settings_interface_scenes_layout_subtitle =>
-      'Standard-Browsing-Modus für Szenen';
+  String get settings_interface_scenes_layout_subtitle => 'Standard-Browsing-Modus für Szenen';
 
   @override
   String get settings_interface_galleries_layout => 'Galerien-Layout';
 
   @override
-  String get settings_interface_galleries_layout_subtitle =>
-      'Standard-Browsing-Modus für Galerien';
+  String get settings_interface_galleries_layout_subtitle => 'Standard-Browsing-Modus für Galerien';
 
   @override
-  String get settings_interface_max_performer_avatars =>
-      'Maximale Darsteller-Avatare';
+  String get settings_interface_max_performer_avatars => 'Maximale Darsteller-Avatare';
 
   @override
-  String get settings_interface_max_performer_avatars_subtitle =>
-      'Maximale Anzahl der Darsteller-Avatare, die in der Szenenkarte angezeigt werden.';
+  String get settings_interface_max_performer_avatars_subtitle => 'Maximale Anzahl der Darsteller-Avatare, die in der Szenenkarte angezeigt werden.';
 
   @override
-  String get settings_interface_show_performer_avatars =>
-      'Darsteller-Avatare anzeigen';
+  String get settings_interface_show_performer_avatars => 'Darsteller-Avatare anzeigen';
 
   @override
-  String get settings_interface_show_performer_avatars_subtitle =>
-      'Darsteller-Symbole auf Szenenkarten auf allen Plattformen anzeigen.';
+  String get settings_interface_show_performer_avatars_subtitle => 'Darsteller-Symbole auf Szenenkarten auf allen Plattformen anzeigen.';
 
   @override
-  String get settings_interface_performer_avatar_size =>
-      'Größe der Darsteller-Avatare';
+  String get settings_interface_performer_avatar_size => 'Größe der Darsteller-Avatare';
 
   @override
   String get settings_interface_layout_default => 'Standard-Layout';
 
   @override
-  String get settings_interface_layout_default_desc =>
-      'Wählen Sie das Standard-Layout für die Seite';
+  String get settings_interface_layout_default_desc => 'Wählen Sie das Standard-Layout für die Seite';
 
   @override
   String get settings_interface_layout_list => 'Liste';
@@ -1258,15 +1213,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_interface_image_viewer => 'Bildbetrachter';
 
   @override
-  String get settings_interface_image_viewer_subtitle =>
-      'Vollbild-Bild-Browsing-Verhalten konfigurieren';
+  String get settings_interface_image_viewer_subtitle => 'Vollbild-Bild-Browsing-Verhalten konfigurieren';
 
   @override
   String get settings_interface_swipe_direction => 'Vollbild-Wischrichtung';
 
   @override
-  String get settings_interface_swipe_direction_desc =>
-      'Wählen Sie, wie Bilder im Vollbildmodus gewechselt werden';
+  String get settings_interface_swipe_direction_desc => 'Wählen Sie, wie Bilder im Vollbildmodus gewechselt werden';
 
   @override
   String get settings_interface_swipe_vertical => 'Vertikal';
@@ -1281,36 +1234,31 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_interface_performer_layouts => 'Darsteller-Layouts';
 
   @override
-  String get settings_interface_performer_layouts_subtitle =>
-      'Medien- und Galerie-Standards für Darsteller';
+  String get settings_interface_performer_layouts_subtitle => 'Medien- und Galerie-Standards für Darsteller';
 
   @override
   String get settings_interface_studio_layouts => 'Studio-Layouts';
 
   @override
-  String get settings_interface_studio_layouts_subtitle =>
-      'Medien- und Galerie-Standards für Studios';
+  String get settings_interface_studio_layouts_subtitle => 'Medien- und Galerie-Standards für Studios';
 
   @override
   String get settings_interface_tag_layouts => 'Tag-Layouts';
 
   @override
-  String get settings_interface_tag_layouts_subtitle =>
-      'Medien- und Galerie-Standards für Tags';
+  String get settings_interface_tag_layouts_subtitle => 'Medien- und Galerie-Standards für Tags';
 
   @override
   String get settings_interface_media_layout => 'Medien-Layout';
 
   @override
-  String get settings_interface_media_layout_subtitle =>
-      'Layout für die Medienseite';
+  String get settings_interface_media_layout_subtitle => 'Layout für die Medienseite';
 
   @override
   String get settings_interface_galleries_layout_item => 'Galerien-Layout';
 
   @override
-  String get settings_interface_galleries_layout_subtitle_item =>
-      'Layout für die Galerieseite';
+  String get settings_interface_galleries_layout_subtitle_item => 'Layout für die Galerieseite';
 
   @override
   String get settings_server_title => 'Server-Einstellungen';
@@ -1319,22 +1267,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_server_status => 'Verbindungsstatus';
 
   @override
-  String get settings_server_status_subtitle =>
-      'Live-Konnektivität zum konfigurierten Server';
+  String get settings_server_status_subtitle => 'Live-Konnektivität zum konfigurierten Server';
 
   @override
   String get settings_server_details => 'Server-Details';
 
   @override
-  String get settings_server_details_subtitle =>
-      'Endpunkt und Authentifizierungsmethode konfigurieren';
+  String get settings_server_details_subtitle => 'Endpunkt und Authentifizierungsmethode konfigurieren';
 
   @override
   String get settings_server_url => 'Stash-URL';
 
   @override
-  String get settings_server_url_helper =>
-      'Geben Sie die URL Ihres Stash-Servers ein. Wenn ein benutzerdefinierter Pfad konfiguriert ist, geben Sie diesen hier an.';
+  String get settings_server_url_helper => 'Geben Sie die URL Ihres Stash-Servers ein. Wenn ein benutzerdefinierter Pfad konfiguriert ist, geben Sie diesen hier an.';
 
   @override
   String get settings_server_url_example => 'http://192.168.1.100:9999';
@@ -1352,12 +1297,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_server_auth_password => 'Benutzername + Passwort';
 
   @override
-  String get settings_server_auth_password_desc =>
-      'Empfohlen: Verwenden Sie Ihre Stash Benutzername/Passwort-Sitzung.';
+  String get settings_server_auth_password_desc => 'Empfohlen: Verwenden Sie Ihre Stash Benutzername/Passwort-Sitzung.';
 
   @override
-  String get settings_server_auth_apikey_desc =>
-      'Verwenden Sie einen API-Key für die statische Token-Authentifizierung.';
+  String get settings_server_auth_apikey_desc => 'Verwenden Sie einen API-Key für die statische Token-Authentifizierung.';
 
   @override
   String get settings_server_username => 'Benutzername';
@@ -1394,12 +1337,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_server_invalid_url => 'Ungültige Server-URL';
 
   @override
-  String get settings_server_resolve_error =>
-      'Server-URL konnte nicht aufgelöst werden. Überprüfen Sie Host, Port und Zugangsdaten.';
+  String get settings_server_resolve_error => 'Server-URL konnte nicht aufgelöst werden. Überprüfen Sie Host, Port und Zugangsdaten.';
 
   @override
-  String get settings_server_logout_confirm =>
-      'Abgemeldet und Cookies gelöscht.';
+  String get settings_server_logout_confirm => 'Abgemeldet und Cookies gelöscht.';
 
   @override
   String get settings_server_profile_add => 'Profil hinzufügen';
@@ -1414,34 +1355,28 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_server_profile_delete => 'Profil löschen';
 
   @override
-  String get settings_server_profile_delete_confirm =>
-      'Sind Sie sicher, dass Sie dieses Profil löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.';
+  String get settings_server_profile_delete_confirm => 'Sind Sie sicher, dass Sie dieses Profil löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.';
 
   @override
   String get settings_server_profile_active => 'Aktiv';
 
   @override
-  String get settings_server_profile_empty =>
-      'Keine Serverprofile konfiguriert';
+  String get settings_server_profile_empty => 'Keine Serverprofile konfiguriert';
 
   @override
   String get settings_server_profiles => 'Serverprofile';
 
   @override
-  String get settings_server_profiles_subtitle =>
-      'Mehrere Stash-Serververbindungen verwalten';
+  String get settings_server_profiles_subtitle => 'Mehrere Stash-Serververbindungen verwalten';
 
   @override
-  String get settings_server_auth_status_logging_in =>
-      'Authentifizierungsstatus: Anmeldung...';
+  String get settings_server_auth_status_logging_in => 'Authentifizierungsstatus: Anmeldung...';
 
   @override
-  String get settings_server_auth_status_logged_in =>
-      'Authentifizierungsstatus: Angemeldet';
+  String get settings_server_auth_status_logged_in => 'Authentifizierungsstatus: Angemeldet';
 
   @override
-  String get settings_server_auth_status_logged_out =>
-      'Authentifizierungsstatus: Abgemeldet';
+  String get settings_server_auth_status_logged_out => 'Authentifizierungsstatus: Abgemeldet';
 
   @override
   String get settings_playback_title => 'Wiedergabe-Einstellungen';
@@ -1450,91 +1385,76 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_playback_behavior => 'Wiedergabeverhalten';
 
   @override
-  String get settings_playback_behavior_subtitle =>
-      'Standard-Wiedergabe- und Hintergrund-Handling';
+  String get settings_playback_behavior_subtitle => 'Standard-Wiedergabe- und Hintergrund-Handling';
 
   @override
   String get settings_playback_prefer_streams => 'sceneStreams bevorzugen';
 
   @override
-  String get settings_playback_prefer_streams_subtitle =>
-      'Wenn deaktiviert, wird die Wiedergabe direkt über paths.stream ausgeführt';
+  String get settings_playback_prefer_streams_subtitle => 'Wenn deaktiviert, wird die Wiedergabe direkt über paths.stream ausgeführt';
 
   @override
-  String get settings_playback_feed_random =>
-      'Feed an zufälliger Position starten';
+  String get settings_playback_feed_random => 'Feed an zufälliger Position starten';
 
   @override
-  String get settings_playback_feed_random_subtitle =>
-      'Beim Abspielen von Szenen im Feed-Modus an einer zufälligen Position zwischen 0% und 90% der Videolänge starten';
+  String get settings_playback_feed_random_subtitle => 'Beim Abspielen von Szenen im Feed-Modus an einer zufälligen Position zwischen 0% und 90% der Videolänge starten';
 
   @override
-  String get settings_playback_resume_position =>
-      'Von der letzten Spielposition aus fortfahren';
+  String get settings_playback_resume_position => 'Von der letzten Spielposition aus fortfahren';
 
   @override
-  String get settings_playback_resume_position_subtitle =>
-      'Wenn Sie ein Video öffnen, wird es automatisch an der Stelle fortgesetzt, an der Sie aufgehört haben';
+  String get settings_playback_resume_position_subtitle => 'Wenn Sie ein Video öffnen, wird es automatisch an der Stelle fortgesetzt, an der Sie aufgehört haben';
 
   @override
   String get settings_playback_end_behavior => 'Endeverhalten abspielen';
 
   @override
-  String get settings_playback_end_behavior_subtitle =>
-      'Was tun, wenn die aktuelle Wiedergabe endet?';
+  String get settings_playback_end_behavior_subtitle => 'Was tun, wenn die aktuelle Wiedergabe endet?';
 
   @override
   String get settings_playback_end_behavior_stop => 'Stoppen';
 
   @override
-  String get settings_playback_end_behavior_loop =>
-      'Aktuelle Szene wiederholen';
+  String get settings_playback_end_behavior_loop => 'Aktuelle Szene wiederholen';
 
   @override
   String get settings_playback_end_behavior_next => 'Nächste Szene abspielen';
 
   @override
-  String get settings_playback_autoplay =>
-      'Nächste Szene automatisch abspielen';
+  String get settings_playback_autoplay => 'Nächste Szene automatisch abspielen';
 
   @override
-  String get settings_playback_autoplay_subtitle =>
-      'Nächste Szene automatisch abspielen, wenn die aktuelle endet';
+  String get settings_playback_autoplay_subtitle => 'Nächste Szene automatisch abspielen, wenn die aktuelle endet';
 
   @override
   String get settings_playback_background => 'Hintergrund-Wiedergabe';
 
   @override
-  String get settings_playback_background_subtitle =>
-      'Video-Audio weiter abspielen, wenn die App im Hintergrund ist';
+  String get settings_playback_background_subtitle => 'Video-Audio weiter abspielen, wenn die App im Hintergrund ist';
 
   @override
   String get settings_playback_pip => 'Natives Bild-im-Bild';
 
   @override
-  String get settings_playback_pip_subtitle =>
-      'Android PiP-Schaltfläche aktivieren und automatisch bei Hintergrundwechsel starten';
+  String get settings_playback_pip_subtitle => 'Android PiP-Schaltfläche aktivieren und automatisch bei Hintergrundwechsel starten';
 
   @override
   String get settings_playback_subtitles => 'Untertitel-Einstellungen';
 
   @override
-  String get settings_playback_subtitles_subtitle =>
-      'Automatisches Laden und Erscheinungsbild';
+  String get settings_playback_subtitles_subtitle => 'Automatisches Laden und Erscheinungsbild';
 
   @override
   String get settings_playback_subtitle_lang => 'Standard-Untertitelsprache';
 
   @override
-  String get settings_playback_subtitle_lang_subtitle =>
-      'Automatisch laden, falls verfügbar';
+  String get settings_playback_subtitle_lang_subtitle => 'Automatisch laden, falls verfügbar';
 
   @override
   String get settings_playback_subtitle_size => 'Schriftgröße der Untertitel';
 
   @override
-  String get settings_playback_subtitle_pos =>
-      'Vertikale Position der Untertitel';
+  String get settings_playback_subtitle_pos => 'Vertikale Position der Untertitel';
 
   @override
   String settings_playback_subtitle_pos_desc(String percent) {
@@ -1542,27 +1462,22 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get settings_playback_subtitle_align =>
-      'Textausrichtung der Untertitel';
+  String get settings_playback_subtitle_align => 'Textausrichtung der Untertitel';
 
   @override
-  String get settings_playback_subtitle_align_subtitle =>
-      'Ausrichtung für mehrzeilige Untertitel';
+  String get settings_playback_subtitle_align_subtitle => 'Ausrichtung für mehrzeilige Untertitel';
 
   @override
   String get settings_playback_seek => 'Seek-Interaktion';
 
   @override
-  String get settings_playback_seek_subtitle =>
-      'Wählen Sie, wie das Vorspulen während der Wiedergabe funktioniert';
+  String get settings_playback_seek_subtitle => 'Wählen Sie, wie das Vorspulen während der Wiedergabe funktioniert';
 
   @override
-  String get settings_playback_seek_double_tap =>
-      'Doppeltippen links/rechts zum Springen (10s)';
+  String get settings_playback_seek_double_tap => 'Doppeltippen links/rechts zum Springen (10s)';
 
   @override
-  String get settings_playback_seek_drag =>
-      'Ziehen Sie auf der Zeitachse zum Suchen';
+  String get settings_playback_seek_drag => 'Ziehen Sie auf der Zeitachse zum Suchen';
 
   @override
   String get settings_playback_seek_drag_label => 'Ziehen';
@@ -1571,28 +1486,22 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_playback_seek_double_tap_label => 'Doppeltippen';
 
   @override
-  String get settings_playback_gravity_orientation =>
-      'Schwerkraftgesteuerte Ausrichtung';
+  String get settings_playback_gravity_orientation => 'Schwerkraftgesteuerte Ausrichtung';
 
   @override
-  String get settings_playback_direct_play =>
-      'Direkt-Wiedergabe bei Szenen-Navigation';
+  String get settings_playback_direct_play => 'Direkt-Wiedergabe bei Szenen-Navigation';
 
   @override
-  String get settings_playback_direct_play_subtitle =>
-      'Bei der Navigation von einer anderen spielenden Szene wird die neue Szene direkt abgespielt';
+  String get settings_playback_direct_play_subtitle => 'Bei der Navigation von einer anderen spielenden Szene wird die neue Szene direkt abgespielt';
 
   @override
-  String get settings_playback_gravity_orientation_subtitle =>
-      'Erlaube die Rotation zwischen passenden Ausrichtungen mithilfe des Gerätesensors (z. B. Landschaft links/rechts).';
+  String get settings_playback_gravity_orientation_subtitle => 'Erlaube die Rotation zwischen passenden Ausrichtungen mithilfe des Gerätesensors (z. B. Landschaft links/rechts).';
 
   @override
-  String get settings_playback_subtitle_lang_none_disabled =>
-      'Keine (Deaktiviert)';
+  String get settings_playback_subtitle_lang_none_disabled => 'Keine (Deaktiviert)';
 
   @override
-  String get settings_playback_subtitle_lang_auto_if_only_one =>
-      'Automatisch (Wenn nur eins)';
+  String get settings_playback_subtitle_lang_auto_if_only_one => 'Automatisch (Wenn nur eins)';
 
   @override
   String get settings_playback_subtitle_lang_english => 'Englisch';
@@ -1634,15 +1543,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_support_diagnostics => 'Diagnose und Projektinfo';
 
   @override
-  String get settings_support_diagnostics_subtitle =>
-      'Laufzeit-Logs öffnen oder zum Repository springen, wenn Sie Hilfe benötigen.';
+  String get settings_support_diagnostics_subtitle => 'Laufzeit-Logs öffnen oder zum Repository springen, wenn Sie Hilfe benötigen.';
 
   @override
   String get settings_support_update_available => 'Update verfügbar';
 
   @override
-  String get settings_support_update_available_subtitle =>
-      'Eine neuere Version ist auf GitHub verfügbar';
+  String get settings_support_update_available_subtitle => 'Eine neuere Version ist auf GitHub verfügbar';
 
   @override
   String settings_support_update_to(String version) {
@@ -1650,15 +1557,13 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get settings_support_update_to_subtitle =>
-      'Neue Funktionen und Verbesserungen warten auf Sie.';
+  String get settings_support_update_to_subtitle => 'Neue Funktionen und Verbesserungen warten auf Sie.';
 
   @override
   String get settings_support_about => 'Über';
 
   @override
-  String get settings_support_about_subtitle =>
-      'Projekt- und Quellinformationen';
+  String get settings_support_about_subtitle => 'Projekt- und Quellinformationen';
 
   @override
   String get settings_support_version => 'Version';
@@ -1667,88 +1572,73 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_support_version_loading => 'Versionsinfo wird geladen...';
 
   @override
-  String get settings_support_version_unavailable =>
-      'Versionsinfo nicht verfügbar';
+  String get settings_support_version_unavailable => 'Versionsinfo nicht verfügbar';
 
   @override
   String get settings_support_github => 'GitHub-Repository';
 
   @override
-  String get settings_support_github_subtitle =>
-      'Quellcode anzeigen und Probleme melden';
+  String get settings_support_github_subtitle => 'Quellcode anzeigen und Probleme melden';
 
   @override
-  String get settings_support_github_error =>
-      'GitHub-Link konnte nicht geöffnet werden';
+  String get settings_support_github_error => 'GitHub-Link konnte nicht geöffnet werden';
 
   @override
   String get settings_support_issues => 'Melden Sie ein Problem';
 
   @override
-  String get settings_support_issues_subtitle =>
-      'Helfen Sie mit, StashFlow zu verbessern, indem Sie Fehler melden';
+  String get settings_support_issues_subtitle => 'Helfen Sie mit, StashFlow zu verbessern, indem Sie Fehler melden';
 
   @override
   String get settings_develop_title => 'Entwickeln';
 
   @override
-  String get settings_develop_enable_logging =>
-      'Debug-Protokollierung aktivieren';
+  String get settings_develop_enable_logging => 'Debug-Protokollierung aktivieren';
 
   @override
-  String get settings_develop_enable_logging_subtitle =>
-      'App-Protokolle zur Fehlerbehebung aufzeichnen';
+  String get settings_develop_enable_logging_subtitle => 'App-Protokolle zur Fehlerbehebung aufzeichnen';
 
   @override
   String get settings_develop_diagnostics => 'Diagnose-Tools';
 
   @override
-  String get settings_develop_diagnostics_subtitle =>
-      'Fehlerbehebung und Leistung';
+  String get settings_develop_diagnostics_subtitle => 'Fehlerbehebung und Leistung';
 
   @override
   String get settings_develop_video_debug => 'Video-Debug-Info anzeigen';
 
   @override
-  String get settings_develop_video_debug_subtitle =>
-      'Technische Wiedergabedetails als Overlay im Videoplayer anzeigen.';
+  String get settings_develop_video_debug_subtitle => 'Technische Wiedergabedetails als Overlay im Videoplayer anzeigen.';
 
   @override
   String get settings_develop_log_viewer => 'Debug-Log-Viewer';
 
   @override
-  String get settings_develop_log_viewer_subtitle =>
-      'Live-Ansicht der In-App-Logs öffnen.';
+  String get settings_develop_log_viewer_subtitle => 'Live-Ansicht der In-App-Logs öffnen.';
 
   @override
-  String get settings_develop_logs_copied =>
-      'Logs in die Zwischenablage kopiert';
+  String get settings_develop_logs_copied => 'Logs in die Zwischenablage kopiert';
 
   @override
-  String get settings_develop_no_logs =>
-      'Noch keine Logs. Interagiere mit der App, um Logs zu erfassen.';
+  String get settings_develop_no_logs => 'Noch keine Logs. Interagiere mit der App, um Logs zu erfassen.';
 
   @override
   String get settings_develop_web_overrides => 'Web-Overrides';
 
   @override
-  String get settings_develop_web_overrides_subtitle =>
-      'Erweiterte Flags für die Web-Plattform';
+  String get settings_develop_web_overrides_subtitle => 'Erweiterte Flags für die Web-Plattform';
 
   @override
   String get settings_develop_web_auth => 'Passwort-Login im Web erlauben';
 
   @override
-  String get settings_develop_web_auth_subtitle =>
-      'Hebt die Native-only-Beschränkung auf und erzwingt die Sichtbarkeit der Benutzername + Passwort-Authentifizierungsmethode in Flutter Web.';
+  String get settings_develop_web_auth_subtitle => 'Hebt die Native-only-Beschränkung auf und erzwingt die Sichtbarkeit der Benutzername + Passwort-Authentifizierungsmethode in Flutter Web.';
 
   @override
-  String get settings_develop_proxy_auth =>
-      'Proxy-Authentifizierungsmodi aktivieren';
+  String get settings_develop_proxy_auth => 'Proxy-Authentifizierungsmodi aktivieren';
 
   @override
-  String get settings_develop_proxy_auth_subtitle =>
-      'Aktivieren Sie erweiterte Basic-Auth- und Bearer-Token-Methoden für die Verwendung mit authentifizierungsfreien Backends hinter Proxys wie Authentik.';
+  String get settings_develop_proxy_auth_subtitle => 'Aktivieren Sie erweiterte Basic-Auth- und Bearer-Token-Methoden für die Verwendung mit authentifizierungsfreien Backends hinter Proxys wie Authentik.';
 
   @override
   String get settings_server_auth_basic => 'Basic Auth';
@@ -1757,12 +1647,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_server_auth_bearer => 'Bearer-Token';
 
   @override
-  String get settings_server_auth_basic_desc =>
-      'Sendet den Header \'Authorization: Basic <base64(user:pass)>\'.';
+  String get settings_server_auth_basic_desc => 'Sendet den Header \'Authorization: Basic <base64(user:pass)>\'.';
 
   @override
-  String get settings_server_auth_bearer_desc =>
-      'Sendet den Header \'Authorization: Bearer <token>\'.';
+  String get settings_server_auth_bearer_desc => 'Sendet den Header \'Authorization: Bearer <token>\'.';
 
   @override
   String get common_edit => 'Bearbeiten';
@@ -1783,8 +1671,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get common_square => 'Quadrat';
 
   @override
-  String get performers_filter_saved =>
-      'Filtereinstellungen als Standard gespeichert';
+  String get performers_filter_saved => 'Filtereinstellungen als Standard gespeichert';
 
   @override
   String get images_title => 'Bilder';
@@ -1793,15 +1680,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get images_filter_title => 'Bilder filtern';
 
   @override
-  String get images_filter_saved =>
-      'Filtereinstellungen als Standard gespeichert';
+  String get images_filter_saved => 'Filtereinstellungen als Standard gespeichert';
 
   @override
   String get images_sort_title => 'Bilder sortieren';
 
   @override
-  String get images_sort_saved =>
-      'Sortier-Einstellungen als Standard gespeichert';
+  String get images_sort_saved => 'Sortier-Einstellungen als Standard gespeichert';
 
   @override
   String get image_rating_updated => 'Bildbewertung aktualisiert.';
@@ -1816,8 +1701,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get common_gallery => 'Galerie';
 
   @override
-  String get images_gallery_rating_unavailable =>
-      'Die Galeriebewertung ist nur verfügbar, wenn Sie eine Galerie durchsuchen.';
+  String get images_gallery_rating_unavailable => 'Die Galeriebewertung ist nur verfügbar, wenn Sie eine Galerie durchsuchen.';
 
   @override
   String images_rating(String rating) {
@@ -1828,8 +1712,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get images_filtered_by_gallery => 'Gefiltert nach Galerie';
 
   @override
-  String get images_slideshow_need_two =>
-      'Mindestens 2 Bilder werden für die Diashow benötigt.';
+  String get images_slideshow_need_two => 'Mindestens 2 Bilder werden für die Diashow benötigt.';
 
   @override
   String get images_slideshow_start_title => 'Diashow starten';
@@ -1866,8 +1749,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_keybind_assign_shortcut => 'Tastenkürzel zuweisen';
 
   @override
-  String get settings_keybind_press_any =>
-      'Drücke eine beliebige Tastenkombination...';
+  String get settings_keybind_press_any => 'Drücke eine beliebige Tastenkombination...';
 
   @override
   String get scenes_select_tags => 'Tags auswählen';
@@ -1925,16 +1807,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get scenes_select_performers => 'Darsteller auswählen';
 
   @override
-  String get scenes_unmatched_scraped_tags =>
-      'Nicht übereinstimmende gescrapte Tags';
+  String get scenes_unmatched_scraped_tags => 'Nicht übereinstimmende gescrapte Tags';
 
   @override
-  String get scenes_unmatched_scraped_performers =>
-      'Nicht übereinstimmende gescrapte Darsteller';
+  String get scenes_unmatched_scraped_performers => 'Nicht übereinstimmende gescrapte Darsteller';
 
   @override
-  String get scenes_no_matching_performer_found =>
-      'Kein übereinstimmender Darsteller in der Bibliothek gefunden';
+  String get scenes_no_matching_performer_found => 'Kein übereinstimmender Darsteller in der Bibliothek gefunden';
 
   @override
   String get common_unknown => 'Unbekannt';
@@ -2019,8 +1898,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cast_airplay_pairing => 'AirPlay-Kopplung';
 
   @override
-  String get cast_enter_pin =>
-      'Geben Sie die 4-stellige PIN ein, die auf Ihrem Fernseher angezeigt wird';
+  String get cast_enter_pin => 'Geben Sie die 4-stellige PIN ein, die auf Ihrem Fernseher angezeigt wird';
 
   @override
   String get cast_pair => 'Paar';
@@ -2067,8 +1945,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_storage_clearing_video => 'Video-Cache wird geleert...';
 
   @override
-  String get settings_storage_clearing_database =>
-      'Datenbank-Cache wird geleert...';
+  String get settings_storage_clearing_database => 'Datenbank-Cache wird geleert...';
 
   @override
   String get settings_storage_cleared_image => 'Bildcache geleert';
@@ -2114,8 +1991,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_storage_limits => 'Grenzen';
 
   @override
-  String get settings_storage_limits_subtitle =>
-      'Legen Sie maximale Cache-Größen fest';
+  String get settings_storage_limits_subtitle => 'Legen Sie maximale Cache-Größen fest';
 
   @override
   String get settings_storage_max_image_cache => 'Maximaler Bildcache (MB)';
@@ -2133,8 +2009,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_storage_usage_subtitle => 'Aktueller Cache-Verbrauch';
 
   @override
-  String get settings_storage_subtitle =>
-      'Lokale Caches und Speichergrenzen verwalten';
+  String get settings_storage_subtitle => 'Lokale Caches und Speichergrenzen verwalten';
 
   @override
   String get performers_field_name => 'Name';
@@ -2359,8 +2234,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get scenes_field_updated_at => 'Aktualisiert am';
 
   @override
-  String get cast_stopped_resuming_locally =>
-      'Übertragung gestoppt, lokal fortgesetzt';
+  String get cast_stopped_resuming_locally => 'Übertragung gestoppt, lokal fortgesetzt';
 
   @override
   String get cast_stop_casting => 'Übertragung stoppen';
@@ -2384,8 +2258,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get common_star => 'Favorit';
 
   @override
-  String get settings_interface_card_title_font_size =>
-      'Schriftgröße des Kartentitels';
+  String get settings_interface_card_title_font_size => 'Schriftgröße des Kartentitels';
 
   @override
   String get common_hint_date => 'JJJJ-MM-TT';
@@ -2450,16 +2323,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get sort_scenes => 'Szenen sortieren';
 
   @override
-  String get failed_to_load_tap_to_retry =>
-      'Fehler beim Laden. Tippen Sie, um es erneut zu versuchen.';
+  String get failed_to_load_tap_to_retry => 'Fehler beim Laden. Tippen Sie, um es erneut zu versuchen.';
 
   @override
-  String get would_you_like_to_visit_the_release_page_to_download_it =>
-      'Möchten Sie die Release-Seite besuchen, um es herunterzuladen?';
+  String get would_you_like_to_visit_the_release_page_to_download_it => 'Möchten Sie die Release-Seite besuchen, um es herunterzuladen?';
 
   @override
-  String get to_get_started_configure_stash_server =>
-      'Um zu beginnen, müssen Sie Ihre Stash-Server-Verbindungsdetails konfigurieren.';
+  String get to_get_started_configure_stash_server => 'Um zu beginnen, müssen Sie Ihre Stash-Server-Verbindungsdetails konfigurieren.';
 
   @override
   String get loading => 'Wird geladen';
@@ -2562,8 +2432,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get main_startup_failed => 'StashFlow konnte nicht gestartet werden';
 
   @override
-  String get main_startup_failed_desc =>
-      'Ein Startdienst ist fehlgeschlagen, bevor die App die Initialisierung abschließen konnte.Starten Sie die App neu, nachdem Sie die Diagnose überprüft haben.';
+  String get main_startup_failed_desc => 'Ein Startdienst ist fehlgeschlagen, bevor die App die Initialisierung abschließen konnte.Starten Sie die App neu, nachdem Sie die Diagnose überprüft haben.';
 
   @override
   String common_searching_for(String query) {
@@ -2574,8 +2443,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cast_device => 'Gerät';
 
   @override
-  String get auth_enter_passcode =>
-      'Geben Sie Ihren Passcode ein, um fortzufahren.';
+  String get auth_enter_passcode => 'Geben Sie Ihren Passcode ein, um fortzufahren.';
 
   @override
   String get auth_unlock => 'Entsperren';
@@ -2605,23 +2473,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_security_enable_app_lock => 'App-Sperre aktivieren';
 
   @override
-  String get settings_security_enable_app_lock_subtitle =>
-      'Passcode beim Fortsetzen/Starten der App erforderlich.';
+  String get settings_security_enable_app_lock_subtitle => 'Passcode beim Fortsetzen/Starten der App erforderlich.';
 
   @override
   String get settings_security_lock_on_launch => 'Beim App-Start sperren';
 
   @override
-  String get settings_security_lock_on_launch_subtitle =>
-      'Fragen Sie sofort nach dem Passwort, wenn die App geöffnet wird.';
+  String get settings_security_lock_on_launch_subtitle => 'Fragen Sie sofort nach dem Passwort, wenn die App geöffnet wird.';
 
   @override
-  String get settings_security_background_lock_timer =>
-      'Hintergrundsperr-Timer';
+  String get settings_security_background_lock_timer => 'Hintergrundsperr-Timer';
 
   @override
-  String get settings_security_background_lock_timer_subtitle =>
-      'Wie lange die App im Hintergrund bleiben kann, bevor sie gesperrt wird.';
+  String get settings_security_background_lock_timer_subtitle => 'Wie lange die App im Hintergrund bleiben kann, bevor sie gesperrt wird.';
 
   @override
   String get settings_security_set_passcode => 'Passcode festlegen';
@@ -2633,12 +2497,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_security_confirm_passcode => 'Bestätigen';
 
   @override
-  String get settings_security_error_numeric =>
-      'Verwenden Sie nur Ziffern mit einer Länge von 4–8.';
+  String get settings_security_error_numeric => 'Verwenden Sie nur Ziffern mit einer Länge von 4–8.';
 
   @override
-  String get settings_security_error_mismatch =>
-      'Passcodes stimmen nicht überein.';
+  String get settings_security_error_mismatch => 'Passcodes stimmen nicht überein.';
 
   @override
   String get common_change => 'Ändern';
@@ -2668,15 +2530,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_security_title => 'Sicherheit';
 
   @override
-  String get settings_security_subtitle =>
-      'App-Sperre und Passcode-Einstellungen';
+  String get settings_security_subtitle => 'App-Sperre und Passcode-Einstellungen';
 
   @override
   String get settings_security_app_lock => 'App-Sperre';
 
   @override
-  String get settings_security_app_lock_subtitle =>
-      'Schützen Sie den Zugriff nach dem Hintergrundbetrieb mit einem Passcode.';
+  String get settings_security_app_lock_subtitle => 'Schützen Sie den Zugriff nach dem Hintergrundbetrieb mit einem Passcode.';
 
   @override
   String get common_saved_filters => 'Gespeicherte Filter';
@@ -2685,16 +2545,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get tools => 'Werkzeuge';
 
   @override
-  String get tools_section_subtitle =>
-      'Wartungs- und Metadaten-Workflows für Szenen.';
+  String get tools_section_subtitle => 'Wartungs- und Metadaten-Workflows für Szenen.';
 
   @override
-  String get tools_scene_deduplication_subtitle =>
-      'Duplikate finden und verwalten.';
+  String get tools_scene_deduplication_subtitle => 'Duplikate finden und verwalten.';
 
   @override
-  String get tools_scene_tagger_subtitle =>
-      'Aktuelle Szenenseiten mit Stash-box scrapen.';
+  String get tools_scene_tagger_subtitle => 'Aktuelle Szenenseiten mit Stash-box scrapen.';
 
   @override
   String get preset_deleted => 'Voreinstellung gelöscht';
@@ -2796,8 +2653,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get duration_difference => 'Dauerunterschied';
 
   @override
-  String get only_select_matching_codecs =>
-      'Wählen Sie nur passende Codecs aus';
+  String get only_select_matching_codecs => 'Wählen Sie nur passende Codecs aus';
 
   @override
   String get select_scenes => 'Wählen Sie Szenen aus';
@@ -2845,8 +2701,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get enter_preset_name => 'Name der Voreinstellung eingeben';
 
   @override
-  String get delete_scene_confirm =>
-      'Möchten Sie diese Szene wirklich löschen?';
+  String get delete_scene_confirm => 'Möchten Sie diese Szene wirklich löschen?';
 
   @override
   String delete_selected_count(int selectedCount) {
@@ -2863,12 +2718,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get available_presets => 'Verfügbare Voreinstellungen';
 
   @override
-  String get existing_names_are_overwritten =>
-      'Vorhandene Namen werden überschrieben';
+  String get existing_names_are_overwritten => 'Vorhandene Namen werden überschrieben';
 
   @override
-  String get active_settings_saved_server =>
-      'Die aktuell aktiven Einstellungen werden auf dem Server gespeichert.';
+  String get active_settings_saved_server => 'Die aktuell aktiven Einstellungen werden auf dem Server gespeichert.';
 
   @override
   String failed_to_save_filter(String error) {
@@ -2916,8 +2769,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get delete_scenes_help =>
-      'Wähle aus, ob nur Stash-Metadaten entfernt werden sollen oder auch die Szenendateien und die zusätzlich generierten Dateien.';
+  String get delete_scenes_help => 'Wähle aus, ob nur Stash-Metadaten entfernt werden sollen oder auch die Szenendateien und die zusätzlich generierten Dateien.';
 
   @override
   String deleted_n_scenes(int count) {
@@ -2938,8 +2790,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get merge_editing_not_wired =>
-      'Das Bearbeiten von Zusammenführungen ist in StashFlow noch nicht angebunden.';
+  String get merge_editing_not_wired => 'Das Bearbeiten von Zusammenführungen ist in StashFlow noch nicht angebunden.';
 
   @override
   String duplicate_sets_count(int count) {
@@ -2975,6 +2826,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String nTags(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2992,6 +2844,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String nGroups(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3009,6 +2862,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String nMarkers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3026,6 +2880,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String nGalleries(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3053,8 +2908,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get no_matched_scenes_yet => 'Noch keine passenden Szenen.';
 
   @override
-  String get no_scenes_match_configuration =>
-      'Keine Szenen entsprechen dieser Konfiguration.';
+  String get no_scenes_match_configuration => 'Keine Szenen entsprechen dieser Konfiguration.';
 
   @override
   String scene_tagger_checked_count(int count) {
@@ -3067,8 +2921,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get stats_library_stats_tooltip =>
-      'Lange drücken für Bibliotheksstatistiken';
+  String get stats_library_stats_tooltip => 'Lange drücken für Bibliotheksstatistiken';
 
   @override
   String get scene_details_marker_created => 'Markierung erstellt';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -45,6 +45,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String nScenes(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -62,6 +63,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String nPerformers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -79,6 +81,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String nPlays(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -300,12 +303,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get scenes_no_random => 'No scenes available for random navigation';
 
   @override
-  String get performers_no_random =>
-      'No performers available for random navigation';
+  String get performers_no_random => 'No performers available for random navigation';
 
   @override
-  String get galleries_no_random =>
-      'No galleries available for random navigation';
+  String get galleries_no_random => 'No galleries available for random navigation';
 
   @override
   String common_error(String message) {
@@ -942,8 +943,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_customize => 'Customize StashFlow';
 
   @override
-  String get settings_customize_subtitle =>
-      'Tune playback, appearance, layout, and support tools from one place.';
+  String get settings_customize_subtitle => 'Tune playback, appearance, layout, and support tools from one place.';
 
   @override
   String get settings_core_section => 'Core settings';
@@ -1018,24 +1018,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_keyboard_go_back => 'Go Back';
 
   @override
-  String get settings_keyboard_play_pause_desc =>
-      'Toggle between playing and pausing video';
+  String get settings_keyboard_play_pause_desc => 'Toggle between playing and pausing video';
 
   @override
-  String get settings_keyboard_seek_forward_5_desc =>
-      'Jump forward by 5 seconds';
+  String get settings_keyboard_seek_forward_5_desc => 'Jump forward by 5 seconds';
 
   @override
-  String get settings_keyboard_seek_backward_5_desc =>
-      'Jump backward by 5 seconds';
+  String get settings_keyboard_seek_backward_5_desc => 'Jump backward by 5 seconds';
 
   @override
-  String get settings_keyboard_seek_forward_10_desc =>
-      'Jump forward by 10 seconds';
+  String get settings_keyboard_seek_forward_10_desc => 'Jump forward by 10 seconds';
 
   @override
-  String get settings_keyboard_seek_backward_10_desc =>
-      'Jump backward by 10 seconds';
+  String get settings_keyboard_seek_backward_10_desc => 'Jump backward by 10 seconds';
 
   @override
   String get settings_appearance => 'Appearance';
@@ -1068,8 +1063,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_appearance_theme_mode => 'Theme Mode';
 
   @override
-  String get settings_appearance_theme_mode_subtitle =>
-      'Choose how the app follows brightness changes';
+  String get settings_appearance_theme_mode_subtitle => 'Choose how the app follows brightness changes';
 
   @override
   String get settings_appearance_theme_system => 'System';
@@ -1084,36 +1078,31 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_appearance_primary_color => 'Primary Color';
 
   @override
-  String get settings_appearance_primary_color_subtitle =>
-      'Pick a seed color for the Material 3 palette';
+  String get settings_appearance_primary_color_subtitle => 'Pick a seed color for the Material 3 palette';
 
   @override
   String get settings_appearance_advanced_theming => 'Advanced Theming';
 
   @override
-  String get settings_appearance_advanced_theming_subtitle =>
-      'Optimizations for specific screen types';
+  String get settings_appearance_advanced_theming_subtitle => 'Optimizations for specific screen types';
 
   @override
   String get settings_appearance_true_black => 'True Black (AMOLED)';
 
   @override
-  String get settings_appearance_true_black_subtitle =>
-      'Use pure black backgrounds in dark mode to save battery on OLED screens';
+  String get settings_appearance_true_black_subtitle => 'Use pure black backgrounds in dark mode to save battery on OLED screens';
 
   @override
   String get settings_appearance_custom_hex => 'Custom Hex Color';
 
   @override
-  String get settings_appearance_custom_hex_helper =>
-      'Enter an 8-digit ARGB hex code';
+  String get settings_appearance_custom_hex_helper => 'Enter an 8-digit ARGB hex code';
 
   @override
   String get settings_appearance_font_size => 'Global UI Scale';
 
   @override
-  String get settings_appearance_font_size_subtitle =>
-      'Scale typography and spacing proportionally';
+  String get settings_appearance_font_size_subtitle => 'Scale typography and spacing proportionally';
 
   @override
   String get settings_interface_title => 'Interface Settings';
@@ -1122,8 +1111,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_interface_language => 'Language';
 
   @override
-  String get settings_interface_language_subtitle =>
-      'Overwrite the default system language';
+  String get settings_interface_language_subtitle => 'Overwrite the default system language';
 
   @override
   String get settings_interface_app_language => 'App Language';
@@ -1132,102 +1120,82 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_interface_navigation => 'Navigation';
 
   @override
-  String get settings_interface_navigation_subtitle =>
-      'Visibility of global navigation shortcuts';
+  String get settings_interface_navigation_subtitle => 'Visibility of global navigation shortcuts';
 
   @override
   String get settings_interface_show_random => 'Show Random Navigation Buttons';
 
   @override
-  String get settings_interface_show_random_subtitle =>
-      'Enable or disable the floating casino buttons across list and details pages';
+  String get settings_interface_show_random_subtitle => 'Enable or disable the floating casino buttons across list and details pages';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation =>
-      'Gravity-controlled orientation (main pages)';
+  String get settings_interface_main_pages_gravity_orientation => 'Gravity-controlled orientation (main pages)';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation_subtitle =>
-      'Allow main pages to rotate using the device sensor. Fullscreen video playback follows its own orientation settings.';
+  String get settings_interface_main_pages_gravity_orientation_subtitle => 'Allow main pages to rotate using the device sensor. Fullscreen video playback follows its own orientation settings.';
 
   @override
   String get settings_interface_show_edit => 'Show Edit Button';
 
   @override
-  String get settings_interface_show_edit_subtitle =>
-      'Enable or disable the edit button on the scene details page';
+  String get settings_interface_show_edit_subtitle => 'Enable or disable the edit button on the scene details page';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer =>
-      'Use actual scene video in miniplayer';
+  String get settings_interface_use_actual_scene_video_miniplayer => 'Use actual scene video in miniplayer';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer_subtitle =>
-      'Show the live scene video surface instead of the scene screenshot when playback is active.';
+  String get settings_interface_use_actual_scene_video_miniplayer_subtitle => 'Show the live scene video surface instead of the scene screenshot when playback is active.';
 
   @override
-  String get settings_interface_entity_image_filtering =>
-      'Entity image filtering';
+  String get settings_interface_entity_image_filtering => 'Entity image filtering';
 
   @override
-  String get settings_interface_entity_image_filtering_subtitle =>
-      'Choose whether entity image pages match image metadata or related galleries.';
+  String get settings_interface_entity_image_filtering_subtitle => 'Choose whether entity image pages match image metadata or related galleries.';
 
   @override
-  String get settings_interface_entity_image_filtering_direct =>
-      'Direct entity';
+  String get settings_interface_entity_image_filtering_direct => 'Direct entity';
 
   @override
-  String get settings_interface_entity_image_filtering_galleries =>
-      'Related galleries';
+  String get settings_interface_entity_image_filtering_galleries => 'Related galleries';
 
   @override
   String get settings_interface_customize_tabs => 'Customize Tabs';
 
   @override
-  String get settings_interface_customize_tabs_subtitle =>
-      'Reorder or hide navigation menu items';
+  String get settings_interface_customize_tabs_subtitle => 'Reorder or hide navigation menu items';
 
   @override
   String get settings_interface_scenes_layout => 'Scenes Layout';
 
   @override
-  String get settings_interface_scenes_layout_subtitle =>
-      'Default browsing mode for scenes';
+  String get settings_interface_scenes_layout_subtitle => 'Default browsing mode for scenes';
 
   @override
   String get settings_interface_galleries_layout => 'Galleries Layout';
 
   @override
-  String get settings_interface_galleries_layout_subtitle =>
-      'Default browsing mode for galleries';
+  String get settings_interface_galleries_layout_subtitle => 'Default browsing mode for galleries';
 
   @override
-  String get settings_interface_max_performer_avatars =>
-      'Max Performer Avatars';
+  String get settings_interface_max_performer_avatars => 'Max Performer Avatars';
 
   @override
-  String get settings_interface_max_performer_avatars_subtitle =>
-      'Maximum number of performer avatars to show in the scene card.';
+  String get settings_interface_max_performer_avatars_subtitle => 'Maximum number of performer avatars to show in the scene card.';
 
   @override
-  String get settings_interface_show_performer_avatars =>
-      'Show Performer Avatars';
+  String get settings_interface_show_performer_avatars => 'Show Performer Avatars';
 
   @override
-  String get settings_interface_show_performer_avatars_subtitle =>
-      'Display performer icons on scene cards across all platforms.';
+  String get settings_interface_show_performer_avatars_subtitle => 'Display performer icons on scene cards across all platforms.';
 
   @override
-  String get settings_interface_performer_avatar_size =>
-      'Performer Avatar Size';
+  String get settings_interface_performer_avatar_size => 'Performer Avatar Size';
 
   @override
   String get settings_interface_layout_default => 'Default Layout';
 
   @override
-  String get settings_interface_layout_default_desc =>
-      'Choose the default layout for the page';
+  String get settings_interface_layout_default_desc => 'Choose the default layout for the page';
 
   @override
   String get settings_interface_layout_list => 'List';
@@ -1245,15 +1213,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_interface_image_viewer => 'Image Viewer';
 
   @override
-  String get settings_interface_image_viewer_subtitle =>
-      'Configure fullscreen image browsing behavior';
+  String get settings_interface_image_viewer_subtitle => 'Configure fullscreen image browsing behavior';
 
   @override
   String get settings_interface_swipe_direction => 'Fullscreen Swipe Direction';
 
   @override
-  String get settings_interface_swipe_direction_desc =>
-      'Choose how images advance in fullscreen mode';
+  String get settings_interface_swipe_direction_desc => 'Choose how images advance in fullscreen mode';
 
   @override
   String get settings_interface_swipe_vertical => 'Vertical';
@@ -1268,36 +1234,31 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_interface_performer_layouts => 'Performer Layouts';
 
   @override
-  String get settings_interface_performer_layouts_subtitle =>
-      'Media and gallery defaults for performers';
+  String get settings_interface_performer_layouts_subtitle => 'Media and gallery defaults for performers';
 
   @override
   String get settings_interface_studio_layouts => 'Studio Layouts';
 
   @override
-  String get settings_interface_studio_layouts_subtitle =>
-      'Media and gallery defaults for studios';
+  String get settings_interface_studio_layouts_subtitle => 'Media and gallery defaults for studios';
 
   @override
   String get settings_interface_tag_layouts => 'Tag Layouts';
 
   @override
-  String get settings_interface_tag_layouts_subtitle =>
-      'Media and gallery defaults for tags';
+  String get settings_interface_tag_layouts_subtitle => 'Media and gallery defaults for tags';
 
   @override
   String get settings_interface_media_layout => 'Media Layout';
 
   @override
-  String get settings_interface_media_layout_subtitle =>
-      'Layout for Media page';
+  String get settings_interface_media_layout_subtitle => 'Layout for Media page';
 
   @override
   String get settings_interface_galleries_layout_item => 'Galleries Layout';
 
   @override
-  String get settings_interface_galleries_layout_subtitle_item =>
-      'Layout for Galleries page';
+  String get settings_interface_galleries_layout_subtitle_item => 'Layout for Galleries page';
 
   @override
   String get settings_server_title => 'Server Settings';
@@ -1306,22 +1267,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_server_status => 'Connection Status';
 
   @override
-  String get settings_server_status_subtitle =>
-      'Live connectivity against the configured server';
+  String get settings_server_status_subtitle => 'Live connectivity against the configured server';
 
   @override
   String get settings_server_details => 'Server Details';
 
   @override
-  String get settings_server_details_subtitle =>
-      'Configure endpoint and authentication method';
+  String get settings_server_details_subtitle => 'Configure endpoint and authentication method';
 
   @override
   String get settings_server_url => 'Stash URL';
 
   @override
-  String get settings_server_url_helper =>
-      'Enter the URL of your Stash server. If configured with a custom path, include it here.';
+  String get settings_server_url_helper => 'Enter the URL of your Stash server. If configured with a custom path, include it here.';
 
   @override
   String get settings_server_url_example => 'http://192.168.1.100:9999';
@@ -1339,12 +1297,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_server_auth_password => 'Username + Password';
 
   @override
-  String get settings_server_auth_password_desc =>
-      'Recommended: use your Stash username/password session.';
+  String get settings_server_auth_password_desc => 'Recommended: use your Stash username/password session.';
 
   @override
-  String get settings_server_auth_apikey_desc =>
-      'Use API key for static-token authentication.';
+  String get settings_server_auth_apikey_desc => 'Use API key for static-token authentication.';
 
   @override
   String get settings_server_username => 'Username';
@@ -1381,12 +1337,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_server_invalid_url => 'Invalid server URL';
 
   @override
-  String get settings_server_resolve_error =>
-      'Could not resolve server URL. Check host, port, and credentials.';
+  String get settings_server_resolve_error => 'Could not resolve server URL. Check host, port, and credentials.';
 
   @override
-  String get settings_server_logout_confirm =>
-      'Logged out and cookies cleared.';
+  String get settings_server_logout_confirm => 'Logged out and cookies cleared.';
 
   @override
   String get settings_server_profile_add => 'Add Profile';
@@ -1401,8 +1355,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_server_profile_delete => 'Delete Profile';
 
   @override
-  String get settings_server_profile_delete_confirm =>
-      'Are you sure you want to delete this profile? This action cannot be undone.';
+  String get settings_server_profile_delete_confirm => 'Are you sure you want to delete this profile? This action cannot be undone.';
 
   @override
   String get settings_server_profile_active => 'Active';
@@ -1414,20 +1367,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_server_profiles => 'Server Profiles';
 
   @override
-  String get settings_server_profiles_subtitle =>
-      'Manage multiple Stash server connections';
+  String get settings_server_profiles_subtitle => 'Manage multiple Stash server connections';
 
   @override
-  String get settings_server_auth_status_logging_in =>
-      'Authentication status: logging in...';
+  String get settings_server_auth_status_logging_in => 'Authentication status: logging in...';
 
   @override
-  String get settings_server_auth_status_logged_in =>
-      'Authentication status: logged in';
+  String get settings_server_auth_status_logged_in => 'Authentication status: logged in';
 
   @override
-  String get settings_server_auth_status_logged_out =>
-      'Authentication status: logged out';
+  String get settings_server_auth_status_logged_out => 'Authentication status: logged out';
 
   @override
   String get settings_playback_title => 'Playback Settings';
@@ -1436,37 +1385,31 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_playback_behavior => 'Playback behavior';
 
   @override
-  String get settings_playback_behavior_subtitle =>
-      'Default playback and background handling';
+  String get settings_playback_behavior_subtitle => 'Default playback and background handling';
 
   @override
   String get settings_playback_prefer_streams => 'Prefer sceneStreams first';
 
   @override
-  String get settings_playback_prefer_streams_subtitle =>
-      'When off, playback directly uses paths.stream';
+  String get settings_playback_prefer_streams_subtitle => 'When off, playback directly uses paths.stream';
 
   @override
   String get settings_playback_feed_random => 'Start Feed from random position';
 
   @override
-  String get settings_playback_feed_random_subtitle =>
-      'When playing scenes in Feed mode, start from a random position between 0% and 90% of the video length';
+  String get settings_playback_feed_random_subtitle => 'When playing scenes in Feed mode, start from a random position between 0% and 90% of the video length';
 
   @override
-  String get settings_playback_resume_position =>
-      'Resume from last playing position';
+  String get settings_playback_resume_position => 'Resume from last playing position';
 
   @override
-  String get settings_playback_resume_position_subtitle =>
-      'When opening a video, automatically resume from where you left off';
+  String get settings_playback_resume_position_subtitle => 'When opening a video, automatically resume from where you left off';
 
   @override
   String get settings_playback_end_behavior => 'Play End Behavior';
 
   @override
-  String get settings_playback_end_behavior_subtitle =>
-      'What to do when current playback ends';
+  String get settings_playback_end_behavior_subtitle => 'What to do when current playback ends';
 
   @override
   String get settings_playback_end_behavior_stop => 'Stop';
@@ -1481,36 +1424,31 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_playback_autoplay => 'Autoplay Next Scene';
 
   @override
-  String get settings_playback_autoplay_subtitle =>
-      'Automatically play the next scene when current playback ends';
+  String get settings_playback_autoplay_subtitle => 'Automatically play the next scene when current playback ends';
 
   @override
   String get settings_playback_background => 'Background Playback';
 
   @override
-  String get settings_playback_background_subtitle =>
-      'Keep video audio playing when app is backgrounded';
+  String get settings_playback_background_subtitle => 'Keep video audio playing when app is backgrounded';
 
   @override
   String get settings_playback_pip => 'Native Picture-in-Picture';
 
   @override
-  String get settings_playback_pip_subtitle =>
-      'Enable Android PiP button and auto-enter on background';
+  String get settings_playback_pip_subtitle => 'Enable Android PiP button and auto-enter on background';
 
   @override
   String get settings_playback_subtitles => 'Subtitle settings';
 
   @override
-  String get settings_playback_subtitles_subtitle =>
-      'Automatic loading and appearance';
+  String get settings_playback_subtitles_subtitle => 'Automatic loading and appearance';
 
   @override
   String get settings_playback_subtitle_lang => 'Default Subtitle Language';
 
   @override
-  String get settings_playback_subtitle_lang_subtitle =>
-      'Auto-load if available';
+  String get settings_playback_subtitle_lang_subtitle => 'Auto-load if available';
 
   @override
   String get settings_playback_subtitle_size => 'Subtitle Font Size';
@@ -1527,19 +1465,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_playback_subtitle_align => 'Subtitle Text Alignment';
 
   @override
-  String get settings_playback_subtitle_align_subtitle =>
-      'Alignment for multiline subtitles';
+  String get settings_playback_subtitle_align_subtitle => 'Alignment for multiline subtitles';
 
   @override
   String get settings_playback_seek => 'Seek interaction';
 
   @override
-  String get settings_playback_seek_subtitle =>
-      'Choose how scrubbing works during playback';
+  String get settings_playback_seek_subtitle => 'Choose how scrubbing works during playback';
 
   @override
-  String get settings_playback_seek_double_tap =>
-      'Double-tap left/right to seek 10s';
+  String get settings_playback_seek_double_tap => 'Double-tap left/right to seek 10s';
 
   @override
   String get settings_playback_seek_drag => 'Drag the timeline to seek';
@@ -1551,26 +1486,22 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_playback_seek_double_tap_label => 'Double-tap';
 
   @override
-  String get settings_playback_gravity_orientation =>
-      'Gravity-controlled orientation';
+  String get settings_playback_gravity_orientation => 'Gravity-controlled orientation';
 
   @override
   String get settings_playback_direct_play => 'Direct-play on scene navigation';
 
   @override
-  String get settings_playback_direct_play_subtitle =>
-      'When navigating from another playing scene, directly play the new scene';
+  String get settings_playback_direct_play_subtitle => 'When navigating from another playing scene, directly play the new scene';
 
   @override
-  String get settings_playback_gravity_orientation_subtitle =>
-      'Allow rotating between matching orientations using the device sensor (e.g. flipping landscape left/right).';
+  String get settings_playback_gravity_orientation_subtitle => 'Allow rotating between matching orientations using the device sensor (e.g. flipping landscape left/right).';
 
   @override
   String get settings_playback_subtitle_lang_none_disabled => 'None (Disabled)';
 
   @override
-  String get settings_playback_subtitle_lang_auto_if_only_one =>
-      'Auto (If only one)';
+  String get settings_playback_subtitle_lang_auto_if_only_one => 'Auto (If only one)';
 
   @override
   String get settings_playback_subtitle_lang_english => 'English';
@@ -1612,15 +1543,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_support_diagnostics => 'Diagnostics and project info';
 
   @override
-  String get settings_support_diagnostics_subtitle =>
-      'Open runtime logs or jump to the repository when you need help.';
+  String get settings_support_diagnostics_subtitle => 'Open runtime logs or jump to the repository when you need help.';
 
   @override
   String get settings_support_update_available => 'Update Available';
 
   @override
-  String get settings_support_update_available_subtitle =>
-      'A newer version is available on GitHub';
+  String get settings_support_update_available_subtitle => 'A newer version is available on GitHub';
 
   @override
   String settings_support_update_to(String version) {
@@ -1628,15 +1557,13 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get settings_support_update_to_subtitle =>
-      'New features and improvements are waiting for you.';
+  String get settings_support_update_to_subtitle => 'New features and improvements are waiting for you.';
 
   @override
   String get settings_support_about => 'About';
 
   @override
-  String get settings_support_about_subtitle =>
-      'Project and source information';
+  String get settings_support_about_subtitle => 'Project and source information';
 
   @override
   String get settings_support_version => 'Version';
@@ -1660,8 +1587,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_support_issues => 'Report an Issue';
 
   @override
-  String get settings_support_issues_subtitle =>
-      'Help improve StashFlow by reporting bugs';
+  String get settings_support_issues_subtitle => 'Help improve StashFlow by reporting bugs';
 
   @override
   String get settings_develop_title => 'Develop';
@@ -1670,57 +1596,49 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_develop_enable_logging => 'Enable Debug Logging';
 
   @override
-  String get settings_develop_enable_logging_subtitle =>
-      'Record app logs for troubleshooting';
+  String get settings_develop_enable_logging_subtitle => 'Record app logs for troubleshooting';
 
   @override
   String get settings_develop_diagnostics => 'Diagnostic Tools';
 
   @override
-  String get settings_develop_diagnostics_subtitle =>
-      'Troubleshooting and performance';
+  String get settings_develop_diagnostics_subtitle => 'Troubleshooting and performance';
 
   @override
   String get settings_develop_video_debug => 'Show Video Debug Info';
 
   @override
-  String get settings_develop_video_debug_subtitle =>
-      'Display technical playback details as an overlay on the video player.';
+  String get settings_develop_video_debug_subtitle => 'Display technical playback details as an overlay on the video player.';
 
   @override
   String get settings_develop_log_viewer => 'Debug Log Viewer';
 
   @override
-  String get settings_develop_log_viewer_subtitle =>
-      'Open a live view of in-app logs.';
+  String get settings_develop_log_viewer_subtitle => 'Open a live view of in-app logs.';
 
   @override
   String get settings_develop_logs_copied => 'Logs copied to clipboard';
 
   @override
-  String get settings_develop_no_logs =>
-      'No logs yet. Interact with the app to capture logs.';
+  String get settings_develop_no_logs => 'No logs yet. Interact with the app to capture logs.';
 
   @override
   String get settings_develop_web_overrides => 'Web Overrides';
 
   @override
-  String get settings_develop_web_overrides_subtitle =>
-      'Advanced flags for web platform';
+  String get settings_develop_web_overrides_subtitle => 'Advanced flags for web platform';
 
   @override
   String get settings_develop_web_auth => 'Allow Password Login on Web';
 
   @override
-  String get settings_develop_web_auth_subtitle =>
-      'Overrides the native-only restriction and forces the Username + Password auth method to be visible on Flutter Web.';
+  String get settings_develop_web_auth_subtitle => 'Overrides the native-only restriction and forces the Username + Password auth method to be visible on Flutter Web.';
 
   @override
   String get settings_develop_proxy_auth => 'Enable Proxy Auth Modes';
 
   @override
-  String get settings_develop_proxy_auth_subtitle =>
-      'Enable advanced Basic Auth and Bearer Token methods for use with auth-free backends behind proxies like Authentik.';
+  String get settings_develop_proxy_auth_subtitle => 'Enable advanced Basic Auth and Bearer Token methods for use with auth-free backends behind proxies like Authentik.';
 
   @override
   String get settings_server_auth_basic => 'Basic Auth';
@@ -1729,12 +1647,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_server_auth_bearer => 'Bearer Token';
 
   @override
-  String get settings_server_auth_basic_desc =>
-      'Sends \'Authorization: Basic <base64(user:pass)>\' header.';
+  String get settings_server_auth_basic_desc => 'Sends \'Authorization: Basic <base64(user:pass)>\' header.';
 
   @override
-  String get settings_server_auth_bearer_desc =>
-      'Sends \'Authorization: Bearer <token>\' header.';
+  String get settings_server_auth_bearer_desc => 'Sends \'Authorization: Bearer <token>\' header.';
 
   @override
   String get common_edit => 'Edit';
@@ -1785,8 +1701,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get common_gallery => 'Gallery';
 
   @override
-  String get images_gallery_rating_unavailable =>
-      'Gallery rating is only available when browsing a gallery.';
+  String get images_gallery_rating_unavailable => 'Gallery rating is only available when browsing a gallery.';
 
   @override
   String images_rating(String rating) {
@@ -1797,8 +1712,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get images_filtered_by_gallery => 'Filtered by Gallery';
 
   @override
-  String get images_slideshow_need_two =>
-      'Need at least 2 images for slideshow.';
+  String get images_slideshow_need_two => 'Need at least 2 images for slideshow.';
 
   @override
   String get images_slideshow_start_title => 'Start Slideshow';
@@ -1896,12 +1810,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get scenes_unmatched_scraped_tags => 'Unmatched Scraped Tags';
 
   @override
-  String get scenes_unmatched_scraped_performers =>
-      'Unmatched Scraped Performers';
+  String get scenes_unmatched_scraped_performers => 'Unmatched Scraped Performers';
 
   @override
-  String get scenes_no_matching_performer_found =>
-      'No matching performer found in library';
+  String get scenes_no_matching_performer_found => 'No matching performer found in library';
 
   @override
   String get common_unknown => 'Unknown';
@@ -2097,8 +2009,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_storage_usage_subtitle => 'Current space used by caches';
 
   @override
-  String get settings_storage_subtitle =>
-      'Manage local caches and storage limits';
+  String get settings_storage_subtitle => 'Manage local caches and storage limits';
 
   @override
   String get performers_field_name => 'Name';
@@ -2415,12 +2326,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get failed_to_load_tap_to_retry => 'Failed to load. Tap to retry.';
 
   @override
-  String get would_you_like_to_visit_the_release_page_to_download_it =>
-      'Would you like to visit the release page to download it?';
+  String get would_you_like_to_visit_the_release_page_to_download_it => 'Would you like to visit the release page to download it?';
 
   @override
-  String get to_get_started_configure_stash_server =>
-      'To get started, you need to configure your Stash server connection details.';
+  String get to_get_started_configure_stash_server => 'To get started, you need to configure your Stash server connection details.';
 
   @override
   String get loading => 'Loading';
@@ -2523,8 +2432,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get main_startup_failed => 'StashFlow failed to start';
 
   @override
-  String get main_startup_failed_desc =>
-      'A startup service failed before the app could finish initializing. Restart the app after checking diagnostics.';
+  String get main_startup_failed_desc => 'A startup service failed before the app could finish initializing. Restart the app after checking diagnostics.';
 
   @override
   String common_searching_for(String query) {
@@ -2565,22 +2473,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_security_enable_app_lock => 'Enable app lock';
 
   @override
-  String get settings_security_enable_app_lock_subtitle =>
-      'Require passcode on app resume/launch.';
+  String get settings_security_enable_app_lock_subtitle => 'Require passcode on app resume/launch.';
 
   @override
   String get settings_security_lock_on_launch => 'Lock on app launch';
 
   @override
-  String get settings_security_lock_on_launch_subtitle =>
-      'Ask for passcode immediately when app opens.';
+  String get settings_security_lock_on_launch_subtitle => 'Ask for passcode immediately when app opens.';
 
   @override
   String get settings_security_background_lock_timer => 'Background lock timer';
 
   @override
-  String get settings_security_background_lock_timer_subtitle =>
-      'How long the app can stay in background before locking.';
+  String get settings_security_background_lock_timer_subtitle => 'How long the app can stay in background before locking.';
 
   @override
   String get settings_security_set_passcode => 'Set passcode';
@@ -2592,8 +2497,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_security_confirm_passcode => 'Confirm';
 
   @override
-  String get settings_security_error_numeric =>
-      'Use only digits, with length 4-8.';
+  String get settings_security_error_numeric => 'Use only digits, with length 4-8.';
 
   @override
   String get settings_security_error_mismatch => 'Passcodes do not match.';
@@ -2632,8 +2536,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_security_app_lock => 'App lock';
 
   @override
-  String get settings_security_app_lock_subtitle =>
-      'Protect access with a passcode after backgrounding.';
+  String get settings_security_app_lock_subtitle => 'Protect access with a passcode after backgrounding.';
 
   @override
   String get common_saved_filters => 'Saved filters';
@@ -2642,16 +2545,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tools => 'Tools';
 
   @override
-  String get tools_section_subtitle =>
-      'Maintenance and metadata workflows for scenes.';
+  String get tools_section_subtitle => 'Maintenance and metadata workflows for scenes.';
 
   @override
-  String get tools_scene_deduplication_subtitle =>
-      'Find and manage duplicate scenes.';
+  String get tools_scene_deduplication_subtitle => 'Find and manage duplicate scenes.';
 
   @override
-  String get tools_scene_tagger_subtitle =>
-      'Scrape current scene pages with Stash-box.';
+  String get tools_scene_tagger_subtitle => 'Scrape current scene pages with Stash-box.';
 
   @override
   String get preset_deleted => 'Preset deleted';
@@ -2801,8 +2701,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get enter_preset_name => 'Enter preset name';
 
   @override
-  String get delete_scene_confirm =>
-      'Are you sure you want to delete this scene?';
+  String get delete_scene_confirm => 'Are you sure you want to delete this scene?';
 
   @override
   String delete_selected_count(int selectedCount) {
@@ -2822,8 +2721,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get existing_names_are_overwritten => 'Existing names are overwritten';
 
   @override
-  String get active_settings_saved_server =>
-      'Current active settings will be saved to the server.';
+  String get active_settings_saved_server => 'Current active settings will be saved to the server.';
 
   @override
   String failed_to_save_filter(String error) {
@@ -2871,8 +2769,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get delete_scenes_help =>
-      'Choose whether to remove only Stash metadata or delete the scene files and generated supporting files too.';
+  String get delete_scenes_help => 'Choose whether to remove only Stash metadata or delete the scene files and generated supporting files too.';
 
   @override
   String deleted_n_scenes(int count) {
@@ -2893,8 +2790,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get merge_editing_not_wired =>
-      'Merge editing is not wired in StashFlow yet.';
+  String get merge_editing_not_wired => 'Merge editing is not wired in StashFlow yet.';
 
   @override
   String duplicate_sets_count(int count) {
@@ -2930,6 +2826,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String nTags(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2947,6 +2844,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String nGroups(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2964,6 +2862,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String nMarkers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2981,6 +2880,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String nGalleries(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3008,8 +2908,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get no_matched_scenes_yet => 'No matched scenes yet.';
 
   @override
-  String get no_scenes_match_configuration =>
-      'No scenes match this configuration.';
+  String get no_scenes_match_configuration => 'No scenes match this configuration.';
 
   @override
   String scene_tagger_checked_count(int count) {

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -45,6 +45,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String nScenes(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -62,6 +63,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String nPerformers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -79,6 +81,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String nPlays(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -150,8 +153,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get common_hide => 'Ocultar';
 
   @override
-  String get galleries_filter_saved =>
-      'Preferencias de filtrado guardadas como predeterminadas';
+  String get galleries_filter_saved => 'Preferencias de filtrado guardadas como predeterminadas';
 
   @override
   String get common_setup_required => 'Configuración requerida';
@@ -178,8 +180,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get studios_filter_title => 'Filtrar estudios';
 
   @override
-  String get studios_filter_saved =>
-      'Preferencias de filtro guardadas como predeterminadas';
+  String get studios_filter_saved => 'Preferencias de filtro guardadas como predeterminadas';
 
   @override
   String get sort_name => 'Nombre';
@@ -278,42 +279,34 @@ class AppLocalizationsEs extends AppLocalizations {
   String get sort_last_played_at => 'Última reproducción';
 
   @override
-  String get studios_sort_saved =>
-      'Preferencias de ordenación guardadas como predeterminadas';
+  String get studios_sort_saved => 'Preferencias de ordenación guardadas como predeterminadas';
 
   @override
-  String get studios_no_random =>
-      'No hay estudios disponibles para navegación aleatoria';
+  String get studios_no_random => 'No hay estudios disponibles para navegación aleatoria';
 
   @override
   String get tags_filter_title => 'Filtrar etiquetas';
 
   @override
-  String get tags_filter_saved =>
-      'Preferencias de filtro guardadas como predeterminadas';
+  String get tags_filter_saved => 'Preferencias de filtro guardadas como predeterminadas';
 
   @override
   String get tags_sort_title => 'Ordenar etiquetas';
 
   @override
-  String get tags_sort_saved =>
-      'Preferencias de ordenación guardadas como predeterminadas';
+  String get tags_sort_saved => 'Preferencias de ordenación guardadas como predeterminadas';
 
   @override
-  String get tags_no_random =>
-      'No hay etiquetas disponibles para navegación aleatoria';
+  String get tags_no_random => 'No hay etiquetas disponibles para navegación aleatoria';
 
   @override
-  String get scenes_no_random =>
-      'No hay escenas disponibles para navegación aleatoria';
+  String get scenes_no_random => 'No hay escenas disponibles para navegación aleatoria';
 
   @override
-  String get performers_no_random =>
-      'No hay actores disponibles para navegación aleatoria';
+  String get performers_no_random => 'No hay actores disponibles para navegación aleatoria';
 
   @override
-  String get galleries_no_random =>
-      'No hay galerías disponibles para navegación aleatoria';
+  String get galleries_no_random => 'No hay galerías disponibles para navegación aleatoria';
 
   @override
   String common_error(String message) {
@@ -598,8 +591,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get scenes_filter_title => 'Filtrar escenas';
 
   @override
-  String get scenes_filter_saved =>
-      'Preferencias de filtro guardadas como predeterminadas';
+  String get scenes_filter_saved => 'Preferencias de filtro guardadas como predeterminadas';
 
   @override
   String get scenes_watched => 'Vistas';
@@ -674,15 +666,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get scenes_sort_last_o_at => 'Último O el';
 
   @override
-  String get scenes_sort_group_scene_number =>
-      'Número de escena en grupo/película';
+  String get scenes_sort_group_scene_number => 'Número de escena en grupo/película';
 
   @override
   String get scenes_sort_code => 'Código';
 
   @override
-  String get scenes_sort_saved_default =>
-      'Preferencias de orden guardadas como predeterminado';
+  String get scenes_sort_saved_default => 'Preferencias de orden guardadas como predeterminado';
 
   @override
   String get scenes_sort_tooltip => 'Opciones de orden';
@@ -953,15 +943,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_customize => 'Personalizar StashFlow';
 
   @override
-  String get settings_customize_subtitle =>
-      'Ajusta la reproducción, apariencia, diseño y herramientas de soporte desde un solo lugar.';
+  String get settings_customize_subtitle => 'Ajusta la reproducción, apariencia, diseño y herramientas de soporte desde un solo lugar.';
 
   @override
   String get settings_core_section => 'Ajustes principales';
 
   @override
-  String get settings_core_subtitle =>
-      'Páginas de configuración más utilizadas';
+  String get settings_core_subtitle => 'Páginas de configuración más utilizadas';
 
   @override
   String get settings_server => 'Servidor';
@@ -973,22 +961,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_playback => 'Reproducción';
 
   @override
-  String get settings_playback_subtitle =>
-      'Comportamiento e interacciones del reproductor';
+  String get settings_playback_subtitle => 'Comportamiento e interacciones del reproductor';
 
   @override
   String get settings_keyboard => 'Teclado';
 
   @override
-  String get settings_keyboard_subtitle =>
-      'Atajos y teclas de acceso rápido personalizables';
+  String get settings_keyboard_subtitle => 'Atajos y teclas de acceso rápido personalizables';
 
   @override
   String get settings_keyboard_title => 'Atajos de teclado';
 
   @override
-  String get settings_keyboard_reset_defaults =>
-      'Restablecer valores predeterminados';
+  String get settings_keyboard_reset_defaults => 'Restablecer valores predeterminados';
 
   @override
   String get settings_keyboard_not_bound => 'No asignado';
@@ -1003,8 +988,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_keyboard_toggle_mute => 'Alternar silencio';
 
   @override
-  String get settings_keyboard_toggle_fullscreen =>
-      'Alternar pantalla completa';
+  String get settings_keyboard_toggle_fullscreen => 'Alternar pantalla completa';
 
   @override
   String get settings_keyboard_next_scene => 'Siguiente escena';
@@ -1013,16 +997,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_keyboard_prev_scene => 'Escena anterior';
 
   @override
-  String get settings_keyboard_increase_speed =>
-      'Aumentar velocidad de reproducción';
+  String get settings_keyboard_increase_speed => 'Aumentar velocidad de reproducción';
 
   @override
-  String get settings_keyboard_decrease_speed =>
-      'Disminuir velocidad de reproducción';
+  String get settings_keyboard_decrease_speed => 'Disminuir velocidad de reproducción';
 
   @override
-  String get settings_keyboard_reset_speed =>
-      'Restablecer velocidad de reproducción';
+  String get settings_keyboard_reset_speed => 'Restablecer velocidad de reproducción';
 
   @override
   String get settings_keyboard_close_player => 'Cerrar reproductor';
@@ -1037,24 +1018,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_keyboard_go_back => 'Volver';
 
   @override
-  String get settings_keyboard_play_pause_desc =>
-      'Alternar entre reproducir y pausar video';
+  String get settings_keyboard_play_pause_desc => 'Alternar entre reproducir y pausar video';
 
   @override
-  String get settings_keyboard_seek_forward_5_desc =>
-      'Saltar adelante 5 segundos';
+  String get settings_keyboard_seek_forward_5_desc => 'Saltar adelante 5 segundos';
 
   @override
-  String get settings_keyboard_seek_backward_5_desc =>
-      'Saltar atrás 5 segundos';
+  String get settings_keyboard_seek_backward_5_desc => 'Saltar atrás 5 segundos';
 
   @override
-  String get settings_keyboard_seek_forward_10_desc =>
-      'Saltar adelante 10 segundos';
+  String get settings_keyboard_seek_forward_10_desc => 'Saltar adelante 10 segundos';
 
   @override
-  String get settings_keyboard_seek_backward_10_desc =>
-      'Saltar atrás 10 segundos';
+  String get settings_keyboard_seek_backward_10_desc => 'Saltar atrás 10 segundos';
 
   @override
   String get settings_appearance => 'Apariencia';
@@ -1066,8 +1042,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_interface => 'Interfaz';
 
   @override
-  String get settings_interface_subtitle =>
-      'Valores predeterminados de navegación y diseño';
+  String get settings_interface_subtitle => 'Valores predeterminados de navegación y diseño';
 
   @override
   String get settings_support => 'Soporte';
@@ -1079,8 +1054,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_develop => 'Desarrollo';
 
   @override
-  String get settings_develop_subtitle =>
-      'Herramientas avanzadas y anulaciones';
+  String get settings_develop_subtitle => 'Herramientas avanzadas y anulaciones';
 
   @override
   String get settings_appearance_title => 'Ajustes de apariencia';
@@ -1089,8 +1063,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_appearance_theme_mode => 'Modo de tema';
 
   @override
-  String get settings_appearance_theme_mode_subtitle =>
-      'Elige cómo la aplicación sigue los cambios de brillo';
+  String get settings_appearance_theme_mode_subtitle => 'Elige cómo la aplicación sigue los cambios de brillo';
 
   @override
   String get settings_appearance_theme_system => 'Sistema';
@@ -1105,38 +1078,31 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_appearance_primary_color => 'Color primario';
 
   @override
-  String get settings_appearance_primary_color_subtitle =>
-      'Elige un color base para la paleta Material 3';
+  String get settings_appearance_primary_color_subtitle => 'Elige un color base para la paleta Material 3';
 
   @override
   String get settings_appearance_advanced_theming => 'Tematización avanzada';
 
   @override
-  String get settings_appearance_advanced_theming_subtitle =>
-      'Optimizaciones para tipos de pantalla específicos';
+  String get settings_appearance_advanced_theming_subtitle => 'Optimizaciones para tipos de pantalla específicos';
 
   @override
   String get settings_appearance_true_black => 'Negro puro (AMOLED)';
 
   @override
-  String get settings_appearance_true_black_subtitle =>
-      'Usa fondos negros puros en el modo oscuro para ahorrar batería en pantallas OLED';
+  String get settings_appearance_true_black_subtitle => 'Usa fondos negros puros en el modo oscuro para ahorrar batería en pantallas OLED';
 
   @override
-  String get settings_appearance_custom_hex =>
-      'Color hexadecimal personalizado';
+  String get settings_appearance_custom_hex => 'Color hexadecimal personalizado';
 
   @override
-  String get settings_appearance_custom_hex_helper =>
-      'Introduce un código hexadecimal ARGB de 8 dígitos';
+  String get settings_appearance_custom_hex_helper => 'Introduce un código hexadecimal ARGB de 8 dígitos';
 
   @override
-  String get settings_appearance_font_size =>
-      'Escala de interfaz de usuario global';
+  String get settings_appearance_font_size => 'Escala de interfaz de usuario global';
 
   @override
-  String get settings_appearance_font_size_subtitle =>
-      'Escalar la tipografía y el espaciado proporcionalmente';
+  String get settings_appearance_font_size_subtitle => 'Escalar la tipografía y el espaciado proporcionalmente';
 
   @override
   String get settings_interface_title => 'Ajustes de interfaz';
@@ -1145,8 +1111,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_interface_language => 'Idioma';
 
   @override
-  String get settings_interface_language_subtitle =>
-      'Anular el idioma predeterminado del sistema';
+  String get settings_interface_language_subtitle => 'Anular el idioma predeterminado del sistema';
 
   @override
   String get settings_interface_app_language => 'Idioma de la aplicación';
@@ -1155,103 +1120,82 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_interface_navigation => 'Navegación';
 
   @override
-  String get settings_interface_navigation_subtitle =>
-      'Visibilidad de los atajos de navegación global';
+  String get settings_interface_navigation_subtitle => 'Visibilidad de los atajos de navegación global';
 
   @override
-  String get settings_interface_show_random =>
-      'Mostrar botones de navegación aleatoria';
+  String get settings_interface_show_random => 'Mostrar botones de navegación aleatoria';
 
   @override
-  String get settings_interface_show_random_subtitle =>
-      'Habilitar o deshabilitar los botones flotantes de casino en las páginas de lista y detalles';
+  String get settings_interface_show_random_subtitle => 'Habilitar o deshabilitar los botones flotantes de casino en las páginas de lista y detalles';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation =>
-      'Orientación controlada por gravedad (páginas principales)';
+  String get settings_interface_main_pages_gravity_orientation => 'Orientación controlada por gravedad (páginas principales)';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation_subtitle =>
-      'Permite que las páginas principales roten usando el sensor del dispositivo. La reproducción de video en pantalla completa usa su propia configuración de orientación.';
+  String get settings_interface_main_pages_gravity_orientation_subtitle => 'Permite que las páginas principales roten usando el sensor del dispositivo. La reproducción de video en pantalla completa usa su propia configuración de orientación.';
 
   @override
   String get settings_interface_show_edit => 'Mostrar botón de editar';
 
   @override
-  String get settings_interface_show_edit_subtitle =>
-      'Habilitar o deshabilitar el botón de editar en la página de detalles de la escena';
+  String get settings_interface_show_edit_subtitle => 'Habilitar o deshabilitar el botón de editar en la página de detalles de la escena';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer =>
-      'Usar video real de escena en el minirreproductor';
+  String get settings_interface_use_actual_scene_video_miniplayer => 'Usar video real de escena en el minirreproductor';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer_subtitle =>
-      'Muestra la superficie de video en vivo en lugar de la captura de la escena cuando la reproducción está activa.';
+  String get settings_interface_use_actual_scene_video_miniplayer_subtitle => 'Muestra la superficie de video en vivo en lugar de la captura de la escena cuando la reproducción está activa.';
 
   @override
-  String get settings_interface_entity_image_filtering =>
-      'Filtrado de imágenes de entidad';
+  String get settings_interface_entity_image_filtering => 'Filtrado de imágenes de entidad';
 
   @override
-  String get settings_interface_entity_image_filtering_subtitle =>
-      'Elige si las páginas de imágenes de entidad coinciden con los metadatos de imagen o las galerías relacionadas.';
+  String get settings_interface_entity_image_filtering_subtitle => 'Elige si las páginas de imágenes de entidad coinciden con los metadatos de imagen o las galerías relacionadas.';
 
   @override
-  String get settings_interface_entity_image_filtering_direct =>
-      'Entidad directa';
+  String get settings_interface_entity_image_filtering_direct => 'Entidad directa';
 
   @override
-  String get settings_interface_entity_image_filtering_galleries =>
-      'Galerías relacionadas';
+  String get settings_interface_entity_image_filtering_galleries => 'Galerías relacionadas';
 
   @override
   String get settings_interface_customize_tabs => 'Personalizar pestañas';
 
   @override
-  String get settings_interface_customize_tabs_subtitle =>
-      'Reordenar u ocultar elementos del menú de navegación';
+  String get settings_interface_customize_tabs_subtitle => 'Reordenar u ocultar elementos del menú de navegación';
 
   @override
   String get settings_interface_scenes_layout => 'Diseño de escenas';
 
   @override
-  String get settings_interface_scenes_layout_subtitle =>
-      'Modo de navegación predeterminado para escenas';
+  String get settings_interface_scenes_layout_subtitle => 'Modo de navegación predeterminado para escenas';
 
   @override
   String get settings_interface_galleries_layout => 'Diseño de galerías';
 
   @override
-  String get settings_interface_galleries_layout_subtitle =>
-      'Modo de navegación predeterminado para galerías';
+  String get settings_interface_galleries_layout_subtitle => 'Modo de navegación predeterminado para galerías';
 
   @override
-  String get settings_interface_max_performer_avatars =>
-      'Máximo de avatares de intérpretes';
+  String get settings_interface_max_performer_avatars => 'Máximo de avatares de intérpretes';
 
   @override
-  String get settings_interface_max_performer_avatars_subtitle =>
-      'Número máximo de avatares de intérpretes a mostrar en la tarjeta de escena.';
+  String get settings_interface_max_performer_avatars_subtitle => 'Número máximo de avatares de intérpretes a mostrar en la tarjeta de escena.';
 
   @override
-  String get settings_interface_show_performer_avatars =>
-      'Mostrar avatares de intérpretes';
+  String get settings_interface_show_performer_avatars => 'Mostrar avatares de intérpretes';
 
   @override
-  String get settings_interface_show_performer_avatars_subtitle =>
-      'Mostrar iconos de intérpretes en las tarjetas de escena en todas las plataformas.';
+  String get settings_interface_show_performer_avatars_subtitle => 'Mostrar iconos de intérpretes en las tarjetas de escena en todas las plataformas.';
 
   @override
-  String get settings_interface_performer_avatar_size =>
-      'Tamaño del avatar del intérprete';
+  String get settings_interface_performer_avatar_size => 'Tamaño del avatar del intérprete';
 
   @override
   String get settings_interface_layout_default => 'Diseño predeterminado';
 
   @override
-  String get settings_interface_layout_default_desc =>
-      'Elige el diseño predeterminado para la página';
+  String get settings_interface_layout_default_desc => 'Elige el diseño predeterminado para la página';
 
   @override
   String get settings_interface_layout_list => 'Lista';
@@ -1269,16 +1213,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_interface_image_viewer => 'Visor de imágenes';
 
   @override
-  String get settings_interface_image_viewer_subtitle =>
-      'Configurar el comportamiento de navegación de imágenes a pantalla completa';
+  String get settings_interface_image_viewer_subtitle => 'Configurar el comportamiento de navegación de imágenes a pantalla completa';
 
   @override
-  String get settings_interface_swipe_direction =>
-      'Dirección de deslizamiento a pantalla completa';
+  String get settings_interface_swipe_direction => 'Dirección de deslizamiento a pantalla completa';
 
   @override
-  String get settings_interface_swipe_direction_desc =>
-      'Elige cómo avanzan las imágenes en el modo de pantalla completa';
+  String get settings_interface_swipe_direction_desc => 'Elige cómo avanzan las imágenes en el modo de pantalla completa';
 
   @override
   String get settings_interface_swipe_vertical => 'Vertical';
@@ -1287,43 +1228,37 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_interface_swipe_horizontal => 'Horizontal';
 
   @override
-  String get settings_interface_waterfall_columns =>
-      'Columnas de cuadrícula en cascada';
+  String get settings_interface_waterfall_columns => 'Columnas de cuadrícula en cascada';
 
   @override
   String get settings_interface_performer_layouts => 'Diseños de actores';
 
   @override
-  String get settings_interface_performer_layouts_subtitle =>
-      'Valores predeterminados de medios y galerías para actores';
+  String get settings_interface_performer_layouts_subtitle => 'Valores predeterminados de medios y galerías para actores';
 
   @override
   String get settings_interface_studio_layouts => 'Diseños de estudios';
 
   @override
-  String get settings_interface_studio_layouts_subtitle =>
-      'Valores predeterminados de medios y galerías para estudios';
+  String get settings_interface_studio_layouts_subtitle => 'Valores predeterminados de medios y galerías para estudios';
 
   @override
   String get settings_interface_tag_layouts => 'Diseños de etiquetas';
 
   @override
-  String get settings_interface_tag_layouts_subtitle =>
-      'Valores predeterminados de medios y galerías para etiquetas';
+  String get settings_interface_tag_layouts_subtitle => 'Valores predeterminados de medios y galerías para etiquetas';
 
   @override
   String get settings_interface_media_layout => 'Diseño de medios';
 
   @override
-  String get settings_interface_media_layout_subtitle =>
-      'Diseño para la página de medios';
+  String get settings_interface_media_layout_subtitle => 'Diseño para la página de medios';
 
   @override
   String get settings_interface_galleries_layout_item => 'Diseño de galerías';
 
   @override
-  String get settings_interface_galleries_layout_subtitle_item =>
-      'Diseño para la página de galerías';
+  String get settings_interface_galleries_layout_subtitle_item => 'Diseño para la página de galerías';
 
   @override
   String get settings_server_title => 'Ajustes del servidor';
@@ -1332,22 +1267,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_server_status => 'Estado de la conexión';
 
   @override
-  String get settings_server_status_subtitle =>
-      'Conectividad en vivo con el servidor configurado';
+  String get settings_server_status_subtitle => 'Conectividad en vivo con el servidor configurado';
 
   @override
   String get settings_server_details => 'Detalles del servidor';
 
   @override
-  String get settings_server_details_subtitle =>
-      'Configurar el endpoint y el método de autenticación';
+  String get settings_server_details_subtitle => 'Configurar el endpoint y el método de autenticación';
 
   @override
   String get settings_server_url => 'URL de Stash';
 
   @override
-  String get settings_server_url_helper =>
-      'Introduce la URL de tu servidor Stash. Si está configurado con una ruta personalizada, inclúyela aquí.';
+  String get settings_server_url_helper => 'Introduce la URL de tu servidor Stash. Si está configurado con una ruta personalizada, inclúyela aquí.';
 
   @override
   String get settings_server_url_example => 'http://192.168.1.100:9999';
@@ -1365,12 +1297,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_server_auth_password => 'Usuario + Contraseña';
 
   @override
-  String get settings_server_auth_password_desc =>
-      'Recomendado: usa tu sesión de usuario/contraseña de Stash.';
+  String get settings_server_auth_password_desc => 'Recomendado: usa tu sesión de usuario/contraseña de Stash.';
 
   @override
-  String get settings_server_auth_apikey_desc =>
-      'Usa la clave API para la autenticación de token estático.';
+  String get settings_server_auth_apikey_desc => 'Usa la clave API para la autenticación de token estático.';
 
   @override
   String get settings_server_username => 'Nombre de usuario';
@@ -1407,12 +1337,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_server_invalid_url => 'URL del servidor no válida';
 
   @override
-  String get settings_server_resolve_error =>
-      'No se pudo resolver la URL del servidor. Comprueba el host, el puerto y las credenciales.';
+  String get settings_server_resolve_error => 'No se pudo resolver la URL del servidor. Comprueba el host, el puerto y las credenciales.';
 
   @override
-  String get settings_server_logout_confirm =>
-      'Sesión cerrada y cookies borradas.';
+  String get settings_server_logout_confirm => 'Sesión cerrada y cookies borradas.';
 
   @override
   String get settings_server_profile_add => 'Añadir perfil';
@@ -1427,34 +1355,28 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_server_profile_delete => 'Eliminar perfil';
 
   @override
-  String get settings_server_profile_delete_confirm =>
-      '¿Estás seguro de que quieres eliminar este perfil? Esta acción no se puede deshacer.';
+  String get settings_server_profile_delete_confirm => '¿Estás seguro de que quieres eliminar este perfil? Esta acción no se puede deshacer.';
 
   @override
   String get settings_server_profile_active => 'Activo';
 
   @override
-  String get settings_server_profile_empty =>
-      'No hay perfiles de servidor configurados';
+  String get settings_server_profile_empty => 'No hay perfiles de servidor configurados';
 
   @override
   String get settings_server_profiles => 'Perfiles de servidor';
 
   @override
-  String get settings_server_profiles_subtitle =>
-      'Gestionar múltiples conexiones de servidor Stash';
+  String get settings_server_profiles_subtitle => 'Gestionar múltiples conexiones de servidor Stash';
 
   @override
-  String get settings_server_auth_status_logging_in =>
-      'Estado de autenticación: iniciando sesión...';
+  String get settings_server_auth_status_logging_in => 'Estado de autenticación: iniciando sesión...';
 
   @override
-  String get settings_server_auth_status_logged_in =>
-      'Estado de autenticación: sesión iniciada';
+  String get settings_server_auth_status_logged_in => 'Estado de autenticación: sesión iniciada';
 
   @override
-  String get settings_server_auth_status_logged_out =>
-      'Estado de autenticación: sesión cerrada';
+  String get settings_server_auth_status_logged_out => 'Estado de autenticación: sesión cerrada';
 
   @override
   String get settings_playback_title => 'Ajustes de reproducción';
@@ -1463,40 +1385,31 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_playback_behavior => 'Comportamiento de reproducción';
 
   @override
-  String get settings_playback_behavior_subtitle =>
-      'Manejo predeterminado de la reproducción y el segundo plano';
+  String get settings_playback_behavior_subtitle => 'Manejo predeterminado de la reproducción y el segundo plano';
 
   @override
-  String get settings_playback_prefer_streams =>
-      'Preferir sceneStreams primero';
+  String get settings_playback_prefer_streams => 'Preferir sceneStreams primero';
 
   @override
-  String get settings_playback_prefer_streams_subtitle =>
-      'Cuando está desactivado, la reproducción usa directamente paths.stream';
+  String get settings_playback_prefer_streams_subtitle => 'Cuando está desactivado, la reproducción usa directamente paths.stream';
 
   @override
-  String get settings_playback_feed_random =>
-      'Iniciar Feed desde posición aleatoria';
+  String get settings_playback_feed_random => 'Iniciar Feed desde posición aleatoria';
 
   @override
-  String get settings_playback_feed_random_subtitle =>
-      'Al reproducir escenas en modo Feed, iniciar desde una posición aleatoria entre el 0% y el 90% de la duración del video';
+  String get settings_playback_feed_random_subtitle => 'Al reproducir escenas en modo Feed, iniciar desde una posición aleatoria entre el 0% y el 90% de la duración del video';
 
   @override
-  String get settings_playback_resume_position =>
-      'Reanudar desde la última posición de juego';
+  String get settings_playback_resume_position => 'Reanudar desde la última posición de juego';
 
   @override
-  String get settings_playback_resume_position_subtitle =>
-      'Al abrir un vídeo, se reanuda automáticamente desde donde lo dejaste.';
+  String get settings_playback_resume_position_subtitle => 'Al abrir un vídeo, se reanuda automáticamente desde donde lo dejaste.';
 
   @override
-  String get settings_playback_end_behavior =>
-      'Comportamiento de finalización del juego';
+  String get settings_playback_end_behavior => 'Comportamiento de finalización del juego';
 
   @override
-  String get settings_playback_end_behavior_subtitle =>
-      'Qué hacer cuando finaliza la reproducción actual';
+  String get settings_playback_end_behavior_subtitle => 'Qué hacer cuando finaliza la reproducción actual';
 
   @override
   String get settings_playback_end_behavior_stop => 'Detener';
@@ -1505,53 +1418,43 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_playback_end_behavior_loop => 'Bucle de escena actual';
 
   @override
-  String get settings_playback_end_behavior_next =>
-      'Reproducir la siguiente escena';
+  String get settings_playback_end_behavior_next => 'Reproducir la siguiente escena';
 
   @override
-  String get settings_playback_autoplay =>
-      'Reproducción automática de la siguiente escena';
+  String get settings_playback_autoplay => 'Reproducción automática de la siguiente escena';
 
   @override
-  String get settings_playback_autoplay_subtitle =>
-      'Reproducir automáticamente la siguiente escena cuando finalice la reproducción actual';
+  String get settings_playback_autoplay_subtitle => 'Reproducir automáticamente la siguiente escena cuando finalice la reproducción actual';
 
   @override
   String get settings_playback_background => 'Reproducción en segundo plano';
 
   @override
-  String get settings_playback_background_subtitle =>
-      'Mantener el audio del video reproduciéndose cuando la aplicación está en segundo plano';
+  String get settings_playback_background_subtitle => 'Mantener el audio del video reproduciéndose cuando la aplicación está en segundo plano';
 
   @override
   String get settings_playback_pip => 'Imagen en imagen nativa';
 
   @override
-  String get settings_playback_pip_subtitle =>
-      'Habilitar el botón PiP de Android y entrar automáticamente al pasar a segundo plano';
+  String get settings_playback_pip_subtitle => 'Habilitar el botón PiP de Android y entrar automáticamente al pasar a segundo plano';
 
   @override
   String get settings_playback_subtitles => 'Ajustes de subtítulos';
 
   @override
-  String get settings_playback_subtitles_subtitle =>
-      'Carga automática y apariencia';
+  String get settings_playback_subtitles_subtitle => 'Carga automática y apariencia';
 
   @override
-  String get settings_playback_subtitle_lang =>
-      'Idioma de subtítulos predeterminado';
+  String get settings_playback_subtitle_lang => 'Idioma de subtítulos predeterminado';
 
   @override
-  String get settings_playback_subtitle_lang_subtitle =>
-      'Carga automática si está disponible';
+  String get settings_playback_subtitle_lang_subtitle => 'Carga automática si está disponible';
 
   @override
-  String get settings_playback_subtitle_size =>
-      'Tamaño de fuente de los subtítulos';
+  String get settings_playback_subtitle_size => 'Tamaño de fuente de los subtítulos';
 
   @override
-  String get settings_playback_subtitle_pos =>
-      'Posición vertical de los subtítulos';
+  String get settings_playback_subtitle_pos => 'Posición vertical de los subtítulos';
 
   @override
   String settings_playback_subtitle_pos_desc(String percent) {
@@ -1559,27 +1462,22 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get settings_playback_subtitle_align =>
-      'Alineación del texto de los subtítulos';
+  String get settings_playback_subtitle_align => 'Alineación del texto de los subtítulos';
 
   @override
-  String get settings_playback_subtitle_align_subtitle =>
-      'Alineación para subtítulos de varias líneas';
+  String get settings_playback_subtitle_align_subtitle => 'Alineación para subtítulos de varias líneas';
 
   @override
   String get settings_playback_seek => 'Interacción de búsqueda';
 
   @override
-  String get settings_playback_seek_subtitle =>
-      'Elige cómo funciona el desplazamiento durante la reproducción';
+  String get settings_playback_seek_subtitle => 'Elige cómo funciona el desplazamiento durante la reproducción';
 
   @override
-  String get settings_playback_seek_double_tap =>
-      'Doble toque izquierda/derecha para buscar 10s';
+  String get settings_playback_seek_double_tap => 'Doble toque izquierda/derecha para buscar 10s';
 
   @override
-  String get settings_playback_seek_drag =>
-      'Arrastra la línea de tiempo para buscar';
+  String get settings_playback_seek_drag => 'Arrastra la línea de tiempo para buscar';
 
   @override
   String get settings_playback_seek_drag_label => 'Arrastrar';
@@ -1588,28 +1486,22 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_playback_seek_double_tap_label => 'Doble toque';
 
   @override
-  String get settings_playback_gravity_orientation =>
-      'Orientación controlada por la gravedad';
+  String get settings_playback_gravity_orientation => 'Orientación controlada por la gravedad';
 
   @override
-  String get settings_playback_direct_play =>
-      'Reproducción directa al navegar por escenas';
+  String get settings_playback_direct_play => 'Reproducción directa al navegar por escenas';
 
   @override
-  String get settings_playback_direct_play_subtitle =>
-      'Al navegar desde otra escena en reproducción, reproducir directamente la nueva escena';
+  String get settings_playback_direct_play_subtitle => 'Al navegar desde otra escena en reproducción, reproducir directamente la nueva escena';
 
   @override
-  String get settings_playback_gravity_orientation_subtitle =>
-      'Permitir rotar entre orientaciones coincidentes usando el sensor del dispositivo (p. ej., girar el paisaje izquierda/derecha).';
+  String get settings_playback_gravity_orientation_subtitle => 'Permitir rotar entre orientaciones coincidentes usando el sensor del dispositivo (p. ej., girar el paisaje izquierda/derecha).';
 
   @override
-  String get settings_playback_subtitle_lang_none_disabled =>
-      'Ninguno (Desactivado)';
+  String get settings_playback_subtitle_lang_none_disabled => 'Ninguno (Desactivado)';
 
   @override
-  String get settings_playback_subtitle_lang_auto_if_only_one =>
-      'Automático (Si solo hay uno)';
+  String get settings_playback_subtitle_lang_auto_if_only_one => 'Automático (Si solo hay uno)';
 
   @override
   String get settings_playback_subtitle_lang_english => 'Inglés';
@@ -1648,19 +1540,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_support_title => 'Soporte';
 
   @override
-  String get settings_support_diagnostics =>
-      'Diagnósticos e información del proyecto';
+  String get settings_support_diagnostics => 'Diagnósticos e información del proyecto';
 
   @override
-  String get settings_support_diagnostics_subtitle =>
-      'Abre los registros de ejecución o ve al repositorio cuando necesites ayuda.';
+  String get settings_support_diagnostics_subtitle => 'Abre los registros de ejecución o ve al repositorio cuando necesites ayuda.';
 
   @override
   String get settings_support_update_available => 'Actualización disponible';
 
   @override
-  String get settings_support_update_available_subtitle =>
-      'Hay una versión más reciente disponible en GitHub';
+  String get settings_support_update_available_subtitle => 'Hay una versión más reciente disponible en GitHub';
 
   @override
   String settings_support_update_to(String version) {
@@ -1668,108 +1557,88 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get settings_support_update_to_subtitle =>
-      'Nuevas características y mejoras te esperan.';
+  String get settings_support_update_to_subtitle => 'Nuevas características y mejoras te esperan.';
 
   @override
   String get settings_support_about => 'Acerca de';
 
   @override
-  String get settings_support_about_subtitle =>
-      'Información del proyecto y de las fuentes';
+  String get settings_support_about_subtitle => 'Información del proyecto y de las fuentes';
 
   @override
   String get settings_support_version => 'Versión';
 
   @override
-  String get settings_support_version_loading =>
-      'Cargando información de la versión...';
+  String get settings_support_version_loading => 'Cargando información de la versión...';
 
   @override
-  String get settings_support_version_unavailable =>
-      'Información de la versión no disponible';
+  String get settings_support_version_unavailable => 'Información de la versión no disponible';
 
   @override
   String get settings_support_github => 'Repositorio de GitHub';
 
   @override
-  String get settings_support_github_subtitle =>
-      'Ver el código fuente e informar de problemas';
+  String get settings_support_github_subtitle => 'Ver el código fuente e informar de problemas';
 
   @override
-  String get settings_support_github_error =>
-      'No se pudo abrir el enlace de GitHub';
+  String get settings_support_github_error => 'No se pudo abrir el enlace de GitHub';
 
   @override
   String get settings_support_issues => 'Informar un problema';
 
   @override
-  String get settings_support_issues_subtitle =>
-      'Ayude a mejorar StashFlow informando errores';
+  String get settings_support_issues_subtitle => 'Ayude a mejorar StashFlow informando errores';
 
   @override
   String get settings_develop_title => 'Desarrollo';
 
   @override
-  String get settings_develop_enable_logging =>
-      'Activar registro de depuración';
+  String get settings_develop_enable_logging => 'Activar registro de depuración';
 
   @override
-  String get settings_develop_enable_logging_subtitle =>
-      'Registrar registros de la aplicación para solucionar problemas';
+  String get settings_develop_enable_logging_subtitle => 'Registrar registros de la aplicación para solucionar problemas';
 
   @override
   String get settings_develop_diagnostics => 'Herramientas de diagnóstico';
 
   @override
-  String get settings_develop_diagnostics_subtitle =>
-      'Solución de problemas y rendimiento';
+  String get settings_develop_diagnostics_subtitle => 'Solución de problemas y rendimiento';
 
   @override
-  String get settings_develop_video_debug =>
-      'Mostrar información de depuración de video';
+  String get settings_develop_video_debug => 'Mostrar información de depuración de video';
 
   @override
-  String get settings_develop_video_debug_subtitle =>
-      'Muestra detalles técnicos de reproducción como una superposición en el reproductor de video.';
+  String get settings_develop_video_debug_subtitle => 'Muestra detalles técnicos de reproducción como una superposición en el reproductor de video.';
 
   @override
   String get settings_develop_log_viewer => 'Visor de registros de depuración';
 
   @override
-  String get settings_develop_log_viewer_subtitle =>
-      'Abre una vista en vivo de los registros de la aplicación.';
+  String get settings_develop_log_viewer_subtitle => 'Abre una vista en vivo de los registros de la aplicación.';
 
   @override
-  String get settings_develop_logs_copied =>
-      'Registros copiados al portapapeles';
+  String get settings_develop_logs_copied => 'Registros copiados al portapapeles';
 
   @override
-  String get settings_develop_no_logs =>
-      'No hay registros todavía. Interactúa con la app para capturar registros.';
+  String get settings_develop_no_logs => 'No hay registros todavía. Interactúa con la app para capturar registros.';
 
   @override
   String get settings_develop_web_overrides => 'Anulaciones web';
 
   @override
-  String get settings_develop_web_overrides_subtitle =>
-      'Indicadores avanzados para la plataforma web';
+  String get settings_develop_web_overrides_subtitle => 'Indicadores avanzados para la plataforma web';
 
   @override
-  String get settings_develop_web_auth =>
-      'Permitir inicio de sesión con contraseña en la web';
+  String get settings_develop_web_auth => 'Permitir inicio de sesión con contraseña en la web';
 
   @override
-  String get settings_develop_web_auth_subtitle =>
-      'Anula la restricción solo nativa y fuerza a que el método de autenticación Usuario + Contraseña sea visible en Flutter Web.';
+  String get settings_develop_web_auth_subtitle => 'Anula la restricción solo nativa y fuerza a que el método de autenticación Usuario + Contraseña sea visible en Flutter Web.';
 
   @override
-  String get settings_develop_proxy_auth =>
-      'Habilitar modos de autenticación de proxy';
+  String get settings_develop_proxy_auth => 'Habilitar modos de autenticación de proxy';
 
   @override
-  String get settings_develop_proxy_auth_subtitle =>
-      'Habilite los métodos avanzados de Basic Auth y Bearer Token para su uso con backends sin autenticación detrás de proxies como Authentik.';
+  String get settings_develop_proxy_auth_subtitle => 'Habilite los métodos avanzados de Basic Auth y Bearer Token para su uso con backends sin autenticación detrás de proxies como Authentik.';
 
   @override
   String get settings_server_auth_basic => 'Autenticación básica';
@@ -1778,12 +1647,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_server_auth_bearer => 'Token de portador';
 
   @override
-  String get settings_server_auth_basic_desc =>
-      'Envía el encabezado \'Authorization: Basic <base64(user:pass)>\'.';
+  String get settings_server_auth_basic_desc => 'Envía el encabezado \'Authorization: Basic <base64(user:pass)>\'.';
 
   @override
-  String get settings_server_auth_bearer_desc =>
-      'Envía el encabezado \'Authorization: Bearer <token>\'.';
+  String get settings_server_auth_bearer_desc => 'Envía el encabezado \'Authorization: Bearer <token>\'.';
 
   @override
   String get common_edit => 'Editar';
@@ -1804,8 +1671,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get common_square => 'Cuadrado';
 
   @override
-  String get performers_filter_saved =>
-      'Preferencias de filtro guardadas como predeterminadas';
+  String get performers_filter_saved => 'Preferencias de filtro guardadas como predeterminadas';
 
   @override
   String get images_title => 'Imágenes';
@@ -1814,22 +1680,19 @@ class AppLocalizationsEs extends AppLocalizations {
   String get images_filter_title => 'Filtrar imágenes';
 
   @override
-  String get images_filter_saved =>
-      'Preferencias de filtro guardadas como predeterminadas';
+  String get images_filter_saved => 'Preferencias de filtro guardadas como predeterminadas';
 
   @override
   String get images_sort_title => 'Ordenar imágenes';
 
   @override
-  String get images_sort_saved =>
-      'Preferencias de orden guardadas como predeterminadas';
+  String get images_sort_saved => 'Preferencias de orden guardadas como predeterminadas';
 
   @override
   String get image_rating_updated => 'Clasificación de la imagen actualizada.';
 
   @override
-  String get gallery_rating_updated =>
-      'Clasificación de la galería actualizada.';
+  String get gallery_rating_updated => 'Clasificación de la galería actualizada.';
 
   @override
   String get common_image => 'Imagen';
@@ -1838,8 +1701,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get common_gallery => 'Galería';
 
   @override
-  String get images_gallery_rating_unavailable =>
-      'La clasificación de la galería solo está disponible cuando se navega en una galería.';
+  String get images_gallery_rating_unavailable => 'La clasificación de la galería solo está disponible cuando se navega en una galería.';
 
   @override
   String images_rating(String rating) {
@@ -1850,8 +1712,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get images_filtered_by_gallery => 'Filtrado por galería';
 
   @override
-  String get images_slideshow_need_two =>
-      'Se necesitan al menos 2 imágenes para la presentación.';
+  String get images_slideshow_need_two => 'Se necesitan al menos 2 imágenes para la presentación.';
 
   @override
   String get images_slideshow_start_title => 'Iniciar presentación';
@@ -1888,8 +1749,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_keybind_assign_shortcut => 'Asignar acceso directo';
 
   @override
-  String get settings_keybind_press_any =>
-      'Presiona cualquier combinación de teclas...';
+  String get settings_keybind_press_any => 'Presiona cualquier combinación de teclas...';
 
   @override
   String get scenes_select_tags => 'Seleccionar etiquetas';
@@ -1947,16 +1807,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get scenes_select_performers => 'Seleccionar intérpretes';
 
   @override
-  String get scenes_unmatched_scraped_tags =>
-      'Etiquetas obtenidas sin emparejar';
+  String get scenes_unmatched_scraped_tags => 'Etiquetas obtenidas sin emparejar';
 
   @override
-  String get scenes_unmatched_scraped_performers =>
-      'Actores obtenidos sin emparejar';
+  String get scenes_unmatched_scraped_performers => 'Actores obtenidos sin emparejar';
 
   @override
-  String get scenes_no_matching_performer_found =>
-      'No se encontró un intérprete coincidente en la biblioteca';
+  String get scenes_no_matching_performer_found => 'No se encontró un intérprete coincidente en la biblioteca';
 
   @override
   String get common_unknown => 'Desconocido';
@@ -1979,8 +1836,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get scenes_duration_long => '> 20 min.';
 
   @override
-  String get details_scene_fingerprint_query =>
-      'Consulta de huella de la escena';
+  String get details_scene_fingerprint_query => 'Consulta de huella de la escena';
 
   @override
   String get scenes_available_scrapers => 'Scrapers disponibles';
@@ -2042,8 +1898,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cast_airplay_pairing => 'Emparejamiento AirPlay';
 
   @override
-  String get cast_enter_pin =>
-      'Ingrese el PIN de 4 dígitos que se muestra en su televisor';
+  String get cast_enter_pin => 'Ingrese el PIN de 4 dígitos que se muestra en su televisor';
 
   @override
   String get cast_pair => 'Par';
@@ -2090,8 +1945,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_storage_clearing_video => 'Borrando caché de vídeo...';
 
   @override
-  String get settings_storage_clearing_database =>
-      'Borrando el caché de la base de datos...';
+  String get settings_storage_clearing_database => 'Borrando el caché de la base de datos...';
 
   @override
   String get settings_storage_cleared_image => 'Caché de imagen borrado';
@@ -2100,8 +1954,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_storage_cleared_video => 'Caché de vídeo borrada';
 
   @override
-  String get settings_storage_cleared_database =>
-      'Caché de base de datos borrado';
+  String get settings_storage_cleared_database => 'Caché de base de datos borrado';
 
   @override
   String get settings_storage_clear => 'Claro';
@@ -2138,8 +1991,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_storage_limits => 'Límites';
 
   @override
-  String get settings_storage_limits_subtitle =>
-      'Establecer tamaños máximos de caché';
+  String get settings_storage_limits_subtitle => 'Establecer tamaños máximos de caché';
 
   @override
   String get settings_storage_max_image_cache => 'Caché de imagen máxima (MB)';
@@ -2157,8 +2009,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_storage_usage_subtitle => 'Espacio usado por la caché';
 
   @override
-  String get settings_storage_subtitle =>
-      'Administrar cachés locales y límites de almacenamiento';
+  String get settings_storage_subtitle => 'Administrar cachés locales y límites de almacenamiento';
 
   @override
   String get performers_field_name => 'Nombre';
@@ -2383,8 +2234,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get scenes_field_updated_at => 'Actualizado el';
 
   @override
-  String get cast_stopped_resuming_locally =>
-      'Transmisión detenida, reanudando localmente';
+  String get cast_stopped_resuming_locally => 'Transmisión detenida, reanudando localmente';
 
   @override
   String get cast_stop_casting => 'Detener transmisión';
@@ -2408,8 +2258,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get common_star => 'Estrella';
 
   @override
-  String get settings_interface_card_title_font_size =>
-      'Tamaño de fuente del título de la tarjeta';
+  String get settings_interface_card_title_font_size => 'Tamaño de fuente del título de la tarjeta';
 
   @override
   String get common_hint_date => 'AAAA-MM-DD';
@@ -2474,16 +2323,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get sort_scenes => 'Ordenar escenas';
 
   @override
-  String get failed_to_load_tap_to_retry =>
-      'Error al cargar. Toca para reintentar.';
+  String get failed_to_load_tap_to_retry => 'Error al cargar. Toca para reintentar.';
 
   @override
-  String get would_you_like_to_visit_the_release_page_to_download_it =>
-      '¿Te gustaría visitar la página de lanzamiento para descargarlo?';
+  String get would_you_like_to_visit_the_release_page_to_download_it => '¿Te gustaría visitar la página de lanzamiento para descargarlo?';
 
   @override
-  String get to_get_started_configure_stash_server =>
-      'Para comenzar, debes configurar los detalles de conexión de tu servidor Stash.';
+  String get to_get_started_configure_stash_server => 'Para comenzar, debes configurar los detalles de conexión de tu servidor Stash.';
 
   @override
   String get loading => 'Cargando';
@@ -2586,8 +2432,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get main_startup_failed => 'StashFlow no pudo iniciarse';
 
   @override
-  String get main_startup_failed_desc =>
-      'Un servicio de inicio falló antes de que la aplicación pudiera terminar de inicializarse.Reinicie la aplicación después de verificar los diagnósticos.';
+  String get main_startup_failed_desc => 'Un servicio de inicio falló antes de que la aplicación pudiera terminar de inicializarse.Reinicie la aplicación después de verificar los diagnósticos.';
 
   @override
   String common_searching_for(String query) {
@@ -2625,46 +2470,37 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_security_passcode_removed => 'Código de acceso eliminado';
 
   @override
-  String get settings_security_enable_app_lock =>
-      'Habilitar bloqueo de aplicaciones';
+  String get settings_security_enable_app_lock => 'Habilitar bloqueo de aplicaciones';
 
   @override
-  String get settings_security_enable_app_lock_subtitle =>
-      'Requerir código de acceso al reanudar/iniciar la aplicación.';
+  String get settings_security_enable_app_lock_subtitle => 'Requerir código de acceso al reanudar/iniciar la aplicación.';
 
   @override
-  String get settings_security_lock_on_launch =>
-      'Bloquear al iniciar la aplicación';
+  String get settings_security_lock_on_launch => 'Bloquear al iniciar la aplicación';
 
   @override
-  String get settings_security_lock_on_launch_subtitle =>
-      'Solicite el código de acceso inmediatamente cuando se abra la aplicación.';
+  String get settings_security_lock_on_launch_subtitle => 'Solicite el código de acceso inmediatamente cuando se abra la aplicación.';
 
   @override
-  String get settings_security_background_lock_timer =>
-      'Temporizador de bloqueo de fondo';
+  String get settings_security_background_lock_timer => 'Temporizador de bloqueo de fondo';
 
   @override
-  String get settings_security_background_lock_timer_subtitle =>
-      'Cuánto tiempo puede permanecer la aplicación en segundo plano antes de bloquearse.';
+  String get settings_security_background_lock_timer_subtitle => 'Cuánto tiempo puede permanecer la aplicación en segundo plano antes de bloquearse.';
 
   @override
   String get settings_security_set_passcode => 'Establecer contraseña';
 
   @override
-  String get settings_security_passcode_prompt =>
-      'Código de acceso (4-8 dígitos)';
+  String get settings_security_passcode_prompt => 'Código de acceso (4-8 dígitos)';
 
   @override
   String get settings_security_confirm_passcode => 'Confirmar';
 
   @override
-  String get settings_security_error_numeric =>
-      'Utilice sólo dígitos, con una longitud de 4 a 8.';
+  String get settings_security_error_numeric => 'Utilice sólo dígitos, con una longitud de 4 a 8.';
 
   @override
-  String get settings_security_error_mismatch =>
-      'Las contraseñas no coinciden.';
+  String get settings_security_error_mismatch => 'Las contraseñas no coinciden.';
 
   @override
   String get common_change => 'Cambiar';
@@ -2694,15 +2530,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_security_title => 'Seguridad';
 
   @override
-  String get settings_security_subtitle =>
-      'Configuración de bloqueo de aplicación y contraseña';
+  String get settings_security_subtitle => 'Configuración de bloqueo de aplicación y contraseña';
 
   @override
   String get settings_security_app_lock => 'Bloqueo de aplicaciones';
 
   @override
-  String get settings_security_app_lock_subtitle =>
-      'Proteja el acceso con una contraseña después de ponerlo en segundo plano.';
+  String get settings_security_app_lock_subtitle => 'Proteja el acceso con una contraseña después de ponerlo en segundo plano.';
 
   @override
   String get common_saved_filters => 'Filtros guardados';
@@ -2711,16 +2545,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tools => 'Herramientas';
 
   @override
-  String get tools_section_subtitle =>
-      'Flujos de trabajo de mantenimiento y metadatos para escenas.';
+  String get tools_section_subtitle => 'Flujos de trabajo de mantenimiento y metadatos para escenas.';
 
   @override
-  String get tools_scene_deduplication_subtitle =>
-      'Buscar y gestionar escenas duplicadas.';
+  String get tools_scene_deduplication_subtitle => 'Buscar y gestionar escenas duplicadas.';
 
   @override
-  String get tools_scene_tagger_subtitle =>
-      'Extraer páginas de escenas actuales con Stash-box.';
+  String get tools_scene_tagger_subtitle => 'Extraer páginas de escenas actuales con Stash-box.';
 
   @override
   String get preset_deleted => 'Preestablecido eliminado';
@@ -2822,15 +2653,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get duration_difference => 'Diferencia de duración';
 
   @override
-  String get only_select_matching_codecs =>
-      'Seleccione solo códecs coincidentes';
+  String get only_select_matching_codecs => 'Seleccione solo códecs coincidentes';
 
   @override
   String get select_scenes => 'Seleccionar escenas';
 
   @override
-  String get all_but_largest_resolution =>
-      'Todas menos la resolución más grande';
+  String get all_but_largest_resolution => 'Todas menos la resolución más grande';
 
   @override
   String get all_but_largest_file => 'Todos los archivos excepto el más grande';
@@ -2872,8 +2701,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get enter_preset_name => 'Introduce el nombre del preajuste';
 
   @override
-  String get delete_scene_confirm =>
-      '¿Estás seguro de que quieres eliminar esta escena?';
+  String get delete_scene_confirm => '¿Estás seguro de que quieres eliminar esta escena?';
 
   @override
   String delete_selected_count(int selectedCount) {
@@ -2890,12 +2718,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get available_presets => 'Preajustes disponibles';
 
   @override
-  String get existing_names_are_overwritten =>
-      'Los nombres existentes se sobrescribirán';
+  String get existing_names_are_overwritten => 'Los nombres existentes se sobrescribirán';
 
   @override
-  String get active_settings_saved_server =>
-      'La configuración activa actual se guardará en el servidor.';
+  String get active_settings_saved_server => 'La configuración activa actual se guardará en el servidor.';
 
   @override
   String failed_to_save_filter(String error) {
@@ -2943,8 +2769,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get delete_scenes_help =>
-      'Elige si deseas eliminar solo los metadatos de Stash o también los archivos de la escena y los archivos auxiliares generados.';
+  String get delete_scenes_help => 'Elige si deseas eliminar solo los metadatos de Stash o también los archivos de la escena y los archivos auxiliares generados.';
 
   @override
   String deleted_n_scenes(int count) {
@@ -2965,8 +2790,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get merge_editing_not_wired =>
-      'La edición de fusiones aún no está conectada en StashFlow.';
+  String get merge_editing_not_wired => 'La edición de fusiones aún no está conectada en StashFlow.';
 
   @override
   String duplicate_sets_count(int count) {
@@ -3002,6 +2826,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String nTags(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3019,6 +2844,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String nGroups(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3036,6 +2862,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String nMarkers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3053,6 +2880,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String nGalleries(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3080,8 +2908,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get no_matched_scenes_yet => 'Todavía no hay escenas coincidentes.';
 
   @override
-  String get no_scenes_match_configuration =>
-      'Ninguna escena coincide con esta configuración.';
+  String get no_scenes_match_configuration => 'Ninguna escena coincide con esta configuración.';
 
   @override
   String scene_tagger_checked_count(int count) {
@@ -3094,8 +2921,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get stats_library_stats_tooltip =>
-      'Mantén pulsado para ver las estadísticas de la biblioteca';
+  String get stats_library_stats_tooltip => 'Mantén pulsado para ver las estadísticas de la biblioteca';
 
   @override
   String get scene_details_marker_created => 'Marcador creado';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -45,6 +45,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String nScenes(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -62,6 +63,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String nPerformers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -79,6 +81,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String nPlays(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -150,8 +153,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get common_hide => 'Masquer';
 
   @override
-  String get galleries_filter_saved =>
-      'Préférences de filtrage enregistrées par défaut';
+  String get galleries_filter_saved => 'Préférences de filtrage enregistrées par défaut';
 
   @override
   String get common_setup_required => 'Configuration requise';
@@ -178,8 +180,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get studios_filter_title => 'Filtrer les studios';
 
   @override
-  String get studios_filter_saved =>
-      'Préférences de filtre enregistrées par défaut';
+  String get studios_filter_saved => 'Préférences de filtre enregistrées par défaut';
 
   @override
   String get sort_name => 'Nom';
@@ -281,15 +282,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get studios_sort_saved => 'Préférences de tri enregistrées par défaut';
 
   @override
-  String get studios_no_random =>
-      'Aucun studio disponible pour la navigation aléatoire';
+  String get studios_no_random => 'Aucun studio disponible pour la navigation aléatoire';
 
   @override
   String get tags_filter_title => 'Filtrer les étiquettes';
 
   @override
-  String get tags_filter_saved =>
-      'Préférences de filtre enregistrées par défaut';
+  String get tags_filter_saved => 'Préférences de filtre enregistrées par défaut';
 
   @override
   String get tags_sort_title => 'Trier les étiquettes';
@@ -298,20 +297,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get tags_sort_saved => 'Préférences de tri enregistrées par défaut';
 
   @override
-  String get tags_no_random =>
-      'Aucun tag disponible pour la navigation aléatoire';
+  String get tags_no_random => 'Aucun tag disponible pour la navigation aléatoire';
 
   @override
-  String get scenes_no_random =>
-      'Aucune scène disponible pour la navigation aléatoire';
+  String get scenes_no_random => 'Aucune scène disponible pour la navigation aléatoire';
 
   @override
-  String get performers_no_random =>
-      'Aucun acteur disponible pour la navigation aléatoire';
+  String get performers_no_random => 'Aucun acteur disponible pour la navigation aléatoire';
 
   @override
-  String get galleries_no_random =>
-      'Aucune galerie disponible pour la navigation aléatoire';
+  String get galleries_no_random => 'Aucune galerie disponible pour la navigation aléatoire';
 
   @override
   String common_error(String message) {
@@ -596,8 +591,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get scenes_filter_title => 'Filtrer les scènes';
 
   @override
-  String get scenes_filter_saved =>
-      'Préférences de filtre enregistrées par défaut';
+  String get scenes_filter_saved => 'Préférences de filtre enregistrées par défaut';
 
   @override
   String get scenes_watched => 'Vu';
@@ -672,15 +666,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get scenes_sort_last_o_at => 'Dernier O le';
 
   @override
-  String get scenes_sort_group_scene_number =>
-      'Numéro de scène dans le groupe/film';
+  String get scenes_sort_group_scene_number => 'Numéro de scène dans le groupe/film';
 
   @override
   String get scenes_sort_code => 'Code';
 
   @override
-  String get scenes_sort_saved_default =>
-      'Préférences de tri enregistrées par défaut';
+  String get scenes_sort_saved_default => 'Préférences de tri enregistrées par défaut';
 
   @override
   String get scenes_sort_tooltip => 'Options de tri';
@@ -875,8 +867,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get filter_matches_regex => 'Correspond à l\'expression régulière';
 
   @override
-  String get filter_not_matches_regex =>
-      'Ne correspond pas à l\'expression régulière';
+  String get filter_not_matches_regex => 'Ne correspond pas à l\'expression régulière';
 
   @override
   String get filter_between => 'Entre';
@@ -952,36 +943,31 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_customize => 'Personnaliser StashFlow';
 
   @override
-  String get settings_customize_subtitle =>
-      'Réglez la lecture, l\'apparence, la disposition et les outils de support en un seul endroit.';
+  String get settings_customize_subtitle => 'Réglez la lecture, l\'apparence, la disposition et les outils de support en un seul endroit.';
 
   @override
   String get settings_core_section => 'Paramètres de base';
 
   @override
-  String get settings_core_subtitle =>
-      'Pages de configuration les plus utilisées';
+  String get settings_core_subtitle => 'Pages de configuration les plus utilisées';
 
   @override
   String get settings_server => 'Serveur';
 
   @override
-  String get settings_server_subtitle =>
-      'Configuration de la connexion et de l\'API';
+  String get settings_server_subtitle => 'Configuration de la connexion et de l\'API';
 
   @override
   String get settings_playback => 'Lecture';
 
   @override
-  String get settings_playback_subtitle =>
-      'Comportement du lecteur et interactions';
+  String get settings_playback_subtitle => 'Comportement du lecteur et interactions';
 
   @override
   String get settings_keyboard => 'Clavier';
 
   @override
-  String get settings_keyboard_subtitle =>
-      'Raccourcis et touches de raccourci personnalisables';
+  String get settings_keyboard_subtitle => 'Raccourcis et touches de raccourci personnalisables';
 
   @override
   String get settings_keyboard_title => 'Raccourcis clavier';
@@ -1011,16 +997,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_keyboard_prev_scene => 'Scène précédente';
 
   @override
-  String get settings_keyboard_increase_speed =>
-      'Augmenter la vitesse de lecture';
+  String get settings_keyboard_increase_speed => 'Augmenter la vitesse de lecture';
 
   @override
-  String get settings_keyboard_decrease_speed =>
-      'Diminuer la vitesse de lecture';
+  String get settings_keyboard_decrease_speed => 'Diminuer la vitesse de lecture';
 
   @override
-  String get settings_keyboard_reset_speed =>
-      'Réinitialiser la vitesse de lecture';
+  String get settings_keyboard_reset_speed => 'Réinitialiser la vitesse de lecture';
 
   @override
   String get settings_keyboard_close_player => 'Fermer le lecteur';
@@ -1035,8 +1018,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_keyboard_go_back => 'Retour';
 
   @override
-  String get settings_keyboard_play_pause_desc =>
-      'Basculer entre lecture et pause';
+  String get settings_keyboard_play_pause_desc => 'Basculer entre lecture et pause';
 
   @override
   String get settings_keyboard_seek_forward_5_desc => 'Avancer de 5 secondes';
@@ -1048,8 +1030,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_keyboard_seek_forward_10_desc => 'Avancer de 10 secondes';
 
   @override
-  String get settings_keyboard_seek_backward_10_desc =>
-      'Reculer de 10 secondes';
+  String get settings_keyboard_seek_backward_10_desc => 'Reculer de 10 secondes';
 
   @override
   String get settings_appearance => 'Apparence';
@@ -1061,8 +1042,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_interface => 'Interface';
 
   @override
-  String get settings_interface_subtitle =>
-      'Valeurs par défaut de navigation et de disposition';
+  String get settings_interface_subtitle => 'Valeurs par défaut de navigation et de disposition';
 
   @override
   String get settings_support => 'Support';
@@ -1083,8 +1063,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_appearance_theme_mode => 'Mode de thème';
 
   @override
-  String get settings_appearance_theme_mode_subtitle =>
-      'Choisissez comment l\'application suit les changements de luminosité';
+  String get settings_appearance_theme_mode_subtitle => 'Choisissez comment l\'application suit les changements de luminosité';
 
   @override
   String get settings_appearance_theme_system => 'Système';
@@ -1099,37 +1078,31 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_appearance_primary_color => 'Couleur principale';
 
   @override
-  String get settings_appearance_primary_color_subtitle =>
-      'Choisissez une couleur de base pour la palette Material 3';
+  String get settings_appearance_primary_color_subtitle => 'Choisissez une couleur de base pour la palette Material 3';
 
   @override
   String get settings_appearance_advanced_theming => 'Thématisation avancée';
 
   @override
-  String get settings_appearance_advanced_theming_subtitle =>
-      'Optimisations pour des types d\'écran spécifiques';
+  String get settings_appearance_advanced_theming_subtitle => 'Optimisations pour des types d\'écran spécifiques';
 
   @override
   String get settings_appearance_true_black => 'Noir pur (AMOLED)';
 
   @override
-  String get settings_appearance_true_black_subtitle =>
-      'Utilisez des arrière-plans noir pur en mode sombre pour économiser la batterie sur les écrans OLED';
+  String get settings_appearance_true_black_subtitle => 'Utilisez des arrière-plans noir pur en mode sombre pour économiser la batterie sur les écrans OLED';
 
   @override
   String get settings_appearance_custom_hex => 'Couleur Hex personnalisée';
 
   @override
-  String get settings_appearance_custom_hex_helper =>
-      'Entrez un code hexadécimal ARGB à 8 chiffres';
+  String get settings_appearance_custom_hex_helper => 'Entrez un code hexadécimal ARGB à 8 chiffres';
 
   @override
-  String get settings_appearance_font_size =>
-      'Échelle mondiale de l\'interface utilisateur';
+  String get settings_appearance_font_size => 'Échelle mondiale de l\'interface utilisateur';
 
   @override
-  String get settings_appearance_font_size_subtitle =>
-      'Mettre à l\'échelle la typographie et l\'espacement proportionnellement';
+  String get settings_appearance_font_size_subtitle => 'Mettre à l\'échelle la typographie et l\'espacement proportionnellement';
 
   @override
   String get settings_interface_title => 'Paramètres d\'interface';
@@ -1138,8 +1111,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_interface_language => 'Langue';
 
   @override
-  String get settings_interface_language_subtitle =>
-      'Surcharger la langue par défaut du système';
+  String get settings_interface_language_subtitle => 'Surcharger la langue par défaut du système';
 
   @override
   String get settings_interface_app_language => 'Langue de l\'application';
@@ -1148,103 +1120,82 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_interface_navigation => 'Navigation';
 
   @override
-  String get settings_interface_navigation_subtitle =>
-      'Visibilité des raccourcis de navigation globaux';
+  String get settings_interface_navigation_subtitle => 'Visibilité des raccourcis de navigation globaux';
 
   @override
-  String get settings_interface_show_random =>
-      'Afficher les boutons de navigation aléatoire';
+  String get settings_interface_show_random => 'Afficher les boutons de navigation aléatoire';
 
   @override
-  String get settings_interface_show_random_subtitle =>
-      'Activer ou désactiver les boutons flottants de casino sur les pages de liste et de détails';
+  String get settings_interface_show_random_subtitle => 'Activer ou désactiver les boutons flottants de casino sur les pages de liste et de détails';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation =>
-      'Orientation contrôlée par la gravité (pages principales)';
+  String get settings_interface_main_pages_gravity_orientation => 'Orientation contrôlée par la gravité (pages principales)';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation_subtitle =>
-      'Autoriser les pages principales à pivoter à l\'aide du capteur de l\'appareil. La lecture vidéo en plein écran utilise ses propres paramètres d\'orientation.';
+  String get settings_interface_main_pages_gravity_orientation_subtitle => 'Autoriser les pages principales à pivoter à l\'aide du capteur de l\'appareil. La lecture vidéo en plein écran utilise ses propres paramètres d\'orientation.';
 
   @override
   String get settings_interface_show_edit => 'Afficher le bouton d\'édition';
 
   @override
-  String get settings_interface_show_edit_subtitle =>
-      'Activer ou désactiver le bouton d\'édition sur la page de détails de la scène';
+  String get settings_interface_show_edit_subtitle => 'Activer ou désactiver le bouton d\'édition sur la page de détails de la scène';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer =>
-      'Utiliser la vraie vidéo de scène dans le mini-lecteur';
+  String get settings_interface_use_actual_scene_video_miniplayer => 'Utiliser la vraie vidéo de scène dans le mini-lecteur';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer_subtitle =>
-      'Affiche la surface vidéo en direct au lieu de la capture de la scène quand la lecture est active.';
+  String get settings_interface_use_actual_scene_video_miniplayer_subtitle => 'Affiche la surface vidéo en direct au lieu de la capture de la scène quand la lecture est active.';
 
   @override
-  String get settings_interface_entity_image_filtering =>
-      'Filtrage d\'images d\'entité';
+  String get settings_interface_entity_image_filtering => 'Filtrage d\'images d\'entité';
 
   @override
-  String get settings_interface_entity_image_filtering_subtitle =>
-      'Choisissez si les pages d\'images d\'entité correspondent aux métadonnées d\'image ou aux galeries associées.';
+  String get settings_interface_entity_image_filtering_subtitle => 'Choisissez si les pages d\'images d\'entité correspondent aux métadonnées d\'image ou aux galeries associées.';
 
   @override
-  String get settings_interface_entity_image_filtering_direct =>
-      'Entité directe';
+  String get settings_interface_entity_image_filtering_direct => 'Entité directe';
 
   @override
-  String get settings_interface_entity_image_filtering_galleries =>
-      'Galeries associées';
+  String get settings_interface_entity_image_filtering_galleries => 'Galeries associées';
 
   @override
   String get settings_interface_customize_tabs => 'Personnaliser les onglets';
 
   @override
-  String get settings_interface_customize_tabs_subtitle =>
-      'Réorganiser ou masquer les éléments du menu de navigation';
+  String get settings_interface_customize_tabs_subtitle => 'Réorganiser ou masquer les éléments du menu de navigation';
 
   @override
   String get settings_interface_scenes_layout => 'Disposition des scènes';
 
   @override
-  String get settings_interface_scenes_layout_subtitle =>
-      'Mode de navigation par défaut pour les scènes';
+  String get settings_interface_scenes_layout_subtitle => 'Mode de navigation par défaut pour les scènes';
 
   @override
   String get settings_interface_galleries_layout => 'Disposition des galeries';
 
   @override
-  String get settings_interface_galleries_layout_subtitle =>
-      'Mode de navigation par défaut pour les galeries';
+  String get settings_interface_galleries_layout_subtitle => 'Mode de navigation par défaut pour les galeries';
 
   @override
-  String get settings_interface_max_performer_avatars =>
-      'Max d\'avatars d\'interprètes';
+  String get settings_interface_max_performer_avatars => 'Max d\'avatars d\'interprètes';
 
   @override
-  String get settings_interface_max_performer_avatars_subtitle =>
-      'Nombre maximum d\'avatars d\'interprètes à afficher dans la carte de scène.';
+  String get settings_interface_max_performer_avatars_subtitle => 'Nombre maximum d\'avatars d\'interprètes à afficher dans la carte de scène.';
 
   @override
-  String get settings_interface_show_performer_avatars =>
-      'Afficher les avatars des interprètes';
+  String get settings_interface_show_performer_avatars => 'Afficher les avatars des interprètes';
 
   @override
-  String get settings_interface_show_performer_avatars_subtitle =>
-      'Afficher les icônes des interprètes sur les cartes de scène sur toutes les plateformes.';
+  String get settings_interface_show_performer_avatars_subtitle => 'Afficher les icônes des interprètes sur les cartes de scène sur toutes les plateformes.';
 
   @override
-  String get settings_interface_performer_avatar_size =>
-      'Taille de l\'avatar de l\'interprète';
+  String get settings_interface_performer_avatar_size => 'Taille de l\'avatar de l\'interprète';
 
   @override
   String get settings_interface_layout_default => 'Disposition par défaut';
 
   @override
-  String get settings_interface_layout_default_desc =>
-      'Choisissez la disposition par défaut pour la page';
+  String get settings_interface_layout_default_desc => 'Choisissez la disposition par défaut pour la page';
 
   @override
   String get settings_interface_layout_list => 'Liste';
@@ -1262,16 +1213,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_interface_image_viewer => 'Visionneuse d\'images';
 
   @override
-  String get settings_interface_image_viewer_subtitle =>
-      'Configurer le comportement de navigation d\'images en plein écran';
+  String get settings_interface_image_viewer_subtitle => 'Configurer le comportement de navigation d\'images en plein écran';
 
   @override
-  String get settings_interface_swipe_direction =>
-      'Direction de balayage plein écran';
+  String get settings_interface_swipe_direction => 'Direction de balayage plein écran';
 
   @override
-  String get settings_interface_swipe_direction_desc =>
-      'Choisissez comment les images avancent en mode plein écran';
+  String get settings_interface_swipe_direction_desc => 'Choisissez comment les images avancent en mode plein écran';
 
   @override
   String get settings_interface_swipe_vertical => 'Vertical';
@@ -1280,44 +1228,37 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_interface_swipe_horizontal => 'Horizontal';
 
   @override
-  String get settings_interface_waterfall_columns =>
-      'Colonnes de la grille en cascade';
+  String get settings_interface_waterfall_columns => 'Colonnes de la grille en cascade';
 
   @override
   String get settings_interface_performer_layouts => 'Dispositions des acteurs';
 
   @override
-  String get settings_interface_performer_layouts_subtitle =>
-      'Valeurs par défaut des médias et galeries pour les acteurs';
+  String get settings_interface_performer_layouts_subtitle => 'Valeurs par défaut des médias et galeries pour les acteurs';
 
   @override
   String get settings_interface_studio_layouts => 'Dispositions des studios';
 
   @override
-  String get settings_interface_studio_layouts_subtitle =>
-      'Valeurs par défaut des médias et galeries pour les studios';
+  String get settings_interface_studio_layouts_subtitle => 'Valeurs par défaut des médias et galeries pour les studios';
 
   @override
   String get settings_interface_tag_layouts => 'Dispositions des tags';
 
   @override
-  String get settings_interface_tag_layouts_subtitle =>
-      'Valeurs par défaut des médias et galeries pour les tags';
+  String get settings_interface_tag_layouts_subtitle => 'Valeurs par défaut des médias et galeries pour les tags';
 
   @override
   String get settings_interface_media_layout => 'Disposition des médias';
 
   @override
-  String get settings_interface_media_layout_subtitle =>
-      'Disposition pour la page Médias';
+  String get settings_interface_media_layout_subtitle => 'Disposition pour la page Médias';
 
   @override
-  String get settings_interface_galleries_layout_item =>
-      'Disposition des galeries';
+  String get settings_interface_galleries_layout_item => 'Disposition des galeries';
 
   @override
-  String get settings_interface_galleries_layout_subtitle_item =>
-      'Disposition pour la page Galeries';
+  String get settings_interface_galleries_layout_subtitle_item => 'Disposition pour la page Galeries';
 
   @override
   String get settings_server_title => 'Paramètres du serveur';
@@ -1326,22 +1267,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_server_status => 'État de la connexion';
 
   @override
-  String get settings_server_status_subtitle =>
-      'Connectivité en direct avec le serveur configuré';
+  String get settings_server_status_subtitle => 'Connectivité en direct avec le serveur configuré';
 
   @override
   String get settings_server_details => 'Détails du serveur';
 
   @override
-  String get settings_server_details_subtitle =>
-      'Configurer le point de terminaison et la méthode d\'authentification';
+  String get settings_server_details_subtitle => 'Configurer le point de terminaison et la méthode d\'authentification';
 
   @override
   String get settings_server_url => 'URL de Stash';
 
   @override
-  String get settings_server_url_helper =>
-      'Entrez l\'URL de votre serveur Stash. Si un chemin personnalisé est configuré, incluez-le ici.';
+  String get settings_server_url_helper => 'Entrez l\'URL de votre serveur Stash. Si un chemin personnalisé est configuré, incluez-le ici.';
 
   @override
   String get settings_server_url_example => 'http://192.168.1.100:9999';
@@ -1359,12 +1297,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_server_auth_password => 'Utilisateur + Mot de passe';
 
   @override
-  String get settings_server_auth_password_desc =>
-      'Recommandé : utilisez votre session utilisateur/mot de passe Stash.';
+  String get settings_server_auth_password_desc => 'Recommandé : utilisez votre session utilisateur/mot de passe Stash.';
 
   @override
-  String get settings_server_auth_apikey_desc =>
-      'Utilisez une clé API pour l\'authentification par jeton statique.';
+  String get settings_server_auth_apikey_desc => 'Utilisez une clé API pour l\'authentification par jeton statique.';
 
   @override
   String get settings_server_username => 'Nom d\'utilisateur';
@@ -1401,8 +1337,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_server_invalid_url => 'URL du serveur invalide';
 
   @override
-  String get settings_server_resolve_error =>
-      'Impossible de résoudre l\'URL du serveur. Vérifiez l\'hôte, le port et les identifiants.';
+  String get settings_server_resolve_error => 'Impossible de résoudre l\'URL du serveur. Vérifiez l\'hôte, le port et les identifiants.';
 
   @override
   String get settings_server_logout_confirm => 'Déconnecté et cookies effacés.';
@@ -1420,34 +1355,28 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_server_profile_delete => 'Supprimer le profil';
 
   @override
-  String get settings_server_profile_delete_confirm =>
-      'Êtes-vous sûr de vouloir supprimer ce profil ? Cette action est irréversible.';
+  String get settings_server_profile_delete_confirm => 'Êtes-vous sûr de vouloir supprimer ce profil ? Cette action est irréversible.';
 
   @override
   String get settings_server_profile_active => 'Actif';
 
   @override
-  String get settings_server_profile_empty =>
-      'Aucun profil de serveur configuré';
+  String get settings_server_profile_empty => 'Aucun profil de serveur configuré';
 
   @override
   String get settings_server_profiles => 'Profils de serveur';
 
   @override
-  String get settings_server_profiles_subtitle =>
-      'Gérer plusieurs connexions au serveur Stash';
+  String get settings_server_profiles_subtitle => 'Gérer plusieurs connexions au serveur Stash';
 
   @override
-  String get settings_server_auth_status_logging_in =>
-      'État d\'authentification : connexion en cours...';
+  String get settings_server_auth_status_logging_in => 'État d\'authentification : connexion en cours...';
 
   @override
-  String get settings_server_auth_status_logged_in =>
-      'État d\'authentification : connecté';
+  String get settings_server_auth_status_logged_in => 'État d\'authentification : connecté';
 
   @override
-  String get settings_server_auth_status_logged_out =>
-      'État d\'authentification : déconnecté';
+  String get settings_server_auth_status_logged_out => 'État d\'authentification : déconnecté';
 
   @override
   String get settings_playback_title => 'Paramètres de lecture';
@@ -1456,39 +1385,31 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_playback_behavior => 'Comportement de lecture';
 
   @override
-  String get settings_playback_behavior_subtitle =>
-      'Gestion par défaut de la lecture et de l\'arrière-plan';
+  String get settings_playback_behavior_subtitle => 'Gestion par défaut de la lecture et de l\'arrière-plan';
 
   @override
-  String get settings_playback_prefer_streams =>
-      'Préférer sceneStreams en premier';
+  String get settings_playback_prefer_streams => 'Préférer sceneStreams en premier';
 
   @override
-  String get settings_playback_prefer_streams_subtitle =>
-      'Si désactivé, la lecture utilise directement paths.stream';
+  String get settings_playback_prefer_streams_subtitle => 'Si désactivé, la lecture utilise directement paths.stream';
 
   @override
-  String get settings_playback_feed_random =>
-      'Démarrer le flux à partir d\'une position aléatoire';
+  String get settings_playback_feed_random => 'Démarrer le flux à partir d\'une position aléatoire';
 
   @override
-  String get settings_playback_feed_random_subtitle =>
-      'Lors de la lecture de scènes en mode Flux, démarrer à une position aléatoire entre 0% et 90% de la durée de la vidéo';
+  String get settings_playback_feed_random_subtitle => 'Lors de la lecture de scènes en mode Flux, démarrer à une position aléatoire entre 0% et 90% de la durée de la vidéo';
 
   @override
-  String get settings_playback_resume_position =>
-      'Reprendre à partir de la dernière position de jeu';
+  String get settings_playback_resume_position => 'Reprendre à partir de la dernière position de jeu';
 
   @override
-  String get settings_playback_resume_position_subtitle =>
-      'Lors de l\'ouverture d\'une vidéo, reprenez automatiquement là où vous vous étiez arrêté';
+  String get settings_playback_resume_position_subtitle => 'Lors de l\'ouverture d\'une vidéo, reprenez automatiquement là où vous vous étiez arrêté';
 
   @override
   String get settings_playback_end_behavior => 'Comportement de fin de lecture';
 
   @override
-  String get settings_playback_end_behavior_subtitle =>
-      'Que faire lorsque la lecture en cours se termine';
+  String get settings_playback_end_behavior_subtitle => 'Que faire lorsque la lecture en cours se termine';
 
   @override
   String get settings_playback_end_behavior_stop => 'Arrêt';
@@ -1500,49 +1421,40 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_playback_end_behavior_next => 'Jouer la scène suivante';
 
   @override
-  String get settings_playback_autoplay =>
-      'Lecture automatique de la scène suivante';
+  String get settings_playback_autoplay => 'Lecture automatique de la scène suivante';
 
   @override
-  String get settings_playback_autoplay_subtitle =>
-      'Lire automatiquement la scène suivante à la fin de la lecture actuelle';
+  String get settings_playback_autoplay_subtitle => 'Lire automatiquement la scène suivante à la fin de la lecture actuelle';
 
   @override
   String get settings_playback_background => 'Lecture en arrière-plan';
 
   @override
-  String get settings_playback_background_subtitle =>
-      'Garder l\'audio de la vidéo pendant que l\'application est en arrière-plan';
+  String get settings_playback_background_subtitle => 'Garder l\'audio de la vidéo pendant que l\'application est en arrière-plan';
 
   @override
   String get settings_playback_pip => 'Image dans l\'image native';
 
   @override
-  String get settings_playback_pip_subtitle =>
-      'Activer le bouton PiP Android et l\'entrée automatique en arrière-plan';
+  String get settings_playback_pip_subtitle => 'Activer le bouton PiP Android et l\'entrée automatique en arrière-plan';
 
   @override
   String get settings_playback_subtitles => 'Paramètres des sous-titres';
 
   @override
-  String get settings_playback_subtitles_subtitle =>
-      'Chargement automatique et apparence';
+  String get settings_playback_subtitles_subtitle => 'Chargement automatique et apparence';
 
   @override
-  String get settings_playback_subtitle_lang =>
-      'Langue par défaut des sous-titres';
+  String get settings_playback_subtitle_lang => 'Langue par défaut des sous-titres';
 
   @override
-  String get settings_playback_subtitle_lang_subtitle =>
-      'Chargement automatique si disponible';
+  String get settings_playback_subtitle_lang_subtitle => 'Chargement automatique si disponible';
 
   @override
-  String get settings_playback_subtitle_size =>
-      'Taille de la police des sous-titres';
+  String get settings_playback_subtitle_size => 'Taille de la police des sous-titres';
 
   @override
-  String get settings_playback_subtitle_pos =>
-      'Position verticale des sous-titres';
+  String get settings_playback_subtitle_pos => 'Position verticale des sous-titres';
 
   @override
   String settings_playback_subtitle_pos_desc(String percent) {
@@ -1550,27 +1462,22 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get settings_playback_subtitle_align =>
-      'Alignement du texte des sous-titres';
+  String get settings_playback_subtitle_align => 'Alignement du texte des sous-titres';
 
   @override
-  String get settings_playback_subtitle_align_subtitle =>
-      'Alignement pour les sous-titres multilignes';
+  String get settings_playback_subtitle_align_subtitle => 'Alignement pour les sous-titres multilignes';
 
   @override
   String get settings_playback_seek => 'Interaction de recherche';
 
   @override
-  String get settings_playback_seek_subtitle =>
-      'Choisissez comment le défilement fonctionne pendant la lecture';
+  String get settings_playback_seek_subtitle => 'Choisissez comment le défilement fonctionne pendant la lecture';
 
   @override
-  String get settings_playback_seek_double_tap =>
-      'Appuyez deux fois à gauche/droite pour avancer/reculer de 10s';
+  String get settings_playback_seek_double_tap => 'Appuyez deux fois à gauche/droite pour avancer/reculer de 10s';
 
   @override
-  String get settings_playback_seek_drag =>
-      'Faire glisser la chronologie pour chercher';
+  String get settings_playback_seek_drag => 'Faire glisser la chronologie pour chercher';
 
   @override
   String get settings_playback_seek_drag_label => 'Glisser';
@@ -1579,28 +1486,22 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_playback_seek_double_tap_label => 'Double-appui';
 
   @override
-  String get settings_playback_gravity_orientation =>
-      'Orientation contrôlée par la gravité';
+  String get settings_playback_gravity_orientation => 'Orientation contrôlée par la gravité';
 
   @override
-  String get settings_playback_direct_play =>
-      'Lecture directe lors de la navigation entre scènes';
+  String get settings_playback_direct_play => 'Lecture directe lors de la navigation entre scènes';
 
   @override
-  String get settings_playback_direct_play_subtitle =>
-      'Lors de la navigation depuis une autre scène en cours de lecture, lire directement la nouvelle scène';
+  String get settings_playback_direct_play_subtitle => 'Lors de la navigation depuis une autre scène en cours de lecture, lire directement la nouvelle scène';
 
   @override
-  String get settings_playback_gravity_orientation_subtitle =>
-      'Permettre la rotation entre orientations correspondantes à l\'aide du capteur de l\'appareil (par ex. basculer paysage gauche/droite).';
+  String get settings_playback_gravity_orientation_subtitle => 'Permettre la rotation entre orientations correspondantes à l\'aide du capteur de l\'appareil (par ex. basculer paysage gauche/droite).';
 
   @override
-  String get settings_playback_subtitle_lang_none_disabled =>
-      'Aucun (Désactivé)';
+  String get settings_playback_subtitle_lang_none_disabled => 'Aucun (Désactivé)';
 
   @override
-  String get settings_playback_subtitle_lang_auto_if_only_one =>
-      'Automatique (S\'il n\'y en a qu\'un)';
+  String get settings_playback_subtitle_lang_auto_if_only_one => 'Automatique (S\'il n\'y en a qu\'un)';
 
   @override
   String get settings_playback_subtitle_lang_english => 'Anglais';
@@ -1639,19 +1540,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_support_title => 'Support';
 
   @override
-  String get settings_support_diagnostics =>
-      'Diagnostics et informations du projet';
+  String get settings_support_diagnostics => 'Diagnostics et informations du projet';
 
   @override
-  String get settings_support_diagnostics_subtitle =>
-      'Ouvrez les journaux d\'exécution ou allez au dépôt si vous avez besoin d\'aide.';
+  String get settings_support_diagnostics_subtitle => 'Ouvrez les journaux d\'exécution ou allez au dépôt si vous avez besoin d\'aide.';
 
   @override
   String get settings_support_update_available => 'Mise à jour disponible';
 
   @override
-  String get settings_support_update_available_subtitle =>
-      'Une nouvelle version est disponible sur GitHub';
+  String get settings_support_update_available_subtitle => 'Une nouvelle version est disponible sur GitHub';
 
   @override
   String settings_support_update_to(String version) {
@@ -1659,109 +1557,88 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get settings_support_update_to_subtitle =>
-      'De nouvelles fonctionnalités et améliorations vous attendent.';
+  String get settings_support_update_to_subtitle => 'De nouvelles fonctionnalités et améliorations vous attendent.';
 
   @override
   String get settings_support_about => 'À propos';
 
   @override
-  String get settings_support_about_subtitle =>
-      'Informations sur le projet et la source';
+  String get settings_support_about_subtitle => 'Informations sur le projet et la source';
 
   @override
   String get settings_support_version => 'Version';
 
   @override
-  String get settings_support_version_loading =>
-      'Chargement des informations de version...';
+  String get settings_support_version_loading => 'Chargement des informations de version...';
 
   @override
-  String get settings_support_version_unavailable =>
-      'Informations de version indisponibles';
+  String get settings_support_version_unavailable => 'Informations de version indisponibles';
 
   @override
   String get settings_support_github => 'Dépôt GitHub';
 
   @override
-  String get settings_support_github_subtitle =>
-      'Voir le code source et signaler des problèmes';
+  String get settings_support_github_subtitle => 'Voir le code source et signaler des problèmes';
 
   @override
-  String get settings_support_github_error =>
-      'Impossible d\'ouvrir le lien GitHub';
+  String get settings_support_github_error => 'Impossible d\'ouvrir le lien GitHub';
 
   @override
   String get settings_support_issues => 'Signaler un problème';
 
   @override
-  String get settings_support_issues_subtitle =>
-      'Aidez à améliorer StashFlow en signalant les bugs';
+  String get settings_support_issues_subtitle => 'Aidez à améliorer StashFlow en signalant les bugs';
 
   @override
   String get settings_develop_title => 'Développer';
 
   @override
-  String get settings_develop_enable_logging =>
-      'Activer le journal de débogage';
+  String get settings_develop_enable_logging => 'Activer le journal de débogage';
 
   @override
-  String get settings_develop_enable_logging_subtitle =>
-      'Enregistrer les journaux de l\'application pour le dépannage';
+  String get settings_develop_enable_logging_subtitle => 'Enregistrer les journaux de l\'application pour le dépannage';
 
   @override
   String get settings_develop_diagnostics => 'Outils de diagnostic';
 
   @override
-  String get settings_develop_diagnostics_subtitle =>
-      'Dépannage et performances';
+  String get settings_develop_diagnostics_subtitle => 'Dépannage et performances';
 
   @override
-  String get settings_develop_video_debug =>
-      'Afficher les infos de débogage vidéo';
+  String get settings_develop_video_debug => 'Afficher les infos de débogage vidéo';
 
   @override
-  String get settings_develop_video_debug_subtitle =>
-      'Afficher les détails techniques de lecture en superposition sur le lecteur vidéo.';
+  String get settings_develop_video_debug_subtitle => 'Afficher les détails techniques de lecture en superposition sur le lecteur vidéo.';
 
   @override
-  String get settings_develop_log_viewer =>
-      'Visionneuse de journaux de débogage';
+  String get settings_develop_log_viewer => 'Visionneuse de journaux de débogage';
 
   @override
-  String get settings_develop_log_viewer_subtitle =>
-      'Ouvrir une vue en direct des journaux de l\'application.';
+  String get settings_develop_log_viewer_subtitle => 'Ouvrir une vue en direct des journaux de l\'application.';
 
   @override
-  String get settings_develop_logs_copied =>
-      'Journaux copiés dans le presse-papiers';
+  String get settings_develop_logs_copied => 'Journaux copiés dans le presse-papiers';
 
   @override
-  String get settings_develop_no_logs =>
-      'Pas encore de journaux. Interagissez avec l\'application pour capturer des journaux.';
+  String get settings_develop_no_logs => 'Pas encore de journaux. Interagissez avec l\'application pour capturer des journaux.';
 
   @override
   String get settings_develop_web_overrides => 'Surcharges Web';
 
   @override
-  String get settings_develop_web_overrides_subtitle =>
-      'Drapeaux avancés pour la plateforme Web';
+  String get settings_develop_web_overrides_subtitle => 'Drapeaux avancés pour la plateforme Web';
 
   @override
-  String get settings_develop_web_auth =>
-      'Autoriser la connexion par mot de passe sur le Web';
+  String get settings_develop_web_auth => 'Autoriser la connexion par mot de passe sur le Web';
 
   @override
-  String get settings_develop_web_auth_subtitle =>
-      'Surcharge la restriction native uniquement et force la visibilité de la méthode d\'authentification Utilisateur + Mot de passe sur Flutter Web.';
+  String get settings_develop_web_auth_subtitle => 'Surcharge la restriction native uniquement et force la visibilité de la méthode d\'authentification Utilisateur + Mot de passe sur Flutter Web.';
 
   @override
-  String get settings_develop_proxy_auth =>
-      'Activer les modes d\'authentification proxy';
+  String get settings_develop_proxy_auth => 'Activer les modes d\'authentification proxy';
 
   @override
-  String get settings_develop_proxy_auth_subtitle =>
-      'Activez les méthodes avancées Basic Auth et Bearer Token pour une utilisation avec des backends sans authentification derrière des proxys comme Authentik.';
+  String get settings_develop_proxy_auth_subtitle => 'Activez les méthodes avancées Basic Auth et Bearer Token pour une utilisation avec des backends sans authentification derrière des proxys comme Authentik.';
 
   @override
   String get settings_server_auth_basic => 'Authentification de base';
@@ -1770,12 +1647,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_server_auth_bearer => 'Jeton porteur';
 
   @override
-  String get settings_server_auth_basic_desc =>
-      'Envoie l\'en-tête \'Authorization: Basic <base64(user:pass)>\'.';
+  String get settings_server_auth_basic_desc => 'Envoie l\'en-tête \'Authorization: Basic <base64(user:pass)>\'.';
 
   @override
-  String get settings_server_auth_bearer_desc =>
-      'Envoie l\'en-tête \'Authorization: Bearer <token>\'.';
+  String get settings_server_auth_bearer_desc => 'Envoie l\'en-tête \'Authorization: Bearer <token>\'.';
 
   @override
   String get common_edit => 'Modifier';
@@ -1796,8 +1671,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get common_square => 'Carré';
 
   @override
-  String get performers_filter_saved =>
-      'Préférences de filtre enregistrées comme défaut';
+  String get performers_filter_saved => 'Préférences de filtre enregistrées comme défaut';
 
   @override
   String get images_title => 'Images';
@@ -1806,15 +1680,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get images_filter_title => 'Filtrer les images';
 
   @override
-  String get images_filter_saved =>
-      'Préférences de filtre enregistrées par défaut';
+  String get images_filter_saved => 'Préférences de filtre enregistrées par défaut';
 
   @override
   String get images_sort_title => 'Trier les images';
 
   @override
-  String get images_sort_saved =>
-      'Préférences de tri enregistrées comme défaut';
+  String get images_sort_saved => 'Préférences de tri enregistrées comme défaut';
 
   @override
   String get image_rating_updated => 'Évaluation de l\'image mise à jour.';
@@ -1829,8 +1701,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get common_gallery => 'Galerie';
 
   @override
-  String get images_gallery_rating_unavailable =>
-      'La note de la galerie n\'est disponible que lors de la navigation dans une galerie.';
+  String get images_gallery_rating_unavailable => 'La note de la galerie n\'est disponible que lors de la navigation dans une galerie.';
 
   @override
   String images_rating(String rating) {
@@ -1841,8 +1712,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get images_filtered_by_gallery => 'Filtré par galerie';
 
   @override
-  String get images_slideshow_need_two =>
-      'Il faut au moins 2 images pour le diaporama.';
+  String get images_slideshow_need_two => 'Il faut au moins 2 images pour le diaporama.';
 
   @override
   String get images_slideshow_start_title => 'Démarrer le diaporama';
@@ -1879,8 +1749,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_keybind_assign_shortcut => 'Attribuer un raccourci';
 
   @override
-  String get settings_keybind_press_any =>
-      'Appuyez sur n\'importe quelle combinaison de touches...';
+  String get settings_keybind_press_any => 'Appuyez sur n\'importe quelle combinaison de touches...';
 
   @override
   String get scenes_select_tags => 'Sélectionner des tags';
@@ -1941,12 +1810,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get scenes_unmatched_scraped_tags => 'Tags récupérés non appariés';
 
   @override
-  String get scenes_unmatched_scraped_performers =>
-      'Interprètes récupérés non appariés';
+  String get scenes_unmatched_scraped_performers => 'Interprètes récupérés non appariés';
 
   @override
-  String get scenes_no_matching_performer_found =>
-      'Aucun interprète correspondant trouvé dans la bibliothèque';
+  String get scenes_no_matching_performer_found => 'Aucun interprète correspondant trouvé dans la bibliothèque';
 
   @override
   String get common_unknown => 'Inconnu';
@@ -1969,8 +1836,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get scenes_duration_long => '> 20 min.';
 
   @override
-  String get details_scene_fingerprint_query =>
-      'Requête d\'empreinte de la scène';
+  String get details_scene_fingerprint_query => 'Requête d\'empreinte de la scène';
 
   @override
   String get scenes_available_scrapers => 'Scrapers disponibles';
@@ -2032,8 +1898,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get cast_airplay_pairing => 'Couplage AirPlay';
 
   @override
-  String get cast_enter_pin =>
-      'Saisissez le code PIN à 4 chiffres affiché sur votre téléviseur';
+  String get cast_enter_pin => 'Saisissez le code PIN à 4 chiffres affiché sur votre téléviseur';
 
   @override
   String get cast_pair => 'Paire';
@@ -2080,8 +1945,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_storage_clearing_video => 'Vider le cache vidéo...';
 
   @override
-  String get settings_storage_clearing_database =>
-      'Vider le cache de la base de données...';
+  String get settings_storage_clearing_database => 'Vider le cache de la base de données...';
 
   @override
   String get settings_storage_cleared_image => 'Cache d\'images vidé';
@@ -2090,15 +1954,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_storage_cleared_video => 'Cache vidéo vidé';
 
   @override
-  String get settings_storage_cleared_database =>
-      'Cache de base de données vidé';
+  String get settings_storage_cleared_database => 'Cache de base de données vidé';
 
   @override
   String get settings_storage_clear => 'Clair';
 
   @override
-  String get settings_storage_error_loading =>
-      'Erreur de chargement des tailles';
+  String get settings_storage_error_loading => 'Erreur de chargement des tailles';
 
   @override
   String settings_storage_mb(num value) {
@@ -2129,8 +1991,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_storage_limits => 'Limites';
 
   @override
-  String get settings_storage_limits_subtitle =>
-      'Définir les tailles maximales de cache';
+  String get settings_storage_limits_subtitle => 'Définir les tailles maximales de cache';
 
   @override
   String get settings_storage_max_image_cache => 'Cache d\'images maximum (Mo)';
@@ -2148,8 +2009,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_storage_usage_subtitle => 'Espace utilisé par les caches';
 
   @override
-  String get settings_storage_subtitle =>
-      'Gérer les caches locaux et les limites de stockage';
+  String get settings_storage_subtitle => 'Gérer les caches locaux et les limites de stockage';
 
   @override
   String get performers_field_name => 'Nom';
@@ -2374,8 +2234,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get scenes_field_updated_at => 'Mis à jour le';
 
   @override
-  String get cast_stopped_resuming_locally =>
-      'Diffusion arrêtée, reprise locale';
+  String get cast_stopped_resuming_locally => 'Diffusion arrêtée, reprise locale';
 
   @override
   String get cast_stop_casting => 'Arrêter la diffusion';
@@ -2399,8 +2258,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get common_star => 'Étoile';
 
   @override
-  String get settings_interface_card_title_font_size =>
-      'Taille de police du titre de la carte';
+  String get settings_interface_card_title_font_size => 'Taille de police du titre de la carte';
 
   @override
   String get common_hint_date => 'AAAA-MM-JJ';
@@ -2465,16 +2323,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get sort_scenes => 'Trier les scènes';
 
   @override
-  String get failed_to_load_tap_to_retry =>
-      'Échec du chargement. Appuyez pour réessayer.';
+  String get failed_to_load_tap_to_retry => 'Échec du chargement. Appuyez pour réessayer.';
 
   @override
-  String get would_you_like_to_visit_the_release_page_to_download_it =>
-      'Souhaitez-vous visiter la page de publication pour le télécharger ?';
+  String get would_you_like_to_visit_the_release_page_to_download_it => 'Souhaitez-vous visiter la page de publication pour le télécharger ?';
 
   @override
-  String get to_get_started_configure_stash_server =>
-      'Pour commencer, vous devez configurer les détails de connexion de votre serveur Stash.';
+  String get to_get_started_configure_stash_server => 'Pour commencer, vous devez configurer les détails de connexion de votre serveur Stash.';
 
   @override
   String get loading => 'Chargement';
@@ -2577,8 +2432,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get main_startup_failed => 'StashFlow n\'a pas réussi à démarrer';
 
   @override
-  String get main_startup_failed_desc =>
-      'Un service de démarrage a échoué avant que l\'application puisse terminer son initialisation.Redémarrez l\'application après avoir vérifié les diagnostics.';
+  String get main_startup_failed_desc => 'Un service de démarrage a échoué avant que l\'application puisse terminer son initialisation.Redémarrez l\'application après avoir vérifié les diagnostics.';
 
   @override
   String common_searching_for(String query) {
@@ -2616,46 +2470,37 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_security_passcode_removed => 'Code d\'accès supprimé';
 
   @override
-  String get settings_security_enable_app_lock =>
-      'Activer le verrouillage des applications';
+  String get settings_security_enable_app_lock => 'Activer le verrouillage des applications';
 
   @override
-  String get settings_security_enable_app_lock_subtitle =>
-      'Exiger un mot de passe lors de la reprise/du lancement de l\'application.';
+  String get settings_security_enable_app_lock_subtitle => 'Exiger un mot de passe lors de la reprise/du lancement de l\'application.';
 
   @override
-  String get settings_security_lock_on_launch =>
-      'Verrouiller le lancement de l\'application';
+  String get settings_security_lock_on_launch => 'Verrouiller le lancement de l\'application';
 
   @override
-  String get settings_security_lock_on_launch_subtitle =>
-      'Demandez le mot de passe immédiatement lorsque l\'application s\'ouvre.';
+  String get settings_security_lock_on_launch_subtitle => 'Demandez le mot de passe immédiatement lorsque l\'application s\'ouvre.';
 
   @override
-  String get settings_security_background_lock_timer =>
-      'Minuterie de verrouillage en arrière-plan';
+  String get settings_security_background_lock_timer => 'Minuterie de verrouillage en arrière-plan';
 
   @override
-  String get settings_security_background_lock_timer_subtitle =>
-      'Combien de temps l\'application peut rester en arrière-plan avant de se verrouiller.';
+  String get settings_security_background_lock_timer_subtitle => 'Combien de temps l\'application peut rester en arrière-plan avant de se verrouiller.';
 
   @override
   String get settings_security_set_passcode => 'Définir le mot de passe';
 
   @override
-  String get settings_security_passcode_prompt =>
-      'Code d\'accès (4 à 8 chiffres)';
+  String get settings_security_passcode_prompt => 'Code d\'accès (4 à 8 chiffres)';
 
   @override
   String get settings_security_confirm_passcode => 'Confirmer';
 
   @override
-  String get settings_security_error_numeric =>
-      'Utilisez uniquement des chiffres, d\'une longueur de 4 à 8.';
+  String get settings_security_error_numeric => 'Utilisez uniquement des chiffres, d\'une longueur de 4 à 8.';
 
   @override
-  String get settings_security_error_mismatch =>
-      'Les codes d\'accès ne correspondent pas.';
+  String get settings_security_error_mismatch => 'Les codes d\'accès ne correspondent pas.';
 
   @override
   String get common_change => 'Changement';
@@ -2685,15 +2530,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_security_title => 'Sécurité';
 
   @override
-  String get settings_security_subtitle =>
-      'Paramètres de verrouillage de l\'application et du code';
+  String get settings_security_subtitle => 'Paramètres de verrouillage de l\'application et du code';
 
   @override
   String get settings_security_app_lock => 'Verrouillage d\'application';
 
   @override
-  String get settings_security_app_lock_subtitle =>
-      'Protégez l’accès avec un mot de passe après la mise en arrière-plan.';
+  String get settings_security_app_lock_subtitle => 'Protégez l’accès avec un mot de passe après la mise en arrière-plan.';
 
   @override
   String get common_saved_filters => 'Filtres enregistrés';
@@ -2702,16 +2545,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get tools => 'Outils';
 
   @override
-  String get tools_section_subtitle =>
-      'Flux de travail de maintenance et de métadonnées pour les scènes.';
+  String get tools_section_subtitle => 'Flux de travail de maintenance et de métadonnées pour les scènes.';
 
   @override
-  String get tools_scene_deduplication_subtitle =>
-      'Rechercher et gérer les scènes en double.';
+  String get tools_scene_deduplication_subtitle => 'Rechercher et gérer les scènes en double.';
 
   @override
-  String get tools_scene_tagger_subtitle =>
-      'Scraper les pages de scènes actuelles avec Stash-box.';
+  String get tools_scene_tagger_subtitle => 'Scraper les pages de scènes actuelles avec Stash-box.';
 
   @override
   String get preset_deleted => 'Préréglage supprimé';
@@ -2813,15 +2653,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get duration_difference => 'Différence de durée';
 
   @override
-  String get only_select_matching_codecs =>
-      'Sélectionnez uniquement les codecs correspondants';
+  String get only_select_matching_codecs => 'Sélectionnez uniquement les codecs correspondants';
 
   @override
   String get select_scenes => 'Sélectionnez des scènes';
 
   @override
-  String get all_but_largest_resolution =>
-      'Toutes les résolutions, sauf la plus grande';
+  String get all_but_largest_resolution => 'Toutes les résolutions, sauf la plus grande';
 
   @override
   String get all_but_largest_file => 'Tous les fichiers sauf le plus gros';
@@ -2863,8 +2701,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get enter_preset_name => 'Entrez le nom du préréglage';
 
   @override
-  String get delete_scene_confirm =>
-      'Êtes-vous sûr de vouloir supprimer cette scène ?';
+  String get delete_scene_confirm => 'Êtes-vous sûr de vouloir supprimer cette scène ?';
 
   @override
   String delete_selected_count(int selectedCount) {
@@ -2881,12 +2718,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get available_presets => 'Préréglages disponibles';
 
   @override
-  String get existing_names_are_overwritten =>
-      'Les noms existants seront écrasés';
+  String get existing_names_are_overwritten => 'Les noms existants seront écrasés';
 
   @override
-  String get active_settings_saved_server =>
-      'Les paramètres actuellement actifs seront enregistrés sur le serveur.';
+  String get active_settings_saved_server => 'Les paramètres actuellement actifs seront enregistrés sur le serveur.';
 
   @override
   String failed_to_save_filter(String error) {
@@ -2934,8 +2769,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get delete_scenes_help =>
-      'Choisissez si vous voulez supprimer uniquement les métadonnées Stash ou aussi les fichiers de scène et les fichiers auxiliaires générés.';
+  String get delete_scenes_help => 'Choisissez si vous voulez supprimer uniquement les métadonnées Stash ou aussi les fichiers de scène et les fichiers auxiliaires générés.';
 
   @override
   String deleted_n_scenes(int count) {
@@ -2956,8 +2790,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get merge_editing_not_wired =>
-      'L\'édition des fusions n\'est pas encore câblée dans StashFlow.';
+  String get merge_editing_not_wired => 'L\'édition des fusions n\'est pas encore câblée dans StashFlow.';
 
   @override
   String duplicate_sets_count(int count) {
@@ -2993,6 +2826,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String nTags(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3010,6 +2844,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String nGroups(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3027,6 +2862,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String nMarkers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3044,6 +2880,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String nGalleries(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3068,12 +2905,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get no_matched_scenes_yet =>
-      'Aucune scène correspondante pour le moment.';
+  String get no_matched_scenes_yet => 'Aucune scène correspondante pour le moment.';
 
   @override
-  String get no_scenes_match_configuration =>
-      'Aucune scène ne correspond à cette configuration.';
+  String get no_scenes_match_configuration => 'Aucune scène ne correspond à cette configuration.';
 
   @override
   String scene_tagger_checked_count(int count) {
@@ -3086,8 +2921,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get stats_library_stats_tooltip =>
-      'Appui long pour les statistiques de la bibliothèque';
+  String get stats_library_stats_tooltip => 'Appui long pour les statistiques de la bibliothèque';
 
   @override
   String get scene_details_marker_created => 'Marqueur créé';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -45,6 +45,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String nScenes(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -62,6 +63,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String nPerformers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -79,6 +81,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String nPlays(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -150,8 +153,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get common_hide => 'Nascondi';
 
   @override
-  String get galleries_filter_saved =>
-      'Preferenze filtro salvate come predefinite';
+  String get galleries_filter_saved => 'Preferenze filtro salvate come predefinite';
 
   @override
   String get common_setup_required => 'Configurazione Richiesta';
@@ -178,8 +180,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get studios_filter_title => 'Filtra Studi';
 
   @override
-  String get studios_filter_saved =>
-      'Preferenze del filtro salvate come predefinite';
+  String get studios_filter_saved => 'Preferenze del filtro salvate come predefinite';
 
   @override
   String get sort_name => 'Nome';
@@ -278,42 +279,34 @@ class AppLocalizationsIt extends AppLocalizations {
   String get sort_last_played_at => 'Ultima riproduzione';
 
   @override
-  String get studios_sort_saved =>
-      'Preferenze di ordinamento salvate come predefinite';
+  String get studios_sort_saved => 'Preferenze di ordinamento salvate come predefinite';
 
   @override
-  String get studios_no_random =>
-      'Nessuno studio disponibile per la navigazione casuale';
+  String get studios_no_random => 'Nessuno studio disponibile per la navigazione casuale';
 
   @override
   String get tags_filter_title => 'Filtra Etichette';
 
   @override
-  String get tags_filter_saved =>
-      'Preferenze del filtro salvate come predefinite';
+  String get tags_filter_saved => 'Preferenze del filtro salvate come predefinite';
 
   @override
   String get tags_sort_title => 'Ordina Etichette';
 
   @override
-  String get tags_sort_saved =>
-      'Preferenze di ordinamento salvate come predefinite';
+  String get tags_sort_saved => 'Preferenze di ordinamento salvate come predefinite';
 
   @override
-  String get tags_no_random =>
-      'Nessun tag disponibile per la navigazione casuale';
+  String get tags_no_random => 'Nessun tag disponibile per la navigazione casuale';
 
   @override
-  String get scenes_no_random =>
-      'Nessuna scena disponibile per la navigazione casuale';
+  String get scenes_no_random => 'Nessuna scena disponibile per la navigazione casuale';
 
   @override
-  String get performers_no_random =>
-      'Nessun attore disponibile per la navigazione casuale';
+  String get performers_no_random => 'Nessun attore disponibile per la navigazione casuale';
 
   @override
-  String get galleries_no_random =>
-      'Nessuna galleria disponibile per la navigazione casuale';
+  String get galleries_no_random => 'Nessuna galleria disponibile per la navigazione casuale';
 
   @override
   String common_error(String message) {
@@ -598,8 +591,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get scenes_filter_title => 'Filtra scene';
 
   @override
-  String get scenes_filter_saved =>
-      'Preferenze del filtro salvate come predefinite';
+  String get scenes_filter_saved => 'Preferenze del filtro salvate come predefinite';
 
   @override
   String get scenes_watched => 'Guardato';
@@ -680,8 +672,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get scenes_sort_code => 'Codice';
 
   @override
-  String get scenes_sort_saved_default =>
-      'Preferenze di ordinamento salvate come predefinito';
+  String get scenes_sort_saved_default => 'Preferenze di ordinamento salvate come predefinito';
 
   @override
   String get scenes_sort_tooltip => 'Opzioni di ordinamento';
@@ -952,15 +943,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_customize => 'Personalizza StashFlow';
 
   @override
-  String get settings_customize_subtitle =>
-      'Regola riproduzione, aspetto, layout e strumenti di supporto da un unico posto.';
+  String get settings_customize_subtitle => 'Regola riproduzione, aspetto, layout e strumenti di supporto da un unico posto.';
 
   @override
   String get settings_core_section => 'Impostazioni principali';
 
   @override
-  String get settings_core_subtitle =>
-      'Pagine di configurazione più utilizzate';
+  String get settings_core_subtitle => 'Pagine di configurazione più utilizzate';
 
   @override
   String get settings_server => 'Server';
@@ -972,15 +961,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_playback => 'Riproduzione';
 
   @override
-  String get settings_playback_subtitle =>
-      'Comportamento del lettore e interazioni';
+  String get settings_playback_subtitle => 'Comportamento del lettore e interazioni';
 
   @override
   String get settings_keyboard => 'Tastiera';
 
   @override
-  String get settings_keyboard_subtitle =>
-      'Scorciatoie e tasti rapidi personalizzabili';
+  String get settings_keyboard_subtitle => 'Scorciatoie e tasti rapidi personalizzabili';
 
   @override
   String get settings_keyboard_title => 'Scorciatoie da tastiera';
@@ -1001,8 +988,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_keyboard_toggle_mute => 'Attiva/Disattiva muto';
 
   @override
-  String get settings_keyboard_toggle_fullscreen =>
-      'Attiva/Disattiva schermo intero';
+  String get settings_keyboard_toggle_fullscreen => 'Attiva/Disattiva schermo intero';
 
   @override
   String get settings_keyboard_next_scene => 'Scena successiva';
@@ -1011,16 +997,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_keyboard_prev_scene => 'Scena precedente';
 
   @override
-  String get settings_keyboard_increase_speed =>
-      'Aumenta velocità di riproduzione';
+  String get settings_keyboard_increase_speed => 'Aumenta velocità di riproduzione';
 
   @override
-  String get settings_keyboard_decrease_speed =>
-      'Diminuisci velocità di riproduzione';
+  String get settings_keyboard_decrease_speed => 'Diminuisci velocità di riproduzione';
 
   @override
-  String get settings_keyboard_reset_speed =>
-      'Ripristina velocità di riproduzione';
+  String get settings_keyboard_reset_speed => 'Ripristina velocità di riproduzione';
 
   @override
   String get settings_keyboard_close_player => 'Chiudi lettore';
@@ -1035,22 +1018,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_keyboard_go_back => 'Torna indietro';
 
   @override
-  String get settings_keyboard_play_pause_desc =>
-      'Alterna tra riproduzione e pausa del video';
+  String get settings_keyboard_play_pause_desc => 'Alterna tra riproduzione e pausa del video';
 
   @override
   String get settings_keyboard_seek_forward_5_desc => 'Avanza di 5 secondi';
 
   @override
-  String get settings_keyboard_seek_backward_5_desc =>
-      'Torna indietro di 5 secondi';
+  String get settings_keyboard_seek_backward_5_desc => 'Torna indietro di 5 secondi';
 
   @override
   String get settings_keyboard_seek_forward_10_desc => 'Avanza di 10 secondi';
 
   @override
-  String get settings_keyboard_seek_backward_10_desc =>
-      'Torna indietro di 10 secondi';
+  String get settings_keyboard_seek_backward_10_desc => 'Torna indietro di 10 secondi';
 
   @override
   String get settings_appearance => 'Aspetto';
@@ -1062,8 +1042,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_interface => 'Interfaccia';
 
   @override
-  String get settings_interface_subtitle =>
-      'Predefiniti di navigazione e layout';
+  String get settings_interface_subtitle => 'Predefiniti di navigazione e layout';
 
   @override
   String get settings_support => 'Supporto';
@@ -1084,8 +1063,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_appearance_theme_mode => 'Modalità Tema';
 
   @override
-  String get settings_appearance_theme_mode_subtitle =>
-      'Scegli come l\'app segue i cambiamenti di luminosità';
+  String get settings_appearance_theme_mode_subtitle => 'Scegli come l\'app segue i cambiamenti di luminosità';
 
   @override
   String get settings_appearance_theme_system => 'Sistema';
@@ -1100,38 +1078,31 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_appearance_primary_color => 'Colore Primario';
 
   @override
-  String get settings_appearance_primary_color_subtitle =>
-      'Scegli un colore base per la tavolozza Material 3';
+  String get settings_appearance_primary_color_subtitle => 'Scegli un colore base per la tavolozza Material 3';
 
   @override
   String get settings_appearance_advanced_theming => 'Temi Avanzati';
 
   @override
-  String get settings_appearance_advanced_theming_subtitle =>
-      'Ottimizzazioni per tipi specifici di schermo';
+  String get settings_appearance_advanced_theming_subtitle => 'Ottimizzazioni per tipi specifici di schermo';
 
   @override
   String get settings_appearance_true_black => 'Nero Assoluto (AMOLED)';
 
   @override
-  String get settings_appearance_true_black_subtitle =>
-      'Usa sfondi neri puri in modalità scura per risparmiare batteria sugli schermi OLED';
+  String get settings_appearance_true_black_subtitle => 'Usa sfondi neri puri in modalità scura per risparmiare batteria sugli schermi OLED';
 
   @override
-  String get settings_appearance_custom_hex =>
-      'Colore Esadecimale Personalizzato';
+  String get settings_appearance_custom_hex => 'Colore Esadecimale Personalizzato';
 
   @override
-  String get settings_appearance_custom_hex_helper =>
-      'Inserisci un codice esadecimale ARGB a 8 cifre';
+  String get settings_appearance_custom_hex_helper => 'Inserisci un codice esadecimale ARGB a 8 cifre';
 
   @override
-  String get settings_appearance_font_size =>
-      'Scala globale dell\'interfaccia utente';
+  String get settings_appearance_font_size => 'Scala globale dell\'interfaccia utente';
 
   @override
-  String get settings_appearance_font_size_subtitle =>
-      'Ridimensiona la tipografia e la spaziatura proporzionalmente';
+  String get settings_appearance_font_size_subtitle => 'Ridimensiona la tipografia e la spaziatura proporzionalmente';
 
   @override
   String get settings_interface_title => 'Impostazioni Interfaccia';
@@ -1140,8 +1111,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_interface_language => 'Lingua';
 
   @override
-  String get settings_interface_language_subtitle =>
-      'Sovrascrivi la lingua di sistema predefinita';
+  String get settings_interface_language_subtitle => 'Sovrascrivi la lingua di sistema predefinita';
 
   @override
   String get settings_interface_app_language => 'Lingua dell\'App';
@@ -1150,103 +1120,82 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_interface_navigation => 'Navigazione';
 
   @override
-  String get settings_interface_navigation_subtitle =>
-      'Visibilità delle scorciatoie di navigazione globale';
+  String get settings_interface_navigation_subtitle => 'Visibilità delle scorciatoie di navigazione globale';
 
   @override
-  String get settings_interface_show_random =>
-      'Mostra Pulsanti Navigazione Casuale';
+  String get settings_interface_show_random => 'Mostra Pulsanti Navigazione Casuale';
 
   @override
-  String get settings_interface_show_random_subtitle =>
-      'Abilita o disabilita i pulsanti fluttuanti nelle pagine di elenco e dettaglio';
+  String get settings_interface_show_random_subtitle => 'Abilita o disabilita i pulsanti fluttuanti nelle pagine di elenco e dettaglio';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation =>
-      'Orientamento controllato dalla gravità (pagine principali)';
+  String get settings_interface_main_pages_gravity_orientation => 'Orientamento controllato dalla gravità (pagine principali)';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation_subtitle =>
-      'Consenti alle pagine principali di ruotare usando il sensore del dispositivo. La riproduzione video a schermo intero usa le proprie impostazioni di orientamento.';
+  String get settings_interface_main_pages_gravity_orientation_subtitle => 'Consenti alle pagine principali di ruotare usando il sensore del dispositivo. La riproduzione video a schermo intero usa le proprie impostazioni di orientamento.';
 
   @override
   String get settings_interface_show_edit => 'Mostra Pulsante Modifica';
 
   @override
-  String get settings_interface_show_edit_subtitle =>
-      'Abilita o disabilita il pulsante di modifica nella pagina dei dettagli della scena';
+  String get settings_interface_show_edit_subtitle => 'Abilita o disabilita il pulsante di modifica nella pagina dei dettagli della scena';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer =>
-      'Usa il video reale della scena nel mini player';
+  String get settings_interface_use_actual_scene_video_miniplayer => 'Usa il video reale della scena nel mini player';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer_subtitle =>
-      'Mostra la superficie video live invece dello screenshot della scena quando la riproduzione è attiva.';
+  String get settings_interface_use_actual_scene_video_miniplayer_subtitle => 'Mostra la superficie video live invece dello screenshot della scena quando la riproduzione è attiva.';
 
   @override
-  String get settings_interface_entity_image_filtering =>
-      'Filtraggio immagini entità';
+  String get settings_interface_entity_image_filtering => 'Filtraggio immagini entità';
 
   @override
-  String get settings_interface_entity_image_filtering_subtitle =>
-      'Scegli se le pagine delle immagini dell\'entità corrispondono ai metadati dell\'immagine o alle gallerie correlate.';
+  String get settings_interface_entity_image_filtering_subtitle => 'Scegli se le pagine delle immagini dell\'entità corrispondono ai metadati dell\'immagine o alle gallerie correlate.';
 
   @override
-  String get settings_interface_entity_image_filtering_direct =>
-      'Entità diretta';
+  String get settings_interface_entity_image_filtering_direct => 'Entità diretta';
 
   @override
-  String get settings_interface_entity_image_filtering_galleries =>
-      'Gallerie correlate';
+  String get settings_interface_entity_image_filtering_galleries => 'Gallerie correlate';
 
   @override
   String get settings_interface_customize_tabs => 'Personalizza Schede';
 
   @override
-  String get settings_interface_customize_tabs_subtitle =>
-      'Riordina o nascondi le voci del menu di navigazione';
+  String get settings_interface_customize_tabs_subtitle => 'Riordina o nascondi le voci del menu di navigazione';
 
   @override
   String get settings_interface_scenes_layout => 'Layout Scene';
 
   @override
-  String get settings_interface_scenes_layout_subtitle =>
-      'Modalità di navigazione predefinita per le scene';
+  String get settings_interface_scenes_layout_subtitle => 'Modalità di navigazione predefinita per le scene';
 
   @override
   String get settings_interface_galleries_layout => 'Layout Gallerie';
 
   @override
-  String get settings_interface_galleries_layout_subtitle =>
-      'Modalità di navigazione predefinita per le gallerie';
+  String get settings_interface_galleries_layout_subtitle => 'Modalità di navigazione predefinita per le gallerie';
 
   @override
-  String get settings_interface_max_performer_avatars =>
-      'Numero massimo di avatar degli attori';
+  String get settings_interface_max_performer_avatars => 'Numero massimo di avatar degli attori';
 
   @override
-  String get settings_interface_max_performer_avatars_subtitle =>
-      'Numero massimo di avatar degli attori da mostrare nella scheda della scena.';
+  String get settings_interface_max_performer_avatars_subtitle => 'Numero massimo di avatar degli attori da mostrare nella scheda della scena.';
 
   @override
-  String get settings_interface_show_performer_avatars =>
-      'Mostra avatar degli attori';
+  String get settings_interface_show_performer_avatars => 'Mostra avatar degli attori';
 
   @override
-  String get settings_interface_show_performer_avatars_subtitle =>
-      'Visualizza le icone degli attori sulle schede delle scene su tutte le piattaforme.';
+  String get settings_interface_show_performer_avatars_subtitle => 'Visualizza le icone degli attori sulle schede delle scene su tutte le piattaforme.';
 
   @override
-  String get settings_interface_performer_avatar_size =>
-      'Dimensioni avatar dell\'attore';
+  String get settings_interface_performer_avatar_size => 'Dimensioni avatar dell\'attore';
 
   @override
   String get settings_interface_layout_default => 'Layout Predefinito';
 
   @override
-  String get settings_interface_layout_default_desc =>
-      'Scegli il layout predefinito per la pagina';
+  String get settings_interface_layout_default_desc => 'Scegli il layout predefinito per la pagina';
 
   @override
   String get settings_interface_layout_list => 'Elenco';
@@ -1264,16 +1213,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_interface_image_viewer => 'Visualizzatore Immagini';
 
   @override
-  String get settings_interface_image_viewer_subtitle =>
-      'Configura il comportamento della navigazione immagini a schermo intero';
+  String get settings_interface_image_viewer_subtitle => 'Configura il comportamento della navigazione immagini a schermo intero';
 
   @override
-  String get settings_interface_swipe_direction =>
-      'Direzione Scorrimento Schermo Intero';
+  String get settings_interface_swipe_direction => 'Direzione Scorrimento Schermo Intero';
 
   @override
-  String get settings_interface_swipe_direction_desc =>
-      'Scegli come avanzano le immagini in modalità schermo intero';
+  String get settings_interface_swipe_direction_desc => 'Scegli come avanzano le immagini in modalità schermo intero';
 
   @override
   String get settings_interface_swipe_vertical => 'Verticale';
@@ -1282,43 +1228,37 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_interface_swipe_horizontal => 'Orizzontale';
 
   @override
-  String get settings_interface_waterfall_columns =>
-      'Colonne Griglia Waterfall';
+  String get settings_interface_waterfall_columns => 'Colonne Griglia Waterfall';
 
   @override
   String get settings_interface_performer_layouts => 'Layout Attori';
 
   @override
-  String get settings_interface_performer_layouts_subtitle =>
-      'Predefiniti media e gallerie per gli attori';
+  String get settings_interface_performer_layouts_subtitle => 'Predefiniti media e gallerie per gli attori';
 
   @override
   String get settings_interface_studio_layouts => 'Layout Studi';
 
   @override
-  String get settings_interface_studio_layouts_subtitle =>
-      'Predefiniti media e gallerie per gli studi';
+  String get settings_interface_studio_layouts_subtitle => 'Predefiniti media e gallerie per gli studi';
 
   @override
   String get settings_interface_tag_layouts => 'Layout Tag';
 
   @override
-  String get settings_interface_tag_layouts_subtitle =>
-      'Predefiniti media e gallerie per i tag';
+  String get settings_interface_tag_layouts_subtitle => 'Predefiniti media e gallerie per i tag';
 
   @override
   String get settings_interface_media_layout => 'Layout Media';
 
   @override
-  String get settings_interface_media_layout_subtitle =>
-      'Layout per la pagina Media';
+  String get settings_interface_media_layout_subtitle => 'Layout per la pagina Media';
 
   @override
   String get settings_interface_galleries_layout_item => 'Layout Gallerie';
 
   @override
-  String get settings_interface_galleries_layout_subtitle_item =>
-      'Layout per la pagina Gallerie';
+  String get settings_interface_galleries_layout_subtitle_item => 'Layout per la pagina Gallerie';
 
   @override
   String get settings_server_title => 'Impostazioni Server';
@@ -1327,22 +1267,19 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_server_status => 'Stato Connessione';
 
   @override
-  String get settings_server_status_subtitle =>
-      'Connettività in tempo reale con il server configurato';
+  String get settings_server_status_subtitle => 'Connettività in tempo reale con il server configurato';
 
   @override
   String get settings_server_details => 'Dettagli Server';
 
   @override
-  String get settings_server_details_subtitle =>
-      'Configura endpoint e metodo di autenticazione';
+  String get settings_server_details_subtitle => 'Configura endpoint e metodo di autenticazione';
 
   @override
   String get settings_server_url => 'URL di Stash';
 
   @override
-  String get settings_server_url_helper =>
-      'Inserisci l\'URL del tuo server Stash. Se configurato con un percorso personalizzato, includilo qui.';
+  String get settings_server_url_helper => 'Inserisci l\'URL del tuo server Stash. Se configurato con un percorso personalizzato, includilo qui.';
 
   @override
   String get settings_server_url_example => 'http://192.168.1.100:9999';
@@ -1360,12 +1297,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_server_auth_password => 'Nome utente + Password';
 
   @override
-  String get settings_server_auth_password_desc =>
-      'Consigliato: usa la sessione nome utente/password di Stash.';
+  String get settings_server_auth_password_desc => 'Consigliato: usa la sessione nome utente/password di Stash.';
 
   @override
-  String get settings_server_auth_apikey_desc =>
-      'Usa la chiave API per l\'autenticazione tramite token statico.';
+  String get settings_server_auth_apikey_desc => 'Usa la chiave API per l\'autenticazione tramite token statico.';
 
   @override
   String get settings_server_username => 'Nome utente';
@@ -1402,12 +1337,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_server_invalid_url => 'URL server non valido';
 
   @override
-  String get settings_server_resolve_error =>
-      'Impossibile risolvere l\'URL del server. Controlla host, porta e credenziali.';
+  String get settings_server_resolve_error => 'Impossibile risolvere l\'URL del server. Controlla host, porta e credenziali.';
 
   @override
-  String get settings_server_logout_confirm =>
-      'Disconnessione effettuata e cookie cancellati.';
+  String get settings_server_logout_confirm => 'Disconnessione effettuata e cookie cancellati.';
 
   @override
   String get settings_server_profile_add => 'Aggiungi profilo';
@@ -1422,34 +1355,28 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_server_profile_delete => 'Elimina profilo';
 
   @override
-  String get settings_server_profile_delete_confirm =>
-      'Sei sicuro di voler eliminare questo profilo? Questa azione non può essere annullata.';
+  String get settings_server_profile_delete_confirm => 'Sei sicuro di voler eliminare questo profilo? Questa azione non può essere annullata.';
 
   @override
   String get settings_server_profile_active => 'Attivo';
 
   @override
-  String get settings_server_profile_empty =>
-      'Nessun profilo server configurato';
+  String get settings_server_profile_empty => 'Nessun profilo server configurato';
 
   @override
   String get settings_server_profiles => 'Profili server';
 
   @override
-  String get settings_server_profiles_subtitle =>
-      'Gestisci connessioni multiple al server Stash';
+  String get settings_server_profiles_subtitle => 'Gestisci connessioni multiple al server Stash';
 
   @override
-  String get settings_server_auth_status_logging_in =>
-      'Stato autenticazione: accesso in corso...';
+  String get settings_server_auth_status_logging_in => 'Stato autenticazione: accesso in corso...';
 
   @override
-  String get settings_server_auth_status_logged_in =>
-      'Stato autenticazione: connesso';
+  String get settings_server_auth_status_logged_in => 'Stato autenticazione: connesso';
 
   @override
-  String get settings_server_auth_status_logged_out =>
-      'Stato autenticazione: disconnesso';
+  String get settings_server_auth_status_logged_out => 'Stato autenticazione: disconnesso';
 
   @override
   String get settings_playback_title => 'Impostazioni Riproduzione';
@@ -1458,96 +1385,76 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_playback_behavior => 'Comportamento riproduzione';
 
   @override
-  String get settings_playback_behavior_subtitle =>
-      'Gestione riproduzione predefinita e background';
+  String get settings_playback_behavior_subtitle => 'Gestione riproduzione predefinita e background';
 
   @override
-  String get settings_playback_prefer_streams =>
-      'Preferisci sceneStreams prima';
+  String get settings_playback_prefer_streams => 'Preferisci sceneStreams prima';
 
   @override
-  String get settings_playback_prefer_streams_subtitle =>
-      'Quando disattivato, la riproduzione utilizza direttamente paths.stream';
+  String get settings_playback_prefer_streams_subtitle => 'Quando disattivato, la riproduzione utilizza direttamente paths.stream';
 
   @override
-  String get settings_playback_feed_random =>
-      'Avvia Feed da una posizione casuale';
+  String get settings_playback_feed_random => 'Avvia Feed da una posizione casuale';
 
   @override
-  String get settings_playback_feed_random_subtitle =>
-      'Durante la riproduzione di scene in modalità Feed, avvia da una posizione casuale tra lo 0% e il 90% della durata del video';
+  String get settings_playback_feed_random_subtitle => 'Durante la riproduzione di scene in modalità Feed, avvia da una posizione casuale tra lo 0% e il 90% della durata del video';
 
   @override
-  String get settings_playback_resume_position =>
-      'Riprendi dall\'ultima posizione di gioco';
+  String get settings_playback_resume_position => 'Riprendi dall\'ultima posizione di gioco';
 
   @override
-  String get settings_playback_resume_position_subtitle =>
-      'Quando apri un video, riprendi automaticamente da dove avevi interrotto';
+  String get settings_playback_resume_position_subtitle => 'Quando apri un video, riprendi automaticamente da dove avevi interrotto';
 
   @override
-  String get settings_playback_end_behavior =>
-      'Riproduci il comportamento finale';
+  String get settings_playback_end_behavior => 'Riproduci il comportamento finale';
 
   @override
-  String get settings_playback_end_behavior_subtitle =>
-      'Cosa fare al termine della riproduzione corrente';
+  String get settings_playback_end_behavior_subtitle => 'Cosa fare al termine della riproduzione corrente';
 
   @override
   String get settings_playback_end_behavior_stop => 'Fermare';
 
   @override
-  String get settings_playback_end_behavior_loop =>
-      'Eseguire il loop della scena corrente';
+  String get settings_playback_end_behavior_loop => 'Eseguire il loop della scena corrente';
 
   @override
-  String get settings_playback_end_behavior_next =>
-      'Riproduci la scena successiva';
+  String get settings_playback_end_behavior_next => 'Riproduci la scena successiva';
 
   @override
-  String get settings_playback_autoplay =>
-      'Riproduzione Automatica Prossima Scena';
+  String get settings_playback_autoplay => 'Riproduzione Automatica Prossima Scena';
 
   @override
-  String get settings_playback_autoplay_subtitle =>
-      'Riproduci automaticamente la scena successiva al termine della corrente';
+  String get settings_playback_autoplay_subtitle => 'Riproduci automaticamente la scena successiva al termine della corrente';
 
   @override
   String get settings_playback_background => 'Riproduzione in Background';
 
   @override
-  String get settings_playback_background_subtitle =>
-      'Mantieni l\'audio del video attivo quando l\'app è in background';
+  String get settings_playback_background_subtitle => 'Mantieni l\'audio del video attivo quando l\'app è in background';
 
   @override
   String get settings_playback_pip => 'Picture-in-Picture Nativo';
 
   @override
-  String get settings_playback_pip_subtitle =>
-      'Abilita il pulsante PiP di Android e l\'ingresso automatico in background';
+  String get settings_playback_pip_subtitle => 'Abilita il pulsante PiP di Android e l\'ingresso automatico in background';
 
   @override
   String get settings_playback_subtitles => 'Impostazioni sottotitoli';
 
   @override
-  String get settings_playback_subtitles_subtitle =>
-      'Caricamento automatico e aspetto';
+  String get settings_playback_subtitles_subtitle => 'Caricamento automatico e aspetto';
 
   @override
-  String get settings_playback_subtitle_lang =>
-      'Lingua Sottotitoli Predefinita';
+  String get settings_playback_subtitle_lang => 'Lingua Sottotitoli Predefinita';
 
   @override
-  String get settings_playback_subtitle_lang_subtitle =>
-      'Carica automaticamente se disponibile';
+  String get settings_playback_subtitle_lang_subtitle => 'Carica automaticamente se disponibile';
 
   @override
-  String get settings_playback_subtitle_size =>
-      'Dimensione Carattere Sottotitoli';
+  String get settings_playback_subtitle_size => 'Dimensione Carattere Sottotitoli';
 
   @override
-  String get settings_playback_subtitle_pos =>
-      'Posizione Verticale Sottotitoli';
+  String get settings_playback_subtitle_pos => 'Posizione Verticale Sottotitoli';
 
   @override
   String settings_playback_subtitle_pos_desc(String percent) {
@@ -1555,23 +1462,19 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get settings_playback_subtitle_align =>
-      'Allineamento Testo Sottotitoli';
+  String get settings_playback_subtitle_align => 'Allineamento Testo Sottotitoli';
 
   @override
-  String get settings_playback_subtitle_align_subtitle =>
-      'Allineamento per sottotitoli su più righe';
+  String get settings_playback_subtitle_align_subtitle => 'Allineamento per sottotitoli su più righe';
 
   @override
   String get settings_playback_seek => 'Interazione ricerca';
 
   @override
-  String get settings_playback_seek_subtitle =>
-      'Scegli come funziona lo scorrimento durante la riproduzione';
+  String get settings_playback_seek_subtitle => 'Scegli come funziona lo scorrimento durante la riproduzione';
 
   @override
-  String get settings_playback_seek_double_tap =>
-      'Doppio tocco sinistra/destra per cercare 10s';
+  String get settings_playback_seek_double_tap => 'Doppio tocco sinistra/destra per cercare 10s';
 
   @override
   String get settings_playback_seek_drag => 'Trascina la timeline per cercare';
@@ -1583,28 +1486,22 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_playback_seek_double_tap_label => 'Doppio tocco';
 
   @override
-  String get settings_playback_gravity_orientation =>
-      'Orientamento controllato dalla gravità';
+  String get settings_playback_gravity_orientation => 'Orientamento controllato dalla gravità';
 
   @override
-  String get settings_playback_direct_play =>
-      'Riproduzione diretta alla navigazione della scena';
+  String get settings_playback_direct_play => 'Riproduzione diretta alla navigazione della scena';
 
   @override
-  String get settings_playback_direct_play_subtitle =>
-      'Quando si naviga da un\'altra scena in riproduzione, riproduce direttamente la nuova scena';
+  String get settings_playback_direct_play_subtitle => 'Quando si naviga da un\'altra scena in riproduzione, riproduce direttamente la nuova scena';
 
   @override
-  String get settings_playback_gravity_orientation_subtitle =>
-      'Consenti la rotazione tra orientamenti corrispondenti usando il sensore del dispositivo (es. capovolgere il paesaggio a sinistra/destra).';
+  String get settings_playback_gravity_orientation_subtitle => 'Consenti la rotazione tra orientamenti corrispondenti usando il sensore del dispositivo (es. capovolgere il paesaggio a sinistra/destra).';
 
   @override
-  String get settings_playback_subtitle_lang_none_disabled =>
-      'Nessuno (Disattivato)';
+  String get settings_playback_subtitle_lang_none_disabled => 'Nessuno (Disattivato)';
 
   @override
-  String get settings_playback_subtitle_lang_auto_if_only_one =>
-      'Automatico (Se ce n\'è solo uno)';
+  String get settings_playback_subtitle_lang_auto_if_only_one => 'Automatico (Se ce n\'è solo uno)';
 
   @override
   String get settings_playback_subtitle_lang_english => 'Inglese';
@@ -1646,15 +1543,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_support_diagnostics => 'Diagnostica e info progetto';
 
   @override
-  String get settings_support_diagnostics_subtitle =>
-      'Apri i log di runtime o vai al repository quando hai bisogno di aiuto.';
+  String get settings_support_diagnostics_subtitle => 'Apri i log di runtime o vai al repository quando hai bisogno di aiuto.';
 
   @override
   String get settings_support_update_available => 'Aggiornamento Disponibile';
 
   @override
-  String get settings_support_update_available_subtitle =>
-      'Una nuova versione è disponibile su GitHub';
+  String get settings_support_update_available_subtitle => 'Una nuova versione è disponibile su GitHub';
 
   @override
   String settings_support_update_to(String version) {
@@ -1662,15 +1557,13 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get settings_support_update_to_subtitle =>
-      'Nuove funzionalità e miglioramenti ti aspettano.';
+  String get settings_support_update_to_subtitle => 'Nuove funzionalità e miglioramenti ti aspettano.';
 
   @override
   String get settings_support_about => 'Informazioni';
 
   @override
-  String get settings_support_about_subtitle =>
-      'Informazioni su progetto e sorgenti';
+  String get settings_support_about_subtitle => 'Informazioni su progetto e sorgenti';
 
   @override
   String get settings_support_version => 'Versione';
@@ -1679,88 +1572,73 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_support_version_loading => 'Caricamento info versione...';
 
   @override
-  String get settings_support_version_unavailable =>
-      'Info versione non disponibili';
+  String get settings_support_version_unavailable => 'Info versione non disponibili';
 
   @override
   String get settings_support_github => 'Repository GitHub';
 
   @override
-  String get settings_support_github_subtitle =>
-      'Visualizza il codice sorgente e segnala problemi';
+  String get settings_support_github_subtitle => 'Visualizza il codice sorgente e segnala problemi';
 
   @override
-  String get settings_support_github_error =>
-      'Impossibile aprire il link GitHub';
+  String get settings_support_github_error => 'Impossibile aprire il link GitHub';
 
   @override
   String get settings_support_issues => 'Segnala un problema';
 
   @override
-  String get settings_support_issues_subtitle =>
-      'Aiuta a migliorare StashFlow segnalando bug';
+  String get settings_support_issues_subtitle => 'Aiuta a migliorare StashFlow segnalando bug';
 
   @override
   String get settings_develop_title => 'Sviluppo';
 
   @override
-  String get settings_develop_enable_logging =>
-      'Abilita registrazione di debug';
+  String get settings_develop_enable_logging => 'Abilita registrazione di debug';
 
   @override
-  String get settings_develop_enable_logging_subtitle =>
-      'Registra i log dell\'applicazione per la risoluzione dei problemi';
+  String get settings_develop_enable_logging_subtitle => 'Registra i log dell\'applicazione per la risoluzione dei problemi';
 
   @override
   String get settings_develop_diagnostics => 'Strumenti Diagnostici';
 
   @override
-  String get settings_develop_diagnostics_subtitle =>
-      'Risoluzione dei problemi e prestazioni';
+  String get settings_develop_diagnostics_subtitle => 'Risoluzione dei problemi e prestazioni';
 
   @override
   String get settings_develop_video_debug => 'Mostra Info Debug Video';
 
   @override
-  String get settings_develop_video_debug_subtitle =>
-      'Visualizza dettagli tecnici di riproduzione in sovrimpressione sul lettore video.';
+  String get settings_develop_video_debug_subtitle => 'Visualizza dettagli tecnici di riproduzione in sovrimpressione sul lettore video.';
 
   @override
   String get settings_develop_log_viewer => 'Visualizzatore Log di Debug';
 
   @override
-  String get settings_develop_log_viewer_subtitle =>
-      'Apri una visualizzazione in tempo reale dei log interni all\'app.';
+  String get settings_develop_log_viewer_subtitle => 'Apri una visualizzazione in tempo reale dei log interni all\'app.';
 
   @override
   String get settings_develop_logs_copied => 'Log copiati negli appunti';
 
   @override
-  String get settings_develop_no_logs =>
-      'Ancora nessun log. Interagisci con l\'app per acquisire i log.';
+  String get settings_develop_no_logs => 'Ancora nessun log. Interagisci con l\'app per acquisire i log.';
 
   @override
   String get settings_develop_web_overrides => 'Override Web';
 
   @override
-  String get settings_develop_web_overrides_subtitle =>
-      'Flag avanzati per la piattaforma web';
+  String get settings_develop_web_overrides_subtitle => 'Flag avanzati per la piattaforma web';
 
   @override
-  String get settings_develop_web_auth =>
-      'Consenti Accesso con Password su Web';
+  String get settings_develop_web_auth => 'Consenti Accesso con Password su Web';
 
   @override
-  String get settings_develop_web_auth_subtitle =>
-      'Ignora la restrizione solo-nativa e forza la visibilità del metodo di autenticazione Nome utente + Password su Flutter Web.';
+  String get settings_develop_web_auth_subtitle => 'Ignora la restrizione solo-nativa e forza la visibilità del metodo di autenticazione Nome utente + Password su Flutter Web.';
 
   @override
-  String get settings_develop_proxy_auth =>
-      'Abilita modalità di autenticazione proxy';
+  String get settings_develop_proxy_auth => 'Abilita modalità di autenticazione proxy';
 
   @override
-  String get settings_develop_proxy_auth_subtitle =>
-      'Abilita i metodi avanzati Basic Auth e Bearer Token per l\'uso con backend senza autenticazione dietro proxy come Authentik.';
+  String get settings_develop_proxy_auth_subtitle => 'Abilita i metodi avanzati Basic Auth e Bearer Token per l\'uso con backend senza autenticazione dietro proxy come Authentik.';
 
   @override
   String get settings_server_auth_basic => 'Autenticazione di base';
@@ -1769,12 +1647,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_server_auth_bearer => 'Token Bearer';
 
   @override
-  String get settings_server_auth_basic_desc =>
-      'Invia l\'header \'Authorization: Basic <base64(user:pass)>\'.';
+  String get settings_server_auth_basic_desc => 'Invia l\'header \'Authorization: Basic <base64(user:pass)>\'.';
 
   @override
-  String get settings_server_auth_bearer_desc =>
-      'Invia l\'header \'Authorization: Bearer <token>\'.';
+  String get settings_server_auth_bearer_desc => 'Invia l\'header \'Authorization: Bearer <token>\'.';
 
   @override
   String get common_edit => 'Modifica';
@@ -1795,8 +1671,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get common_square => 'Quadrato';
 
   @override
-  String get performers_filter_saved =>
-      'Preferenze del filtro salvate come predefinite';
+  String get performers_filter_saved => 'Preferenze del filtro salvate come predefinite';
 
   @override
   String get images_title => 'Immagini';
@@ -1805,15 +1680,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get images_filter_title => 'Filtra immagini';
 
   @override
-  String get images_filter_saved =>
-      'Preferenze del filtro salvate come predefinite';
+  String get images_filter_saved => 'Preferenze del filtro salvate come predefinite';
 
   @override
   String get images_sort_title => 'Ordina immagini';
 
   @override
-  String get images_sort_saved =>
-      'Preferenze di ordinamento salvate come predefinite';
+  String get images_sort_saved => 'Preferenze di ordinamento salvate come predefinite';
 
   @override
   String get image_rating_updated => 'Valutazione immagine aggiornata.';
@@ -1828,8 +1701,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get common_gallery => 'Galleria';
 
   @override
-  String get images_gallery_rating_unavailable =>
-      'La valutazione della galleria è disponibile solo quando si sfoglia una galleria.';
+  String get images_gallery_rating_unavailable => 'La valutazione della galleria è disponibile solo quando si sfoglia una galleria.';
 
   @override
   String images_rating(String rating) {
@@ -1840,8 +1712,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get images_filtered_by_gallery => 'Filtrato per galleria';
 
   @override
-  String get images_slideshow_need_two =>
-      'Sono necessarie almeno 2 immagini per la presentazione.';
+  String get images_slideshow_need_two => 'Sono necessarie almeno 2 immagini per la presentazione.';
 
   @override
   String get images_slideshow_start_title => 'Avvia presentazione';
@@ -1875,12 +1746,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get common_done => 'Fatto';
 
   @override
-  String get settings_keybind_assign_shortcut =>
-      'Premi una scorciatoia per assegnare';
+  String get settings_keybind_assign_shortcut => 'Premi una scorciatoia per assegnare';
 
   @override
-  String get settings_keybind_press_any =>
-      'Premi qualsiasi tasto per assegnare la scorciatoia';
+  String get settings_keybind_press_any => 'Premi qualsiasi tasto per assegnare la scorciatoia';
 
   @override
   String get scenes_select_tags => 'Seleziona tag';
@@ -1941,12 +1810,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get scenes_unmatched_scraped_tags => 'Tag estratti non corrispondenti';
 
   @override
-  String get scenes_unmatched_scraped_performers =>
-      'Interpreti estratti non corrispondenti';
+  String get scenes_unmatched_scraped_performers => 'Interpreti estratti non corrispondenti';
 
   @override
-  String get scenes_no_matching_performer_found =>
-      'Nessun interprete corrispondente trovato nella libreria';
+  String get scenes_no_matching_performer_found => 'Nessun interprete corrispondente trovato nella libreria';
 
   @override
   String get common_unknown => 'Sconosciuto';
@@ -2031,8 +1898,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get cast_airplay_pairing => 'Associazione AirPlay';
 
   @override
-  String get cast_enter_pin =>
-      'Inserisci il PIN di 4 cifre mostrato sulla tua TV';
+  String get cast_enter_pin => 'Inserisci il PIN di 4 cifre mostrato sulla tua TV';
 
   @override
   String get cast_pair => 'Paio';
@@ -2073,34 +1939,28 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_storage_database => 'Banca dati';
 
   @override
-  String get settings_storage_clearing_image =>
-      'Cancellazione della cache delle immagini...';
+  String get settings_storage_clearing_image => 'Cancellazione della cache delle immagini...';
 
   @override
-  String get settings_storage_clearing_video =>
-      'Cancellazione della cache video...';
+  String get settings_storage_clearing_video => 'Cancellazione della cache video...';
 
   @override
-  String get settings_storage_clearing_database =>
-      'Cancellazione della cache del database...';
+  String get settings_storage_clearing_database => 'Cancellazione della cache del database...';
 
   @override
-  String get settings_storage_cleared_image =>
-      'Cache delle immagini cancellata';
+  String get settings_storage_cleared_image => 'Cache delle immagini cancellata';
 
   @override
   String get settings_storage_cleared_video => 'Cache video cancellata';
 
   @override
-  String get settings_storage_cleared_database =>
-      'Cache del database cancellata';
+  String get settings_storage_cleared_database => 'Cache del database cancellata';
 
   @override
   String get settings_storage_clear => 'Chiaro';
 
   @override
-  String get settings_storage_error_loading =>
-      'Errore durante il caricamento delle dimensioni';
+  String get settings_storage_error_loading => 'Errore durante il caricamento delle dimensioni';
 
   @override
   String settings_storage_mb(num value) {
@@ -2131,8 +1991,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_storage_limits => 'Limiti';
 
   @override
-  String get settings_storage_limits_subtitle =>
-      'Imposta le dimensioni massime della cache';
+  String get settings_storage_limits_subtitle => 'Imposta le dimensioni massime della cache';
 
   @override
   String get settings_storage_max_image_cache => 'Cache immagini massima (MB)';
@@ -2150,8 +2009,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_storage_usage_subtitle => 'Spazio usato dalle cache';
 
   @override
-  String get settings_storage_subtitle =>
-      'Gestisci cache locali e limiti di archiviazione';
+  String get settings_storage_subtitle => 'Gestisci cache locali e limiti di archiviazione';
 
   @override
   String get performers_field_name => 'Nome';
@@ -2376,8 +2234,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get scenes_field_updated_at => 'Aggiornato il';
 
   @override
-  String get cast_stopped_resuming_locally =>
-      'Trasmissione interrotta, ripresa locale';
+  String get cast_stopped_resuming_locally => 'Trasmissione interrotta, ripresa locale';
 
   @override
   String get cast_stop_casting => 'Interrompi trasmissione';
@@ -2401,8 +2258,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get common_star => 'Stella';
 
   @override
-  String get settings_interface_card_title_font_size =>
-      'Dimensione carattere titolo scheda';
+  String get settings_interface_card_title_font_size => 'Dimensione carattere titolo scheda';
 
   @override
   String get common_hint_date => 'AAAA-MM-GG';
@@ -2467,16 +2323,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get sort_scenes => 'Ordina scene';
 
   @override
-  String get failed_to_load_tap_to_retry =>
-      'Impossibile caricare. Tocca per riprovare.';
+  String get failed_to_load_tap_to_retry => 'Impossibile caricare. Tocca per riprovare.';
 
   @override
-  String get would_you_like_to_visit_the_release_page_to_download_it =>
-      'Vuoi visitare la pagina della release per scaricarlo?';
+  String get would_you_like_to_visit_the_release_page_to_download_it => 'Vuoi visitare la pagina della release per scaricarlo?';
 
   @override
-  String get to_get_started_configure_stash_server =>
-      'Per iniziare, devi configurare i dettagli di connessione del tuo server Stash.';
+  String get to_get_started_configure_stash_server => 'Per iniziare, devi configurare i dettagli di connessione del tuo server Stash.';
 
   @override
   String get loading => 'Caricamento';
@@ -2579,8 +2432,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get main_startup_failed => 'Impossibile avviare StashFlow';
 
   @override
-  String get main_startup_failed_desc =>
-      'Un servizio di avvio non è riuscito prima che l\'app potesse completare l\'inizializzazione.Riavvia l\'app dopo aver controllato la diagnostica.';
+  String get main_startup_failed_desc => 'Un servizio di avvio non è riuscito prima che l\'app potesse completare l\'inizializzazione.Riavvia l\'app dopo aver controllato la diagnostica.';
 
   @override
   String common_searching_for(String query) {
@@ -2621,41 +2473,34 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_security_enable_app_lock => 'Abilita il blocco dell\'app';
 
   @override
-  String get settings_security_enable_app_lock_subtitle =>
-      'Richiedi il passcode al ripristino/avvio dell\'app.';
+  String get settings_security_enable_app_lock_subtitle => 'Richiedi il passcode al ripristino/avvio dell\'app.';
 
   @override
   String get settings_security_lock_on_launch => 'Blocca all\'avvio dell\'app';
 
   @override
-  String get settings_security_lock_on_launch_subtitle =>
-      'Richiedi immediatamente il passcode all\'apertura dell\'app.';
+  String get settings_security_lock_on_launch_subtitle => 'Richiedi immediatamente il passcode all\'apertura dell\'app.';
 
   @override
-  String get settings_security_background_lock_timer =>
-      'Temporizzatore di blocco dello sfondo';
+  String get settings_security_background_lock_timer => 'Temporizzatore di blocco dello sfondo';
 
   @override
-  String get settings_security_background_lock_timer_subtitle =>
-      'Per quanto tempo l\'app può rimanere in background prima di bloccarsi.';
+  String get settings_security_background_lock_timer_subtitle => 'Per quanto tempo l\'app può rimanere in background prima di bloccarsi.';
 
   @override
   String get settings_security_set_passcode => 'Imposta il codice di accesso';
 
   @override
-  String get settings_security_passcode_prompt =>
-      'Codice di accesso (4-8 cifre)';
+  String get settings_security_passcode_prompt => 'Codice di accesso (4-8 cifre)';
 
   @override
   String get settings_security_confirm_passcode => 'Confermare';
 
   @override
-  String get settings_security_error_numeric =>
-      'Utilizzare solo cifre, con lunghezza compresa tra 4 e 8.';
+  String get settings_security_error_numeric => 'Utilizzare solo cifre, con lunghezza compresa tra 4 e 8.';
 
   @override
-  String get settings_security_error_mismatch =>
-      'I codici di accesso non corrispondono.';
+  String get settings_security_error_mismatch => 'I codici di accesso non corrispondono.';
 
   @override
   String get common_change => 'Modifica';
@@ -2685,15 +2530,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_security_title => 'Sicurezza';
 
   @override
-  String get settings_security_subtitle =>
-      'Impostazioni del blocco dell\'applicazione e del passcode';
+  String get settings_security_subtitle => 'Impostazioni del blocco dell\'applicazione e del passcode';
 
   @override
   String get settings_security_app_lock => 'Blocco dell\'app';
 
   @override
-  String get settings_security_app_lock_subtitle =>
-      'Proteggi l\'accesso con un passcode dopo il background.';
+  String get settings_security_app_lock_subtitle => 'Proteggi l\'accesso con un passcode dopo il background.';
 
   @override
   String get common_saved_filters => 'Filtri salvati';
@@ -2702,16 +2545,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get tools => 'Utensili';
 
   @override
-  String get tools_section_subtitle =>
-      'Flussi di lavoro di manutenzione e metadati per le scene.';
+  String get tools_section_subtitle => 'Flussi di lavoro di manutenzione e metadati per le scene.';
 
   @override
-  String get tools_scene_deduplication_subtitle =>
-      'Trova e gestisci le scene duplicate.';
+  String get tools_scene_deduplication_subtitle => 'Trova e gestisci le scene duplicate.';
 
   @override
-  String get tools_scene_tagger_subtitle =>
-      'Scrape delle pagine delle scene correnti con Stash-box.';
+  String get tools_scene_tagger_subtitle => 'Scrape delle pagine delle scene correnti con Stash-box.';
 
   @override
   String get preset_deleted => 'Preimpostazione eliminata';
@@ -2813,15 +2653,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get duration_difference => 'Differenza di durata';
 
   @override
-  String get only_select_matching_codecs =>
-      'Seleziona solo i codec corrispondenti';
+  String get only_select_matching_codecs => 'Seleziona solo i codec corrispondenti';
 
   @override
   String get select_scenes => 'Seleziona le scene';
 
   @override
-  String get all_but_largest_resolution =>
-      'Tutto tranne la massima risoluzione';
+  String get all_but_largest_resolution => 'Tutto tranne la massima risoluzione';
 
   @override
   String get all_but_largest_file => 'Tutto tranne il file più grande';
@@ -2863,8 +2701,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get enter_preset_name => 'Inserisci il nome del preset';
 
   @override
-  String get delete_scene_confirm =>
-      'Sei sicuro di voler eliminare questa scena?';
+  String get delete_scene_confirm => 'Sei sicuro di voler eliminare questa scena?';
 
   @override
   String delete_selected_count(int selectedCount) {
@@ -2881,12 +2718,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get available_presets => 'Preset disponibili';
 
   @override
-  String get existing_names_are_overwritten =>
-      'I nomi esistenti verranno sovrascritti';
+  String get existing_names_are_overwritten => 'I nomi esistenti verranno sovrascritti';
 
   @override
-  String get active_settings_saved_server =>
-      'Le impostazioni attive correnti verranno salvate sul server.';
+  String get active_settings_saved_server => 'Le impostazioni attive correnti verranno salvate sul server.';
 
   @override
   String failed_to_save_filter(String error) {
@@ -2934,8 +2769,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get delete_scenes_help =>
-      'Scegli se rimuovere solo i metadati di Stash oppure eliminare anche i file della scena e i file di supporto generati.';
+  String get delete_scenes_help => 'Scegli se rimuovere solo i metadati di Stash oppure eliminare anche i file della scena e i file di supporto generati.';
 
   @override
   String deleted_n_scenes(int count) {
@@ -2956,8 +2790,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get merge_editing_not_wired =>
-      'La modifica delle unioni non è ancora collegata in StashFlow.';
+  String get merge_editing_not_wired => 'La modifica delle unioni non è ancora collegata in StashFlow.';
 
   @override
   String duplicate_sets_count(int count) {
@@ -2993,6 +2826,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String nTags(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3010,6 +2844,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String nGroups(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3027,6 +2862,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String nMarkers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3044,6 +2880,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String nGalleries(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3071,8 +2908,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get no_matched_scenes_yet => 'Nessuna scena corrispondente finora.';
 
   @override
-  String get no_scenes_match_configuration =>
-      'Nessuna scena corrisponde a questa configurazione.';
+  String get no_scenes_match_configuration => 'Nessuna scena corrisponde a questa configurazione.';
 
   @override
   String scene_tagger_checked_count(int count) {
@@ -3085,8 +2921,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get stats_library_stats_tooltip =>
-      'Tieni premuto per le statistiche della libreria';
+  String get stats_library_stats_tooltip => 'Tieni premuto per le statistiche della libreria';
 
   @override
   String get scene_details_marker_created => 'Marcatore creato';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -45,6 +45,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String nScenes(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -62,6 +63,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String nPerformers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -79,6 +81,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String nPlays(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -1075,8 +1078,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_appearance_primary_color => 'プライマリーカラー';
 
   @override
-  String get settings_appearance_primary_color_subtitle =>
-      'Material 3パレットのシードカラーを選択します';
+  String get settings_appearance_primary_color_subtitle => 'Material 3パレットのシードカラーを選択します';
 
   @override
   String get settings_appearance_advanced_theming => '高度なテーマ設定';
@@ -1088,8 +1090,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_appearance_true_black => 'トゥルーブラック (AMOLED)';
 
   @override
-  String get settings_appearance_true_black_subtitle =>
-      'ダークモードで純粋な黒の背景を使用し、OLED画面のバッテリーを節約します';
+  String get settings_appearance_true_black_subtitle => 'ダークモードで純粋な黒の背景を使用し、OLED画面のバッテリーを節約します';
 
   @override
   String get settings_appearance_custom_hex => 'カスタム16進数カラー';
@@ -1119,45 +1120,37 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_interface_navigation => 'ナビゲーション';
 
   @override
-  String get settings_interface_navigation_subtitle =>
-      'グローバルナビゲーションショートカットの表示設定';
+  String get settings_interface_navigation_subtitle => 'グローバルナビゲーションショートカットの表示設定';
 
   @override
   String get settings_interface_show_random => 'ランダムナビゲーションボタンを表示';
 
   @override
-  String get settings_interface_show_random_subtitle =>
-      'リストおよび詳細ページでフローティングカジノボタンを有効または無効にします';
+  String get settings_interface_show_random_subtitle => 'リストおよび詳細ページでフローティングカジノボタンを有効または無効にします';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation =>
-      '重力制御の画面向き（メインページ）';
+  String get settings_interface_main_pages_gravity_orientation => '重力制御の画面向き（メインページ）';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation_subtitle =>
-      'デバイスセンサーを使ってメインページの向きを回転できるようにします。全画面動画再生は専用の画面向き設定に従います。';
+  String get settings_interface_main_pages_gravity_orientation_subtitle => 'デバイスセンサーを使ってメインページの向きを回転できるようにします。全画面動画再生は専用の画面向き設定に従います。';
 
   @override
   String get settings_interface_show_edit => '編集ボタンを表示';
 
   @override
-  String get settings_interface_show_edit_subtitle =>
-      'シーン詳細ページの編集ボタンを有効または無効にします';
+  String get settings_interface_show_edit_subtitle => 'シーン詳細ページの編集ボタンを有効または無効にします';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer =>
-      'ミニプレーヤーで実際のシーン動画を使用';
+  String get settings_interface_use_actual_scene_video_miniplayer => 'ミニプレーヤーで実際のシーン動画を使用';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer_subtitle =>
-      '再生中はシーンのスクリーンショットの代わりにライブ動画サーフェスを表示します。';
+  String get settings_interface_use_actual_scene_video_miniplayer_subtitle => '再生中はシーンのスクリーンショットの代わりにライブ動画サーフェスを表示します。';
 
   @override
   String get settings_interface_entity_image_filtering => 'エンティティ画像フィルタリング';
 
   @override
-  String get settings_interface_entity_image_filtering_subtitle =>
-      'エンティティ画像ページが画像メタデータと一致するか、関連ギャラリーと一致するかを選択します。';
+  String get settings_interface_entity_image_filtering_subtitle => 'エンティティ画像ページが画像メタデータと一致するか、関連ギャラリーと一致するかを選択します。';
 
   @override
   String get settings_interface_entity_image_filtering_direct => '直接エンティティ';
@@ -1169,8 +1162,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_interface_customize_tabs => 'タブをカスタマイズ';
 
   @override
-  String get settings_interface_customize_tabs_subtitle =>
-      'ナビゲーションメニュー項目の並べ替えや非表示を行います';
+  String get settings_interface_customize_tabs_subtitle => 'ナビゲーションメニュー項目の並べ替えや非表示を行います';
 
   @override
   String get settings_interface_scenes_layout => 'シーンのレイアウト';
@@ -1188,15 +1180,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_interface_max_performer_avatars => 'パフォーマーの最大アバター数';
 
   @override
-  String get settings_interface_max_performer_avatars_subtitle =>
-      'シーンカードに表示するパフォーマーのアバターの最大数。';
+  String get settings_interface_max_performer_avatars_subtitle => 'シーンカードに表示するパフォーマーのアバターの最大数。';
 
   @override
   String get settings_interface_show_performer_avatars => 'パフォーマーのアバターを表示';
 
   @override
-  String get settings_interface_show_performer_avatars_subtitle =>
-      'すべてのプラットフォームでシーンカードにパフォーマーのアイコンを表示します。';
+  String get settings_interface_show_performer_avatars_subtitle => 'すべてのプラットフォームでシーンカードにパフォーマーのアイコンを表示します。';
 
   @override
   String get settings_interface_performer_avatar_size => 'パフォーマーのアバターのサイズ';
@@ -1229,8 +1219,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_interface_swipe_direction => 'フルスクリーンスワイプ方向';
 
   @override
-  String get settings_interface_swipe_direction_desc =>
-      'フルスクリーンモードで画像を切り替える方法を選択します';
+  String get settings_interface_swipe_direction_desc => 'フルスクリーンモードで画像を切り替える方法を選択します';
 
   @override
   String get settings_interface_swipe_vertical => '垂直';
@@ -1245,22 +1234,19 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_interface_performer_layouts => 'パフォーマーのレイアウト';
 
   @override
-  String get settings_interface_performer_layouts_subtitle =>
-      'パフォーマーのメディアおよびギャラリーのデフォルト設定';
+  String get settings_interface_performer_layouts_subtitle => 'パフォーマーのメディアおよびギャラリーのデフォルト設定';
 
   @override
   String get settings_interface_studio_layouts => 'スタジオのレイアウト';
 
   @override
-  String get settings_interface_studio_layouts_subtitle =>
-      'スタジオのメディアおよびギャラリーのデフォルト設定';
+  String get settings_interface_studio_layouts_subtitle => 'スタジオのメディアおよびギャラリーのデフォルト設定';
 
   @override
   String get settings_interface_tag_layouts => 'タグのレイアウト';
 
   @override
-  String get settings_interface_tag_layouts_subtitle =>
-      'タグのメディアおよびギャラリーのデフォルト設定';
+  String get settings_interface_tag_layouts_subtitle => 'タグのメディアおよびギャラリーのデフォルト設定';
 
   @override
   String get settings_interface_media_layout => 'メディアのレイアウト';
@@ -1272,8 +1258,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_interface_galleries_layout_item => 'ギャラリーのレイアウト';
 
   @override
-  String get settings_interface_galleries_layout_subtitle_item =>
-      'ギャラリーページのレイアウト';
+  String get settings_interface_galleries_layout_subtitle_item => 'ギャラリーページのレイアウト';
 
   @override
   String get settings_server_title => 'サーバー設定';
@@ -1294,8 +1279,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_server_url => 'StashのURL';
 
   @override
-  String get settings_server_url_helper =>
-      'StashサーバーのURLを入力してください。カスタムパスが設定されている場合は、それを含めてください。';
+  String get settings_server_url_helper => 'StashサーバーのURLを入力してください。カスタムパスが設定されている場合は、それを含めてください。';
 
   @override
   String get settings_server_url_example => 'http://192.168.1.100:9999';
@@ -1313,8 +1297,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_server_auth_password => 'ユーザー名 + パスワード';
 
   @override
-  String get settings_server_auth_password_desc =>
-      '推奨: Stashのユーザー名/パスワードセッションを使用します。';
+  String get settings_server_auth_password_desc => '推奨: Stashのユーザー名/パスワードセッションを使用します。';
 
   @override
   String get settings_server_auth_apikey_desc => '静的トークン認証にAPIキーを使用します。';
@@ -1354,8 +1337,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_server_invalid_url => '無効なサーバーURL';
 
   @override
-  String get settings_server_resolve_error =>
-      'サーバーURLを解決できませんでした。ホスト、ポート、認証情報を確認してください。';
+  String get settings_server_resolve_error => 'サーバーURLを解決できませんでした。ホスト、ポート、認証情報を確認してください。';
 
   @override
   String get settings_server_logout_confirm => 'ログアウトし、クッキーをクリアしました。';
@@ -1373,8 +1355,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_server_profile_delete => 'プロファイルを削除';
 
   @override
-  String get settings_server_profile_delete_confirm =>
-      'このプロファイルを削除してもよろしいですか？この操作は取り消せません。';
+  String get settings_server_profile_delete_confirm => 'このプロファイルを削除してもよろしいですか？この操作は取り消せません。';
 
   @override
   String get settings_server_profile_active => '有効';
@@ -1410,22 +1391,19 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_playback_prefer_streams => 'sceneStreamsを優先';
 
   @override
-  String get settings_playback_prefer_streams_subtitle =>
-      'オフの場合、再生は直接paths.streamを使用します';
+  String get settings_playback_prefer_streams_subtitle => 'オフの場合、再生は直接paths.streamを使用します';
 
   @override
   String get settings_playback_feed_random => 'フィードをランダムな位置から開始';
 
   @override
-  String get settings_playback_feed_random_subtitle =>
-      'フィードモードでシーンを再生するとき、動画の長さの0%から90%の間のランダムな位置から開始します';
+  String get settings_playback_feed_random_subtitle => 'フィードモードでシーンを再生するとき、動画の長さの0%から90%の間のランダムな位置から開始します';
 
   @override
   String get settings_playback_resume_position => '最後に再生した位置から再開';
 
   @override
-  String get settings_playback_resume_position_subtitle =>
-      'ビデオを開くと、中断したところから自動的に再開します';
+  String get settings_playback_resume_position_subtitle => 'ビデオを開くと、中断したところから自動的に再開します';
 
   @override
   String get settings_playback_end_behavior => '再生終了時の動作';
@@ -1446,22 +1424,19 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_playback_autoplay => '次のシーンを自動再生';
 
   @override
-  String get settings_playback_autoplay_subtitle =>
-      '現在の再生が終了したときに次のシーンを自動的に再生します';
+  String get settings_playback_autoplay_subtitle => '現在の再生が終了したときに次のシーンを自動的に再生します';
 
   @override
   String get settings_playback_background => 'バックグラウンド再生';
 
   @override
-  String get settings_playback_background_subtitle =>
-      'アプリがバックグラウンドに移動しても動画の音声を再生し続けます';
+  String get settings_playback_background_subtitle => 'アプリがバックグラウンドに移動しても動画の音声を再生し続けます';
 
   @override
   String get settings_playback_pip => 'ネイティブ ピクチャー・イン・ピクチャー';
 
   @override
-  String get settings_playback_pip_subtitle =>
-      'Android PiPボタンを有効にし、バックグラウンド時に自動移行します';
+  String get settings_playback_pip_subtitle => 'Android PiPボタンを有効にし、バックグラウンド時に自動移行します';
 
   @override
   String get settings_playback_subtitles => '字幕設定';
@@ -1517,12 +1492,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_playback_direct_play => 'シーン移動時に直接再生';
 
   @override
-  String get settings_playback_direct_play_subtitle =>
-      '他の再生中シーンから移動した際、新しいシーンを直接再生します';
+  String get settings_playback_direct_play_subtitle => '他の再生中シーンから移動した際、新しいシーンを直接再生します';
 
   @override
-  String get settings_playback_gravity_orientation_subtitle =>
-      'デバイスのセンサーを使って一致する向きに回転できるようにします（例：左右の横向きに反転）。';
+  String get settings_playback_gravity_orientation_subtitle => 'デバイスのセンサーを使って一致する向きに回転できるようにします（例：左右の横向きに反転）。';
 
   @override
   String get settings_playback_subtitle_lang_none_disabled => 'なし（無効）';
@@ -1570,15 +1543,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_support_diagnostics => '診断とプロジェクト情報';
 
   @override
-  String get settings_support_diagnostics_subtitle =>
-      'ヘルプが必要なときに実行ログを開いたり、リポジトリに移動したりします。';
+  String get settings_support_diagnostics_subtitle => 'ヘルプが必要なときに実行ログを開いたり、リポジトリに移動したりします。';
 
   @override
   String get settings_support_update_available => 'アップデートがあります';
 
   @override
-  String get settings_support_update_available_subtitle =>
-      'GitHubで新しいバージョンが利用可能です';
+  String get settings_support_update_available_subtitle => 'GitHubで新しいバージョンが利用可能です';
 
   @override
   String settings_support_update_to(String version) {
@@ -1616,8 +1587,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_support_issues => '問題を報告する';
 
   @override
-  String get settings_support_issues_subtitle =>
-      'バグを報告して StashFlow の改善にご協力ください';
+  String get settings_support_issues_subtitle => 'バグを報告して StashFlow の改善にご協力ください';
 
   @override
   String get settings_develop_title => '開発';
@@ -1626,8 +1596,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_develop_enable_logging => 'デバッグログを有効にする';
 
   @override
-  String get settings_develop_enable_logging_subtitle =>
-      'トラブルシューティング用にアプリのログを記録します';
+  String get settings_develop_enable_logging_subtitle => 'トラブルシューティング用にアプリのログを記録します';
 
   @override
   String get settings_develop_diagnostics => '診断ツール';
@@ -1639,8 +1608,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_develop_video_debug => 'ビデオデバッグ情報を表示';
 
   @override
-  String get settings_develop_video_debug_subtitle =>
-      '技術的な再生詳細を動画プレーヤー上にオーバーレイ表示します。';
+  String get settings_develop_video_debug_subtitle => '技術的な再生詳細を動画プレーヤー上にオーバーレイ表示します。';
 
   @override
   String get settings_develop_log_viewer => 'デバッグログビューアー';
@@ -1664,15 +1632,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_develop_web_auth => 'Webでのパスワードログインを許可';
 
   @override
-  String get settings_develop_web_auth_subtitle =>
-      'ネイティブ限定の制限を上書きし、Flutter Webでユーザー名 + パスワード認証を強制表示します。';
+  String get settings_develop_web_auth_subtitle => 'ネイティブ限定の制限を上書きし、Flutter Webでユーザー名 + パスワード認証を強制表示します。';
 
   @override
   String get settings_develop_proxy_auth => 'プロキシ認証モードを有効にする';
 
   @override
-  String get settings_develop_proxy_auth_subtitle =>
-      'Authentikなどのプロキシの背後にある認証不要のバックエンドで使用するために、高度なBasic認証およびBearerトークン方式を有効にします。';
+  String get settings_develop_proxy_auth_subtitle => 'Authentikなどのプロキシの背後にある認証不要のバックエンドで使用するために、高度なBasic認証およびBearerトークン方式を有効にします。';
 
   @override
   String get settings_server_auth_basic => 'Basic認証';
@@ -1681,12 +1647,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_server_auth_bearer => 'Bearerトークン';
 
   @override
-  String get settings_server_auth_basic_desc =>
-      '\'Authorization: Basic <base64(user:pass)>\' ヘッダーを送信します。';
+  String get settings_server_auth_basic_desc => '\'Authorization: Basic <base64(user:pass)>\' ヘッダーを送信します。';
 
   @override
-  String get settings_server_auth_bearer_desc =>
-      '\'Authorization: Bearer <token>\' ヘッダーを送信します。';
+  String get settings_server_auth_bearer_desc => '\'Authorization: Bearer <token>\' ヘッダーを送信します。';
 
   @override
   String get common_edit => '編集';
@@ -1737,8 +1701,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get common_gallery => 'ギャラリー';
 
   @override
-  String get images_gallery_rating_unavailable =>
-      'ギャラリーの評価は、ギャラリーを閲覧しているときにのみ利用できます。';
+  String get images_gallery_rating_unavailable => 'ギャラリーの評価は、ギャラリーを閲覧しているときにのみ利用できます。';
 
   @override
   String images_rating(String rating) {
@@ -2363,12 +2326,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get failed_to_load_tap_to_retry => '読み込みに失敗しました。タップして再試行してください。';
 
   @override
-  String get would_you_like_to_visit_the_release_page_to_download_it =>
-      'リリース ページにアクセスしてダウンロードしますか？';
+  String get would_you_like_to_visit_the_release_page_to_download_it => 'リリース ページにアクセスしてダウンロードしますか？';
 
   @override
-  String get to_get_started_configure_stash_server =>
-      '開始するには、Stash サーバーの接続設定を行う必要があります。';
+  String get to_get_started_configure_stash_server => '開始するには、Stash サーバーの接続設定を行う必要があります。';
 
   @override
   String get loading => '読み込み中';
@@ -2471,8 +2432,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get main_startup_failed => 'StashFlow の開始に失敗しました';
 
   @override
-  String get main_startup_failed_desc =>
-      'アプリの初期化が完了する前に、スタートアップ サービスが失敗しました。診断を確認した後、アプリを再起動します。';
+  String get main_startup_failed_desc => 'アプリの初期化が完了する前に、スタートアップ サービスが失敗しました。診断を確認した後、アプリを再起動します。';
 
   @override
   String common_searching_for(String query) {
@@ -2513,22 +2473,19 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_security_enable_app_lock => 'アプリロックを有効にする';
 
   @override
-  String get settings_security_enable_app_lock_subtitle =>
-      'アプリの再開/起動時にパスコードを要求します。';
+  String get settings_security_enable_app_lock_subtitle => 'アプリの再開/起動時にパスコードを要求します。';
 
   @override
   String get settings_security_lock_on_launch => 'アプリ起動時にロックする';
 
   @override
-  String get settings_security_lock_on_launch_subtitle =>
-      'アプリを開いたらすぐにパスコードを要求します。';
+  String get settings_security_lock_on_launch_subtitle => 'アプリを開いたらすぐにパスコードを要求します。';
 
   @override
   String get settings_security_background_lock_timer => 'バックグラウンドロックタイマー';
 
   @override
-  String get settings_security_background_lock_timer_subtitle =>
-      'アプリがロックされるまでにバックグラウンドに留まることができる時間。';
+  String get settings_security_background_lock_timer_subtitle => 'アプリがロックされるまでにバックグラウンドに留まることができる時間。';
 
   @override
   String get settings_security_set_passcode => 'パスコードを設定する';
@@ -2579,8 +2536,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settings_security_app_lock => 'アプリロック';
 
   @override
-  String get settings_security_app_lock_subtitle =>
-      'バックグラウンド化後はパスコードでアクセスを保護します。';
+  String get settings_security_app_lock_subtitle => 'バックグラウンド化後はパスコードでアクセスを保護します。';
 
   @override
   String get common_saved_filters => '保存されたフィルター';
@@ -2595,8 +2551,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get tools_scene_deduplication_subtitle => '重複するシーンを見つけて管理します。';
 
   @override
-  String get tools_scene_tagger_subtitle =>
-      'Stash-boxを使用して現在のシーンページをスクレイピングします。';
+  String get tools_scene_tagger_subtitle => 'Stash-boxを使用して現在のシーンページをスクレイピングします。';
 
   @override
   String get preset_deleted => 'プリセットが削除されました';
@@ -2814,8 +2769,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get delete_scenes_help =>
-      'Stash のメタデータのみを削除するか、シーンファイルと生成された補助ファイルも削除するかを選択してください。';
+  String get delete_scenes_help => 'Stash のメタデータのみを削除するか、シーンファイルと生成された補助ファイルも削除するかを選択してください。';
 
   @override
   String deleted_n_scenes(int count) {
@@ -2872,6 +2826,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String nTags(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2889,6 +2844,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String nGroups(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2906,6 +2862,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String nMarkers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2923,6 +2880,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String nGalleries(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -45,6 +45,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String nScenes(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -61,6 +62,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String nPerformers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -77,6 +79,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String nPlays(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -938,8 +941,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_customize => 'StashFlow 사용자 정의';
 
   @override
-  String get settings_customize_subtitle =>
-      '재생, 모양, 레이아웃 및 지원 도구를 한 곳에서 조정하세요.';
+  String get settings_customize_subtitle => '재생, 모양, 레이아웃 및 지원 도구를 한 곳에서 조정하세요.';
 
   @override
   String get settings_core_section => '핵심 설정';
@@ -1074,22 +1076,19 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_appearance_primary_color => '기본 색상';
 
   @override
-  String get settings_appearance_primary_color_subtitle =>
-      'Material 3 팔레트의 시드 색상 선택';
+  String get settings_appearance_primary_color_subtitle => 'Material 3 팔레트의 시드 색상 선택';
 
   @override
   String get settings_appearance_advanced_theming => '고급 테마 설정';
 
   @override
-  String get settings_appearance_advanced_theming_subtitle =>
-      '특정 화면 유형에 대한 최적화';
+  String get settings_appearance_advanced_theming_subtitle => '특정 화면 유형에 대한 최적화';
 
   @override
   String get settings_appearance_true_black => '트루 블랙 (AMOLED)';
 
   @override
-  String get settings_appearance_true_black_subtitle =>
-      '어두운 모드에서 순수 검정색 배경을 사용하여 OLED 화면의 배터리 절약';
+  String get settings_appearance_true_black_subtitle => '어두운 모드에서 순수 검정색 배경을 사용하여 OLED 화면의 배터리 절약';
 
   @override
   String get settings_appearance_custom_hex => '사용자 정의 헥스 색상';
@@ -1125,38 +1124,31 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_interface_show_random => '랜덤 탐색 버튼 표시';
 
   @override
-  String get settings_interface_show_random_subtitle =>
-      '목록 및 상세 페이지에서 부동 카지노 버튼 활성화 또는 비활성화';
+  String get settings_interface_show_random_subtitle => '목록 및 상세 페이지에서 부동 카지노 버튼 활성화 또는 비활성화';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation =>
-      '중력 제어 화면 방향(메인 페이지)';
+  String get settings_interface_main_pages_gravity_orientation => '중력 제어 화면 방향(메인 페이지)';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation_subtitle =>
-      '기기 센서를 사용해 메인 페이지가 회전하도록 허용합니다. 전체 화면 동영상 재생은 별도의 화면 방향 설정을 따릅니다.';
+  String get settings_interface_main_pages_gravity_orientation_subtitle => '기기 센서를 사용해 메인 페이지가 회전하도록 허용합니다. 전체 화면 동영상 재생은 별도의 화면 방향 설정을 따릅니다.';
 
   @override
   String get settings_interface_show_edit => '편집 버튼 표시';
 
   @override
-  String get settings_interface_show_edit_subtitle =>
-      '장면 상세 페이지에서 편집 버튼 활성화 또는 비활성화';
+  String get settings_interface_show_edit_subtitle => '장면 상세 페이지에서 편집 버튼 활성화 또는 비활성화';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer =>
-      '미니플레이어에서 실제 장면 비디오 사용';
+  String get settings_interface_use_actual_scene_video_miniplayer => '미니플레이어에서 실제 장면 비디오 사용';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer_subtitle =>
-      '재생 중일 때 장면 스크린샷 대신 실시간 비디오 화면을 표시합니다.';
+  String get settings_interface_use_actual_scene_video_miniplayer_subtitle => '재생 중일 때 장면 스크린샷 대신 실시간 비디오 화면을 표시합니다.';
 
   @override
   String get settings_interface_entity_image_filtering => '엔티티 이미지 필터링';
 
   @override
-  String get settings_interface_entity_image_filtering_subtitle =>
-      '엔티티 이미지 페이지가 이미지 메타데이터와 일치하는지 관련 갤러리와 일치하는지 선택하세요.';
+  String get settings_interface_entity_image_filtering_subtitle => '엔티티 이미지 페이지가 이미지 메타데이터와 일치하는지 관련 갤러리와 일치하는지 선택하세요.';
 
   @override
   String get settings_interface_entity_image_filtering_direct => '직접 엔티티';
@@ -1168,8 +1160,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_interface_customize_tabs => '탭 사용자 정의';
 
   @override
-  String get settings_interface_customize_tabs_subtitle =>
-      '탐색 메뉴 항목 순서 변경 또는 숨기기';
+  String get settings_interface_customize_tabs_subtitle => '탐색 메뉴 항목 순서 변경 또는 숨기기';
 
   @override
   String get settings_interface_scenes_layout => '장면 레이아웃';
@@ -1187,15 +1178,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_interface_max_performer_avatars => '출연자 아바타 최대 수';
 
   @override
-  String get settings_interface_max_performer_avatars_subtitle =>
-      '장면 카드에 표시할 출연자 아바타의 최대 수입니다.';
+  String get settings_interface_max_performer_avatars_subtitle => '장면 카드에 표시할 출연자 아바타의 최대 수입니다.';
 
   @override
   String get settings_interface_show_performer_avatars => '출연자 아바타 표시';
 
   @override
-  String get settings_interface_show_performer_avatars_subtitle =>
-      '모든 플랫폼의 장면 카드에 출연자 아이콘을 표시합니다.';
+  String get settings_interface_show_performer_avatars_subtitle => '모든 플랫폼의 장면 카드에 출연자 아이콘을 표시합니다.';
 
   @override
   String get settings_interface_performer_avatar_size => '출연자 아바타 크기';
@@ -1228,8 +1217,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_interface_swipe_direction => '전체 화면 스와이프 방향';
 
   @override
-  String get settings_interface_swipe_direction_desc =>
-      '전체 화면 모드에서 이미지가 넘어가는 방식 선택';
+  String get settings_interface_swipe_direction_desc => '전체 화면 모드에서 이미지가 넘어가는 방식 선택';
 
   @override
   String get settings_interface_swipe_vertical => '세로';
@@ -1244,15 +1232,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_interface_performer_layouts => '출연자 레이아웃';
 
   @override
-  String get settings_interface_performer_layouts_subtitle =>
-      '출연자의 미디어 및 갤러리 기본값';
+  String get settings_interface_performer_layouts_subtitle => '출연자의 미디어 및 갤러리 기본값';
 
   @override
   String get settings_interface_studio_layouts => '스튜디오 레이아웃';
 
   @override
-  String get settings_interface_studio_layouts_subtitle =>
-      '스튜디오의 미디어 및 갤러리 기본값';
+  String get settings_interface_studio_layouts_subtitle => '스튜디오의 미디어 및 갤러리 기본값';
 
   @override
   String get settings_interface_tag_layouts => '태그 레이아웃';
@@ -1270,8 +1256,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_interface_galleries_layout_item => '갤러리 레이아웃';
 
   @override
-  String get settings_interface_galleries_layout_subtitle_item =>
-      '갤러리 페이지용 레이아웃';
+  String get settings_interface_galleries_layout_subtitle_item => '갤러리 페이지용 레이아웃';
 
   @override
   String get settings_server_title => '서버 설정';
@@ -1292,8 +1277,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_server_url => 'Stash 주소';
 
   @override
-  String get settings_server_url_helper =>
-      'Stash 서버의 URL을 입력하세요. 사용자 정의 경로가 구성된 경우 여기에 포함하세요.';
+  String get settings_server_url_helper => 'Stash 서버의 URL을 입력하세요. 사용자 정의 경로가 구성된 경우 여기에 포함하세요.';
 
   @override
   String get settings_server_url_example => 'http://192.168.1.100:9999';
@@ -1311,8 +1295,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_server_auth_password => '사용자 이름 + 비밀번호';
 
   @override
-  String get settings_server_auth_password_desc =>
-      '권장: Stash 사용자 이름/비밀번호 세션을 사용하세요.';
+  String get settings_server_auth_password_desc => '권장: Stash 사용자 이름/비밀번호 세션을 사용하세요.';
 
   @override
   String get settings_server_auth_apikey_desc => '정적 토큰 인증을 위해 API 키를 사용하세요.';
@@ -1352,8 +1335,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_server_invalid_url => '잘못된 서버 URL';
 
   @override
-  String get settings_server_resolve_error =>
-      '서버 URL을 확인할 수 없습니다. 호스트, 포트 및 자격 증명을 확인하세요.';
+  String get settings_server_resolve_error => '서버 URL을 확인할 수 없습니다. 호스트, 포트 및 자격 증명을 확인하세요.';
 
   @override
   String get settings_server_logout_confirm => '로그아웃되었으며 쿠키가 삭제되었습니다.';
@@ -1371,8 +1353,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_server_profile_delete => '프로필 삭제';
 
   @override
-  String get settings_server_profile_delete_confirm =>
-      '이 프로필을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.';
+  String get settings_server_profile_delete_confirm => '이 프로필을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.';
 
   @override
   String get settings_server_profile_active => '활성';
@@ -1408,29 +1389,25 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_playback_prefer_streams => 'sceneStreams 우선';
 
   @override
-  String get settings_playback_prefer_streams_subtitle =>
-      '꺼져 있으면 재생 시 paths.stream을 직접 사용합니다';
+  String get settings_playback_prefer_streams_subtitle => '꺼져 있으면 재생 시 paths.stream을 직접 사용합니다';
 
   @override
   String get settings_playback_feed_random => '피드를 임의의 위치에서 시작';
 
   @override
-  String get settings_playback_feed_random_subtitle =>
-      '피드 모드에서 장면을 재생할 때 비디오 길이의 0%에서 90% 사이의 임의의 위치에서 시작합니다';
+  String get settings_playback_feed_random_subtitle => '피드 모드에서 장면을 재생할 때 비디오 길이의 0%에서 90% 사이의 임의의 위치에서 시작합니다';
 
   @override
   String get settings_playback_resume_position => '마지막 재생 위치에서 다시 시작';
 
   @override
-  String get settings_playback_resume_position_subtitle =>
-      '비디오를 열 때 중단한 부분부터 자동으로 다시 시작';
+  String get settings_playback_resume_position_subtitle => '비디오를 열 때 중단한 부분부터 자동으로 다시 시작';
 
   @override
   String get settings_playback_end_behavior => '재생 종료 동작';
 
   @override
-  String get settings_playback_end_behavior_subtitle =>
-      '현재 재생이 끝나면 어떻게 해야 할까요?';
+  String get settings_playback_end_behavior_subtitle => '현재 재생이 끝나면 어떻게 해야 할까요?';
 
   @override
   String get settings_playback_end_behavior_stop => '멈추다';
@@ -1445,22 +1422,19 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_playback_autoplay => '다음 장면 자동 재생';
 
   @override
-  String get settings_playback_autoplay_subtitle =>
-      '현재 재생이 끝나면 자동으로 다음 장면을 재생합니다';
+  String get settings_playback_autoplay_subtitle => '현재 재생이 끝나면 자동으로 다음 장면을 재생합니다';
 
   @override
   String get settings_playback_background => '백그라운드 재생';
 
   @override
-  String get settings_playback_background_subtitle =>
-      '앱이 백그라운드로 전환되어도 동영상 오디오를 계속 재생합니다';
+  String get settings_playback_background_subtitle => '앱이 백그라운드로 전환되어도 동영상 오디오를 계속 재생합니다';
 
   @override
   String get settings_playback_pip => '네이티브 화면 속 화면 (PiP)';
 
   @override
-  String get settings_playback_pip_subtitle =>
-      'Android PiP 버튼을 활성화하고 백그라운드 전환 시 자동 진입합니다';
+  String get settings_playback_pip_subtitle => 'Android PiP 버튼을 활성화하고 백그라운드 전환 시 자동 진입합니다';
 
   @override
   String get settings_playback_subtitles => '자막 설정';
@@ -1516,12 +1490,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_playback_direct_play => '장면 이동 시 즉시 재생';
 
   @override
-  String get settings_playback_direct_play_subtitle =>
-      '다른 재생 중인 장면에서 이동할 때 새 장면을 즉시 재생합니다';
+  String get settings_playback_direct_play_subtitle => '다른 재생 중인 장면에서 이동할 때 새 장면을 즉시 재생합니다';
 
   @override
-  String get settings_playback_gravity_orientation_subtitle =>
-      '기기 센서를 사용하여 일치하는 방향으로 회전하도록 허용합니다(예: 좌/우 가로 방향 전환).';
+  String get settings_playback_gravity_orientation_subtitle => '기기 센서를 사용하여 일치하는 방향으로 회전하도록 허용합니다(예: 좌/우 가로 방향 전환).';
 
   @override
   String get settings_playback_subtitle_lang_none_disabled => '없음(비활성화)';
@@ -1569,15 +1541,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_support_diagnostics => '진단 및 프로젝트 정보';
 
   @override
-  String get settings_support_diagnostics_subtitle =>
-      '도움이 필요할 때 런타임 로그를 열거나 저장소로 이동하세요.';
+  String get settings_support_diagnostics_subtitle => '도움이 필요할 때 런타임 로그를 열거나 저장소로 이동하세요.';
 
   @override
   String get settings_support_update_available => '업데이트 가능';
 
   @override
-  String get settings_support_update_available_subtitle =>
-      'GitHub에서 새 버전을 사용할 수 있습니다';
+  String get settings_support_update_available_subtitle => 'GitHub에서 새 버전을 사용할 수 있습니다';
 
   @override
   String settings_support_update_to(String version) {
@@ -1615,8 +1585,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_support_issues => '문제 신고';
 
   @override
-  String get settings_support_issues_subtitle =>
-      '버그를 보고하여 StashFlow 개선에 도움을 주세요.';
+  String get settings_support_issues_subtitle => '버그를 보고하여 StashFlow 개선에 도움을 주세요.';
 
   @override
   String get settings_develop_title => '개발';
@@ -1625,8 +1594,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_develop_enable_logging => '디버그 로깅 활성화';
 
   @override
-  String get settings_develop_enable_logging_subtitle =>
-      '문제 해결을 위해 앱 로그를 기록합니다';
+  String get settings_develop_enable_logging_subtitle => '문제 해결을 위해 앱 로그를 기록합니다';
 
   @override
   String get settings_develop_diagnostics => '진단 도구';
@@ -1638,8 +1606,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_develop_video_debug => '비디오 디버그 정보 표시';
 
   @override
-  String get settings_develop_video_debug_subtitle =>
-      '비디오 플레이어 위에 기술적인 재생 세부 정보를 오버레이로 표시합니다.';
+  String get settings_develop_video_debug_subtitle => '비디오 플레이어 위에 기술적인 재생 세부 정보를 오버레이로 표시합니다.';
 
   @override
   String get settings_develop_log_viewer => '디버그 로그 뷰어';
@@ -1663,15 +1630,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_develop_web_auth => '웹에서 비밀번호 로그인 허용';
 
   @override
-  String get settings_develop_web_auth_subtitle =>
-      '네이티브 전용 제한을 무시하고 Flutter 웹에서 사용자 이름 + 비밀번호 인증 방식을 강제로 표시합니다.';
+  String get settings_develop_web_auth_subtitle => '네이티브 전용 제한을 무시하고 Flutter 웹에서 사용자 이름 + 비밀번호 인증 방식을 강제로 표시합니다.';
 
   @override
   String get settings_develop_proxy_auth => '프록시 인증 모드 활성화';
 
   @override
-  String get settings_develop_proxy_auth_subtitle =>
-      'Authentik과 같은 프록시 뒤의 인증 없는 백엔드에서 사용하기 위해 고급 Basic Auth 및 Bearer Token 방식을 활성화합니다.';
+  String get settings_develop_proxy_auth_subtitle => 'Authentik과 같은 프록시 뒤의 인증 없는 백엔드에서 사용하기 위해 고급 Basic Auth 및 Bearer Token 방식을 활성화합니다.';
 
   @override
   String get settings_server_auth_basic => '기본 인증';
@@ -1680,12 +1645,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_server_auth_bearer => '전달자 토큰';
 
   @override
-  String get settings_server_auth_basic_desc =>
-      '\'Authorization: Basic <base64(user:pass)>\' 헤더를 전송합니다.';
+  String get settings_server_auth_basic_desc => '\'Authorization: Basic <base64(user:pass)>\' 헤더를 전송합니다.';
 
   @override
-  String get settings_server_auth_bearer_desc =>
-      '\'Authorization: Bearer <token>\' 헤더를 전송합니다.';
+  String get settings_server_auth_bearer_desc => '\'Authorization: Bearer <token>\' 헤더를 전송합니다.';
 
   @override
   String get common_edit => '편집';
@@ -1736,8 +1699,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get common_gallery => '갤러리';
 
   @override
-  String get images_gallery_rating_unavailable =>
-      '갤러리 평점은 갤러리를 탐색할 때만 사용할 수 있습니다.';
+  String get images_gallery_rating_unavailable => '갤러리 평점은 갤러리를 탐색할 때만 사용할 수 있습니다.';
 
   @override
   String images_rating(String rating) {
@@ -1849,8 +1811,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get scenes_unmatched_scraped_performers => '일치하지 않는 스크랩된 출연자';
 
   @override
-  String get scenes_no_matching_performer_found =>
-      '라이브러리에서 일치하는 출연자를 찾을 수 없습니다';
+  String get scenes_no_matching_performer_found => '라이브러리에서 일치하는 출연자를 찾을 수 없습니다';
 
   @override
   String get common_unknown => '알 수 없음';
@@ -2363,12 +2324,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get failed_to_load_tap_to_retry => '불러오기 실패. 탭하여 다시 시도하세요.';
 
   @override
-  String get would_you_like_to_visit_the_release_page_to_download_it =>
-      '릴리스 페이지를 방문하여 다운로드하시겠습니까?';
+  String get would_you_like_to_visit_the_release_page_to_download_it => '릴리스 페이지를 방문하여 다운로드하시겠습니까?';
 
   @override
-  String get to_get_started_configure_stash_server =>
-      '시작하려면 Stash 서버 연결 세부 정보를 구성해야 합니다.';
+  String get to_get_started_configure_stash_server => '시작하려면 Stash 서버 연결 세부 정보를 구성해야 합니다.';
 
   @override
   String get loading => '로딩 중';
@@ -2471,8 +2430,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get main_startup_failed => 'StashFlow를 시작하지 못했습니다.';
 
   @override
-  String get main_startup_failed_desc =>
-      '앱 초기화가 완료되기 전에 시작 서비스가 실패했습니다.진단을 확인한 후 앱을 다시 시작하세요.';
+  String get main_startup_failed_desc => '앱 초기화가 완료되기 전에 시작 서비스가 실패했습니다.진단을 확인한 후 앱을 다시 시작하세요.';
 
   @override
   String common_searching_for(String query) {
@@ -2513,22 +2471,19 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settings_security_enable_app_lock => '앱 잠금 활성화';
 
   @override
-  String get settings_security_enable_app_lock_subtitle =>
-      '앱 재개/실행 시 비밀번호가 필요합니다.';
+  String get settings_security_enable_app_lock_subtitle => '앱 재개/실행 시 비밀번호가 필요합니다.';
 
   @override
   String get settings_security_lock_on_launch => '앱 실행 시 잠금';
 
   @override
-  String get settings_security_lock_on_launch_subtitle =>
-      '앱이 열리면 즉시 비밀번호를 요청하세요.';
+  String get settings_security_lock_on_launch_subtitle => '앱이 열리면 즉시 비밀번호를 요청하세요.';
 
   @override
   String get settings_security_background_lock_timer => '백그라운드 잠금 타이머';
 
   @override
-  String get settings_security_background_lock_timer_subtitle =>
-      '앱이 잠기기 전에 백그라운드에 머무를 수 있는 시간입니다.';
+  String get settings_security_background_lock_timer_subtitle => '앱이 잠기기 전에 백그라운드에 머무를 수 있는 시간입니다.';
 
   @override
   String get settings_security_set_passcode => '비밀번호 설정';
@@ -2812,8 +2767,7 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get delete_scenes_help =>
-      'Stash 메타데이터만 제거할지, 장면 파일과 생성된 보조 파일까지 함께 삭제할지 선택하세요.';
+  String get delete_scenes_help => 'Stash 메타데이터만 제거할지, 장면 파일과 생성된 보조 파일까지 함께 삭제할지 선택하세요.';
 
   @override
   String deleted_n_scenes(int count) {
@@ -2870,6 +2824,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String nTags(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2887,6 +2842,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String nGroups(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2904,6 +2860,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String nMarkers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2921,6 +2878,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String nGalleries(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -45,6 +45,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String nScenes(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -63,6 +64,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String nPerformers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -81,6 +83,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String nPlays(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -152,8 +155,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get common_hide => 'скрыть';
 
   @override
-  String get galleries_filter_saved =>
-      'Настройки фильтра сохранены по умолчанию';
+  String get galleries_filter_saved => 'Настройки фильтра сохранены по умолчанию';
 
   @override
   String get common_setup_required => 'Требуется настройка';
@@ -279,8 +281,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get sort_last_played_at => 'Последнее воспроизведение';
 
   @override
-  String get studios_sort_saved =>
-      'Настройки сортировки сохранены по умолчанию';
+  String get studios_sort_saved => 'Настройки сортировки сохранены по умолчанию';
 
   @override
   String get studios_no_random => 'Нет доступных студий для случайного выбора';
@@ -304,12 +305,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get scenes_no_random => 'Нет доступных сцен для случайного выбора';
 
   @override
-  String get performers_no_random =>
-      'Нет доступных исполнителей для случайного выбора';
+  String get performers_no_random => 'Нет доступных исполнителей для случайного выбора';
 
   @override
-  String get galleries_no_random =>
-      'Нет доступных галерей для случайного выбора';
+  String get galleries_no_random => 'Нет доступных галерей для случайного выбора';
 
   @override
   String common_error(String message) {
@@ -675,8 +674,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get scenes_sort_code => 'Код';
 
   @override
-  String get scenes_sort_saved_default =>
-      'Настройки сортировки сохранены по умолчанию';
+  String get scenes_sort_saved_default => 'Настройки сортировки сохранены по умолчанию';
 
   @override
   String get scenes_sort_tooltip => 'Параметры сортировки';
@@ -871,8 +869,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get filter_matches_regex => 'Соответствует регулярному выражению';
 
   @override
-  String get filter_not_matches_regex =>
-      'Не соответствует регулярному выражению';
+  String get filter_not_matches_regex => 'Не соответствует регулярному выражению';
 
   @override
   String get filter_between => 'Между';
@@ -948,15 +945,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_customize => 'Настройка StashFlow';
 
   @override
-  String get settings_customize_subtitle =>
-      'Настройте воспроизведение, внешний вид, макет и инструменты поддержки в одном месте.';
+  String get settings_customize_subtitle => 'Настройте воспроизведение, внешний вид, макет и инструменты поддержки в одном месте.';
 
   @override
   String get settings_core_section => 'Основные настройки';
 
   @override
-  String get settings_core_subtitle =>
-      'Самые используемые страницы конфигурации';
+  String get settings_core_subtitle => 'Самые используемые страницы конфигурации';
 
   @override
   String get settings_server => 'Сервер';
@@ -1025,8 +1020,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_keyboard_go_back => 'Назад';
 
   @override
-  String get settings_keyboard_play_pause_desc =>
-      'Переключение между воспроизведением и паузой';
+  String get settings_keyboard_play_pause_desc => 'Переключение между воспроизведением и паузой';
 
   @override
   String get settings_keyboard_seek_forward_5_desc => 'Вперед на 5 секунд';
@@ -1050,8 +1044,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_interface => 'Интерфейс';
 
   @override
-  String get settings_interface_subtitle =>
-      'Навигация и настройки макета по умолчанию';
+  String get settings_interface_subtitle => 'Навигация и настройки макета по умолчанию';
 
   @override
   String get settings_support => 'Поддержка';
@@ -1063,8 +1056,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_develop => 'Разработка';
 
   @override
-  String get settings_develop_subtitle =>
-      'Расширенные инструменты и переопределения';
+  String get settings_develop_subtitle => 'Расширенные инструменты и переопределения';
 
   @override
   String get settings_appearance_title => 'Настройки внешнего вида';
@@ -1073,8 +1065,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_appearance_theme_mode => 'Режим темы';
 
   @override
-  String get settings_appearance_theme_mode_subtitle =>
-      'Выберите, как приложение следует за изменениями яркости';
+  String get settings_appearance_theme_mode_subtitle => 'Выберите, как приложение следует за изменениями яркости';
 
   @override
   String get settings_appearance_theme_system => 'Системная';
@@ -1089,37 +1080,31 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_appearance_primary_color => 'Основной цвет';
 
   @override
-  String get settings_appearance_primary_color_subtitle =>
-      'Выберите базовый цвет для палитры Material 3';
+  String get settings_appearance_primary_color_subtitle => 'Выберите базовый цвет для палитры Material 3';
 
   @override
   String get settings_appearance_advanced_theming => 'Расширенная темизация';
 
   @override
-  String get settings_appearance_advanced_theming_subtitle =>
-      'Оптимизация для конкретных типов экранов';
+  String get settings_appearance_advanced_theming_subtitle => 'Оптимизация для конкретных типов экранов';
 
   @override
   String get settings_appearance_true_black => 'Истинный черный (AMOLED)';
 
   @override
-  String get settings_appearance_true_black_subtitle =>
-      'Использовать чисто черный фон в темном режиме для экономии заряда батареи на OLED-экранах';
+  String get settings_appearance_true_black_subtitle => 'Использовать чисто черный фон в темном режиме для экономии заряда батареи на OLED-экранах';
 
   @override
   String get settings_appearance_custom_hex => 'Пользовательский Hex-цвет';
 
   @override
-  String get settings_appearance_custom_hex_helper =>
-      'Введите 8-значный ARGB hex-код';
+  String get settings_appearance_custom_hex_helper => 'Введите 8-значный ARGB hex-код';
 
   @override
-  String get settings_appearance_font_size =>
-      'Глобальный масштаб пользовательского интерфейса';
+  String get settings_appearance_font_size => 'Глобальный масштаб пользовательского интерфейса';
 
   @override
-  String get settings_appearance_font_size_subtitle =>
-      'Пропорционально масштабируйте типографику и интервалы.';
+  String get settings_appearance_font_size_subtitle => 'Пропорционально масштабируйте типографику и интервалы.';
 
   @override
   String get settings_interface_title => 'Настройки интерфейса';
@@ -1128,8 +1113,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_interface_language => 'Язык';
 
   @override
-  String get settings_interface_language_subtitle =>
-      'Переопределить язык системы по умолчанию';
+  String get settings_interface_language_subtitle => 'Переопределить язык системы по умолчанию';
 
   @override
   String get settings_interface_app_language => 'Язык приложения';
@@ -1138,103 +1122,82 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_interface_navigation => 'Навигация';
 
   @override
-  String get settings_interface_navigation_subtitle =>
-      'Видимость глобальных ярлыков навигации';
+  String get settings_interface_navigation_subtitle => 'Видимость глобальных ярлыков навигации';
 
   @override
-  String get settings_interface_show_random =>
-      'Показывать кнопки случайной навигации';
+  String get settings_interface_show_random => 'Показывать кнопки случайной навигации';
 
   @override
-  String get settings_interface_show_random_subtitle =>
-      'Включить или отключить плавающие кнопки казино на страницах списков и деталей';
+  String get settings_interface_show_random_subtitle => 'Включить или отключить плавающие кнопки казино на страницах списков и деталей';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation =>
-      'Ориентация, управляемая гравитацией (основные страницы)';
+  String get settings_interface_main_pages_gravity_orientation => 'Ориентация, управляемая гравитацией (основные страницы)';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation_subtitle =>
-      'Разрешить основным страницам поворачиваться с помощью датчика устройства. Полноэкранное воспроизведение видео использует собственные настройки ориентации.';
+  String get settings_interface_main_pages_gravity_orientation_subtitle => 'Разрешить основным страницам поворачиваться с помощью датчика устройства. Полноэкранное воспроизведение видео использует собственные настройки ориентации.';
 
   @override
   String get settings_interface_show_edit => 'Показывать кнопку редактирования';
 
   @override
-  String get settings_interface_show_edit_subtitle =>
-      'Включить или отключить кнопку редактирования на странице деталей сцены';
+  String get settings_interface_show_edit_subtitle => 'Включить или отключить кнопку редактирования на странице деталей сцены';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer =>
-      'Использовать настоящее видео сцены в мини-плеере';
+  String get settings_interface_use_actual_scene_video_miniplayer => 'Использовать настоящее видео сцены в мини-плеере';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer_subtitle =>
-      'Показывать живую видеоповерхность вместо скриншота сцены, когда воспроизведение активно.';
+  String get settings_interface_use_actual_scene_video_miniplayer_subtitle => 'Показывать живую видеоповерхность вместо скриншота сцены, когда воспроизведение активно.';
 
   @override
-  String get settings_interface_entity_image_filtering =>
-      'Фильтрация изображений сущностей';
+  String get settings_interface_entity_image_filtering => 'Фильтрация изображений сущностей';
 
   @override
-  String get settings_interface_entity_image_filtering_subtitle =>
-      'Выберите, должны ли страницы изображений сущностей соответствовать метаданным изображений или связанным галереям.';
+  String get settings_interface_entity_image_filtering_subtitle => 'Выберите, должны ли страницы изображений сущностей соответствовать метаданным изображений или связанным галереям.';
 
   @override
-  String get settings_interface_entity_image_filtering_direct =>
-      'Прямая сущность';
+  String get settings_interface_entity_image_filtering_direct => 'Прямая сущность';
 
   @override
-  String get settings_interface_entity_image_filtering_galleries =>
-      'Связанные галереи';
+  String get settings_interface_entity_image_filtering_galleries => 'Связанные галереи';
 
   @override
   String get settings_interface_customize_tabs => 'Настройка вкладок';
 
   @override
-  String get settings_interface_customize_tabs_subtitle =>
-      'Изменить порядок или скрыть элементы меню навигации';
+  String get settings_interface_customize_tabs_subtitle => 'Изменить порядок или скрыть элементы меню навигации';
 
   @override
   String get settings_interface_scenes_layout => 'Макет сцен';
 
   @override
-  String get settings_interface_scenes_layout_subtitle =>
-      'Режим просмотра по умолчанию для сцен';
+  String get settings_interface_scenes_layout_subtitle => 'Режим просмотра по умолчанию для сцен';
 
   @override
   String get settings_interface_galleries_layout => 'Макет галерей';
 
   @override
-  String get settings_interface_galleries_layout_subtitle =>
-      'Режим просмотра по умолчанию для галерей';
+  String get settings_interface_galleries_layout_subtitle => 'Режим просмотра по умолчанию для галерей';
 
   @override
-  String get settings_interface_max_performer_avatars =>
-      'Максимальное количество аватаров исполнителей';
+  String get settings_interface_max_performer_avatars => 'Максимальное количество аватаров исполнителей';
 
   @override
-  String get settings_interface_max_performer_avatars_subtitle =>
-      'Максимальное количество аватаров исполнителей, отображаемых в карточке сцены.';
+  String get settings_interface_max_performer_avatars_subtitle => 'Максимальное количество аватаров исполнителей, отображаемых в карточке сцены.';
 
   @override
-  String get settings_interface_show_performer_avatars =>
-      'Показывать аватары исполнителей';
+  String get settings_interface_show_performer_avatars => 'Показывать аватары исполнителей';
 
   @override
-  String get settings_interface_show_performer_avatars_subtitle =>
-      'Отображать иконки исполнителей на карточках сцен на всех платформах.';
+  String get settings_interface_show_performer_avatars_subtitle => 'Отображать иконки исполнителей на карточках сцен на всех платформах.';
 
   @override
-  String get settings_interface_performer_avatar_size =>
-      'Размер аватара исполнителя';
+  String get settings_interface_performer_avatar_size => 'Размер аватара исполнителя';
 
   @override
   String get settings_interface_layout_default => 'Макет по умолчанию';
 
   @override
-  String get settings_interface_layout_default_desc =>
-      'Выберите макет по умолчанию для страницы';
+  String get settings_interface_layout_default_desc => 'Выберите макет по умолчанию для страницы';
 
   @override
   String get settings_interface_layout_list => 'Список';
@@ -1252,16 +1215,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_interface_image_viewer => 'Просмотр изображений';
 
   @override
-  String get settings_interface_image_viewer_subtitle =>
-      'Настроить поведение полноэкранного просмотра изображений';
+  String get settings_interface_image_viewer_subtitle => 'Настроить поведение полноэкранного просмотра изображений';
 
   @override
-  String get settings_interface_swipe_direction =>
-      'Направление свайпа в полноэкранном режиме';
+  String get settings_interface_swipe_direction => 'Направление свайпа в полноэкранном режиме';
 
   @override
-  String get settings_interface_swipe_direction_desc =>
-      'Выберите способ перелистывания изображений в полноэкранном режиме';
+  String get settings_interface_swipe_direction_desc => 'Выберите способ перелистывания изображений в полноэкранном режиме';
 
   @override
   String get settings_interface_swipe_vertical => 'Вертикально';
@@ -1276,36 +1236,31 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_interface_performer_layouts => 'Макеты исполнителей';
 
   @override
-  String get settings_interface_performer_layouts_subtitle =>
-      'Настройки медиа и галерей для исполнителей по умолчанию';
+  String get settings_interface_performer_layouts_subtitle => 'Настройки медиа и галерей для исполнителей по умолчанию';
 
   @override
   String get settings_interface_studio_layouts => 'Макеты студий';
 
   @override
-  String get settings_interface_studio_layouts_subtitle =>
-      'Настройки медиа и галерей для студий по умолчанию';
+  String get settings_interface_studio_layouts_subtitle => 'Настройки медиа и галерей для студий по умолчанию';
 
   @override
   String get settings_interface_tag_layouts => 'Макеты тегов';
 
   @override
-  String get settings_interface_tag_layouts_subtitle =>
-      'Настройки медиа и галерей для тегов по умолчанию';
+  String get settings_interface_tag_layouts_subtitle => 'Настройки медиа и галерей для тегов по умолчанию';
 
   @override
   String get settings_interface_media_layout => 'Макет медиа';
 
   @override
-  String get settings_interface_media_layout_subtitle =>
-      'Макет для страницы Медиа';
+  String get settings_interface_media_layout_subtitle => 'Макет для страницы Медиа';
 
   @override
   String get settings_interface_galleries_layout_item => 'Макет галерей';
 
   @override
-  String get settings_interface_galleries_layout_subtitle_item =>
-      'Макет для страницы Галереи';
+  String get settings_interface_galleries_layout_subtitle_item => 'Макет для страницы Галереи';
 
   @override
   String get settings_server_title => 'Настройки сервера';
@@ -1314,22 +1269,19 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_server_status => 'Статус подключения';
 
   @override
-  String get settings_server_status_subtitle =>
-      'Текущее состояние подключения к настроенному серверу';
+  String get settings_server_status_subtitle => 'Текущее состояние подключения к настроенному серверу';
 
   @override
   String get settings_server_details => 'Детали сервера';
 
   @override
-  String get settings_server_details_subtitle =>
-      'Настройте адрес и метод аутентификации';
+  String get settings_server_details_subtitle => 'Настройте адрес и метод аутентификации';
 
   @override
   String get settings_server_url => 'URL-адрес Stash';
 
   @override
-  String get settings_server_url_helper =>
-      'Введите URL-адрес вашего сервера Stash. Если настроен пользовательский путь, укажите его здесь.';
+  String get settings_server_url_helper => 'Введите URL-адрес вашего сервера Stash. Если настроен пользовательский путь, укажите его здесь.';
 
   @override
   String get settings_server_url_example => 'http://192.168.1.100:9999';
@@ -1347,12 +1299,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_server_auth_password => 'Имя пользователя + Пароль';
 
   @override
-  String get settings_server_auth_password_desc =>
-      'Рекомендуется: используйте имя пользователя и пароль Stash.';
+  String get settings_server_auth_password_desc => 'Рекомендуется: используйте имя пользователя и пароль Stash.';
 
   @override
-  String get settings_server_auth_apikey_desc =>
-      'Используйте API-ключ для аутентификации по статическому токену.';
+  String get settings_server_auth_apikey_desc => 'Используйте API-ключ для аутентификации по статическому токену.';
 
   @override
   String get settings_server_username => 'Имя пользователя';
@@ -1389,12 +1339,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_server_invalid_url => 'Недопустимый URL сервера';
 
   @override
-  String get settings_server_resolve_error =>
-      'Не удалось разрешить URL сервера. Проверьте хост, порт и учетные данные.';
+  String get settings_server_resolve_error => 'Не удалось разрешить URL сервера. Проверьте хост, порт и учетные данные.';
 
   @override
-  String get settings_server_logout_confirm =>
-      'Выход выполнен, файлы cookie очищены.';
+  String get settings_server_logout_confirm => 'Выход выполнен, файлы cookie очищены.';
 
   @override
   String get settings_server_profile_add => 'Добавить профиль';
@@ -1409,8 +1357,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_server_profile_delete => 'Удалить профиль';
 
   @override
-  String get settings_server_profile_delete_confirm =>
-      'Вы уверены, что хотите удалить этот профиль? Это действие нельзя отменить.';
+  String get settings_server_profile_delete_confirm => 'Вы уверены, что хотите удалить этот профиль? Это действие нельзя отменить.';
 
   @override
   String get settings_server_profile_active => 'Активен';
@@ -1422,20 +1369,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_server_profiles => 'Профили сервера';
 
   @override
-  String get settings_server_profiles_subtitle =>
-      'Управление несколькими подключениями к серверу Stash';
+  String get settings_server_profiles_subtitle => 'Управление несколькими подключениями к серверу Stash';
 
   @override
-  String get settings_server_auth_status_logging_in =>
-      'Статус аутентификации: выполняется вход...';
+  String get settings_server_auth_status_logging_in => 'Статус аутентификации: выполняется вход...';
 
   @override
-  String get settings_server_auth_status_logged_in =>
-      'Статус аутентификации: вход выполнен';
+  String get settings_server_auth_status_logged_in => 'Статус аутентификации: вход выполнен';
 
   @override
-  String get settings_server_auth_status_logged_out =>
-      'Статус аутентификации: выход выполнен';
+  String get settings_server_auth_status_logged_out => 'Статус аутентификации: выход выполнен';
 
   @override
   String get settings_playback_title => 'Настройки воспроизведения';
@@ -1444,38 +1387,31 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_playback_behavior => 'Поведение воспроизведения';
 
   @override
-  String get settings_playback_behavior_subtitle =>
-      'Настройки воспроизведения и фонового режима по умолчанию';
+  String get settings_playback_behavior_subtitle => 'Настройки воспроизведения и фонового режима по умолчанию';
 
   @override
   String get settings_playback_prefer_streams => 'Предпочитать sceneStreams';
 
   @override
-  String get settings_playback_prefer_streams_subtitle =>
-      'Если отключено, воспроизведение использует paths.stream напрямую';
+  String get settings_playback_prefer_streams_subtitle => 'Если отключено, воспроизведение использует paths.stream напрямую';
 
   @override
-  String get settings_playback_feed_random =>
-      'Начать Ленту со случайного места';
+  String get settings_playback_feed_random => 'Начать Ленту со случайного места';
 
   @override
-  String get settings_playback_feed_random_subtitle =>
-      'При воспроизведении сцен в режиме Ленты начинать со случайного места между 0% и 90% длины видео';
+  String get settings_playback_feed_random_subtitle => 'При воспроизведении сцен в режиме Ленты начинать со случайного места между 0% и 90% длины видео';
 
   @override
-  String get settings_playback_resume_position =>
-      'Возобновить с последней игровой позиции';
+  String get settings_playback_resume_position => 'Возобновить с последней игровой позиции';
 
   @override
-  String get settings_playback_resume_position_subtitle =>
-      'При открытии видео автоматически возобновляется с того места, на котором вы остановились.';
+  String get settings_playback_resume_position_subtitle => 'При открытии видео автоматически возобновляется с того места, на котором вы остановились.';
 
   @override
   String get settings_playback_end_behavior => 'Поведение в конце игры';
 
   @override
-  String get settings_playback_end_behavior_subtitle =>
-      'Что делать, когда текущее воспроизведение заканчивается';
+  String get settings_playback_end_behavior_subtitle => 'Что делать, когда текущее воспроизведение заканчивается';
 
   @override
   String get settings_playback_end_behavior_stop => 'Останавливаться';
@@ -1484,51 +1420,43 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_playback_end_behavior_loop => 'Зациклить текущую сцену';
 
   @override
-  String get settings_playback_end_behavior_next =>
-      'Воспроизвести следующую сцену';
+  String get settings_playback_end_behavior_next => 'Воспроизвести следующую сцену';
 
   @override
-  String get settings_playback_autoplay =>
-      'Автовоспроизведение следующей сцены';
+  String get settings_playback_autoplay => 'Автовоспроизведение следующей сцены';
 
   @override
-  String get settings_playback_autoplay_subtitle =>
-      'Автоматически воспроизводить следующую сцену по завершении текущей';
+  String get settings_playback_autoplay_subtitle => 'Автоматически воспроизводить следующую сцену по завершении текущей';
 
   @override
   String get settings_playback_background => 'Фоновое воспроизведение';
 
   @override
-  String get settings_playback_background_subtitle =>
-      'Продолжать воспроизведение звука видео при сворачивании приложения';
+  String get settings_playback_background_subtitle => 'Продолжать воспроизведение звука видео при сворачивании приложения';
 
   @override
   String get settings_playback_pip => 'Нативная «Картинка в картинке»';
 
   @override
-  String get settings_playback_pip_subtitle =>
-      'Включить кнопку PiP на Android и автоматический переход при сворачивании';
+  String get settings_playback_pip_subtitle => 'Включить кнопку PiP на Android и автоматический переход при сворачивании';
 
   @override
   String get settings_playback_subtitles => 'Настройки субтитров';
 
   @override
-  String get settings_playback_subtitles_subtitle =>
-      'Автоматическая загрузка и внешний вид';
+  String get settings_playback_subtitles_subtitle => 'Автоматическая загрузка и внешний вид';
 
   @override
   String get settings_playback_subtitle_lang => 'Язык субтитров по умолчанию';
 
   @override
-  String get settings_playback_subtitle_lang_subtitle =>
-      'Автозагрузка при наличии';
+  String get settings_playback_subtitle_lang_subtitle => 'Автозагрузка при наличии';
 
   @override
   String get settings_playback_subtitle_size => 'Размер шрифта субтитров';
 
   @override
-  String get settings_playback_subtitle_pos =>
-      'Вертикальное положение субтитров';
+  String get settings_playback_subtitle_pos => 'Вертикальное положение субтитров';
 
   @override
   String settings_playback_subtitle_pos_desc(String percent) {
@@ -1536,27 +1464,22 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get settings_playback_subtitle_align =>
-      'Выравнивание текста субтитров';
+  String get settings_playback_subtitle_align => 'Выравнивание текста субтитров';
 
   @override
-  String get settings_playback_subtitle_align_subtitle =>
-      'Выравнивание для многострочных субтитров';
+  String get settings_playback_subtitle_align_subtitle => 'Выравнивание для многострочных субтитров';
 
   @override
   String get settings_playback_seek => 'Взаимодействие при перемотке';
 
   @override
-  String get settings_playback_seek_subtitle =>
-      'Выберите способ перемотки во время воспроизведения';
+  String get settings_playback_seek_subtitle => 'Выберите способ перемотки во время воспроизведения';
 
   @override
-  String get settings_playback_seek_double_tap =>
-      'Двойное нажатие влево/вправо для перемотки на 10с';
+  String get settings_playback_seek_double_tap => 'Двойное нажатие влево/вправо для перемотки на 10с';
 
   @override
-  String get settings_playback_seek_drag =>
-      'Перетаскивание временной шкалы для перемотки';
+  String get settings_playback_seek_drag => 'Перетаскивание временной шкалы для перемотки';
 
   @override
   String get settings_playback_seek_drag_label => 'Перетаскивание';
@@ -1565,27 +1488,22 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_playback_seek_double_tap_label => 'Двойное нажатие';
 
   @override
-  String get settings_playback_gravity_orientation =>
-      'Ориентация, управляемая гравитацией';
+  String get settings_playback_gravity_orientation => 'Ориентация, управляемая гравитацией';
 
   @override
-  String get settings_playback_direct_play =>
-      'Прямое воспроизведение при навигации по сценам';
+  String get settings_playback_direct_play => 'Прямое воспроизведение при навигации по сценам';
 
   @override
-  String get settings_playback_direct_play_subtitle =>
-      'При переходе из другой воспроизводящейся сцены, сразу включать новую сцену';
+  String get settings_playback_direct_play_subtitle => 'При переходе из другой воспроизводящейся сцены, сразу включать новую сцену';
 
   @override
-  String get settings_playback_gravity_orientation_subtitle =>
-      'Разрешить поворот между совпадающими ориентациями с помощью датчика устройства (например, переворачивать альбомную ориентацию влево/вправо).';
+  String get settings_playback_gravity_orientation_subtitle => 'Разрешить поворот между совпадающими ориентациями с помощью датчика устройства (например, переворачивать альбомную ориентацию влево/вправо).';
 
   @override
   String get settings_playback_subtitle_lang_none_disabled => 'Нет (Отключено)';
 
   @override
-  String get settings_playback_subtitle_lang_auto_if_only_one =>
-      'Авто (если только один)';
+  String get settings_playback_subtitle_lang_auto_if_only_one => 'Авто (если только один)';
 
   @override
   String get settings_playback_subtitle_lang_english => 'Английский';
@@ -1624,19 +1542,16 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_support_title => 'Поддержка';
 
   @override
-  String get settings_support_diagnostics =>
-      'Диагностика и информация о проекте';
+  String get settings_support_diagnostics => 'Диагностика и информация о проекте';
 
   @override
-  String get settings_support_diagnostics_subtitle =>
-      'Открыть журналы работы или перейти в репозиторий за помощью.';
+  String get settings_support_diagnostics_subtitle => 'Открыть журналы работы или перейти в репозиторий за помощью.';
 
   @override
   String get settings_support_update_available => 'Доступно обновление';
 
   @override
-  String get settings_support_update_available_subtitle =>
-      'На GitHub доступна более новая версия';
+  String get settings_support_update_available_subtitle => 'На GitHub доступна более новая версия';
 
   @override
   String settings_support_update_to(String version) {
@@ -1644,106 +1559,88 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get settings_support_update_to_subtitle =>
-      'Вас ждут новые функции и улучшения.';
+  String get settings_support_update_to_subtitle => 'Вас ждут новые функции и улучшения.';
 
   @override
   String get settings_support_about => 'О программе';
 
   @override
-  String get settings_support_about_subtitle =>
-      'Информация о проекте и исходном коде';
+  String get settings_support_about_subtitle => 'Информация о проекте и исходном коде';
 
   @override
   String get settings_support_version => 'Версия';
 
   @override
-  String get settings_support_version_loading =>
-      'Загрузка информации о версии...';
+  String get settings_support_version_loading => 'Загрузка информации о версии...';
 
   @override
-  String get settings_support_version_unavailable =>
-      'Информация о версии недоступна';
+  String get settings_support_version_unavailable => 'Информация о версии недоступна';
 
   @override
   String get settings_support_github => 'Репозиторий GitHub';
 
   @override
-  String get settings_support_github_subtitle =>
-      'Просмотр исходного кода и сообщение об ошибках';
+  String get settings_support_github_subtitle => 'Просмотр исходного кода и сообщение об ошибках';
 
   @override
-  String get settings_support_github_error =>
-      'Не удалось открыть ссылку на GitHub';
+  String get settings_support_github_error => 'Не удалось открыть ссылку на GitHub';
 
   @override
   String get settings_support_issues => 'Сообщить о проблеме';
 
   @override
-  String get settings_support_issues_subtitle =>
-      'Помогите улучшить StashFlow, сообщая об ошибках.';
+  String get settings_support_issues_subtitle => 'Помогите улучшить StashFlow, сообщая об ошибках.';
 
   @override
   String get settings_develop_title => 'Разработка';
 
   @override
-  String get settings_develop_enable_logging =>
-      'Включить отладочное логирование';
+  String get settings_develop_enable_logging => 'Включить отладочное логирование';
 
   @override
-  String get settings_develop_enable_logging_subtitle =>
-      'Записывать логи приложения для устранения неполадок';
+  String get settings_develop_enable_logging_subtitle => 'Записывать логи приложения для устранения неполадок';
 
   @override
   String get settings_develop_diagnostics => 'Инструменты диагностики';
 
   @override
-  String get settings_develop_diagnostics_subtitle =>
-      'Устранение неполадок и производительность';
+  String get settings_develop_diagnostics_subtitle => 'Устранение неполадок и производительность';
 
   @override
-  String get settings_develop_video_debug =>
-      'Показывать отладочную информацию видео';
+  String get settings_develop_video_debug => 'Показывать отладочную информацию видео';
 
   @override
-  String get settings_develop_video_debug_subtitle =>
-      'Отображать технические детали воспроизведения поверх видеоплеера.';
+  String get settings_develop_video_debug_subtitle => 'Отображать технические детали воспроизведения поверх видеоплеера.';
 
   @override
   String get settings_develop_log_viewer => 'Просмотр журнала отладки';
 
   @override
-  String get settings_develop_log_viewer_subtitle =>
-      'Открыть просмотр журналов приложения в реальном времени.';
+  String get settings_develop_log_viewer_subtitle => 'Открыть просмотр журналов приложения в реальном времени.';
 
   @override
   String get settings_develop_logs_copied => 'Логи скопированы в буфер обмена';
 
   @override
-  String get settings_develop_no_logs =>
-      'Журналы отсутствуют. Взаимодействуйте с приложением, чтобы собрать логи.';
+  String get settings_develop_no_logs => 'Журналы отсутствуют. Взаимодействуйте с приложением, чтобы собрать логи.';
 
   @override
   String get settings_develop_web_overrides => 'Переопределения для Web';
 
   @override
-  String get settings_develop_web_overrides_subtitle =>
-      'Расширенные флаги для веб-платформы';
+  String get settings_develop_web_overrides_subtitle => 'Расширенные флаги для веб-платформы';
 
   @override
   String get settings_develop_web_auth => 'Разрешить вход по паролю в Web';
 
   @override
-  String get settings_develop_web_auth_subtitle =>
-      'Переопределяет ограничение «только для нативных приложений» и делает видимым метод аутентификации по имени пользователя и паролю во Flutter Web.';
+  String get settings_develop_web_auth_subtitle => 'Переопределяет ограничение «только для нативных приложений» и делает видимым метод аутентификации по имени пользователя и паролю во Flutter Web.';
 
   @override
-  String get settings_develop_proxy_auth =>
-      'Включить режимы аутентификации через прокси';
+  String get settings_develop_proxy_auth => 'Включить режимы аутентификации через прокси';
 
   @override
-  String get settings_develop_proxy_auth_subtitle =>
-      'Включите расширенные методы Basic Auth и Bearer Token для использования с бэкендами без аутентификации за прокси-серверами, такими как Authentik.';
+  String get settings_develop_proxy_auth_subtitle => 'Включите расширенные методы Basic Auth и Bearer Token для использования с бэкендами без аутентификации за прокси-серверами, такими как Authentik.';
 
   @override
   String get settings_server_auth_basic => 'Базовая аутентификация';
@@ -1752,12 +1649,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_server_auth_bearer => 'Токен носителя';
 
   @override
-  String get settings_server_auth_basic_desc =>
-      'Отправляет заголовок \'Authorization: Basic <base64(user:pass)>\'.';
+  String get settings_server_auth_basic_desc => 'Отправляет заголовок \'Authorization: Basic <base64(user:pass)>\'.';
 
   @override
-  String get settings_server_auth_bearer_desc =>
-      'Отправляет заголовок \'Authorization: Bearer <token>\'.';
+  String get settings_server_auth_bearer_desc => 'Отправляет заголовок \'Authorization: Bearer <token>\'.';
 
   @override
   String get common_edit => 'Редактировать';
@@ -1778,8 +1673,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get common_square => 'Квадрат';
 
   @override
-  String get performers_filter_saved =>
-      'Параметры фильтра сохранены как по умолчанию';
+  String get performers_filter_saved => 'Параметры фильтра сохранены как по умолчанию';
 
   @override
   String get images_title => 'Изображения';
@@ -1794,8 +1688,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get images_sort_title => 'Сортировать изображения';
 
   @override
-  String get images_sort_saved =>
-      'Параметры сортировки сохранены как по умолчанию';
+  String get images_sort_saved => 'Параметры сортировки сохранены как по умолчанию';
 
   @override
   String get image_rating_updated => 'Рейтинг изображения обновлен.';
@@ -1810,8 +1703,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get common_gallery => 'Галерея';
 
   @override
-  String get images_gallery_rating_unavailable =>
-      'Рейтинг галереи доступен только при просмотре галереи.';
+  String get images_gallery_rating_unavailable => 'Рейтинг галереи доступен только при просмотре галереи.';
 
   @override
   String images_rating(String rating) {
@@ -1822,8 +1714,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get images_filtered_by_gallery => 'Отфильтровано по галерее';
 
   @override
-  String get images_slideshow_need_two =>
-      'Требуется как минимум 2 изображения для слайд-шоу.';
+  String get images_slideshow_need_two => 'Требуется как минимум 2 изображения для слайд-шоу.';
 
   @override
   String get images_slideshow_start_title => 'Запустить слайд-шоу';
@@ -1918,16 +1809,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get scenes_select_performers => 'Выбрать исполнителей';
 
   @override
-  String get scenes_unmatched_scraped_tags =>
-      'Несопоставленные полученные теги';
+  String get scenes_unmatched_scraped_tags => 'Несопоставленные полученные теги';
 
   @override
-  String get scenes_unmatched_scraped_performers =>
-      'Несопоставленные полученные исполнители';
+  String get scenes_unmatched_scraped_performers => 'Несопоставленные полученные исполнители';
 
   @override
-  String get scenes_no_matching_performer_found =>
-      'Не найден подходящий исполнитель в библиотеке';
+  String get scenes_no_matching_performer_found => 'Не найден подходящий исполнитель в библиотеке';
 
   @override
   String get common_unknown => 'Неизвестно';
@@ -2012,8 +1900,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get cast_airplay_pairing => 'Сопряжение AirPlay';
 
   @override
-  String get cast_enter_pin =>
-      'Введите 4-значный PIN-код, показанный на вашем телевизоре.';
+  String get cast_enter_pin => 'Введите 4-значный PIN-код, показанный на вашем телевизоре.';
 
   @override
   String get cast_pair => 'Пара';
@@ -2060,8 +1947,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_storage_clearing_video => 'Очистка видеокеша...';
 
   @override
-  String get settings_storage_clearing_database =>
-      'Очистка кэша базы данных...';
+  String get settings_storage_clearing_database => 'Очистка кэша базы данных...';
 
   @override
   String get settings_storage_cleared_image => 'Кэш изображений очищен.';
@@ -2107,12 +1993,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_storage_limits => 'Пределы';
 
   @override
-  String get settings_storage_limits_subtitle =>
-      'Установить максимальные размеры кэша';
+  String get settings_storage_limits_subtitle => 'Установить максимальные размеры кэша';
 
   @override
-  String get settings_storage_max_image_cache =>
-      'Максимальный кэш изображений (МБ)';
+  String get settings_storage_max_image_cache => 'Максимальный кэш изображений (МБ)';
 
   @override
   String get settings_storage_max_video_cache => 'Макс. видеокэш (МБ)';
@@ -2127,8 +2011,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_storage_usage_subtitle => 'Место, занятое кэшем';
 
   @override
-  String get settings_storage_subtitle =>
-      'Управление кэшем и лимитами хранилища';
+  String get settings_storage_subtitle => 'Управление кэшем и лимитами хранилища';
 
   @override
   String get performers_field_name => 'Имя';
@@ -2353,8 +2236,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get scenes_field_updated_at => 'Обновлено';
 
   @override
-  String get cast_stopped_resuming_locally =>
-      'Трансляция остановлена, возобновление локально';
+  String get cast_stopped_resuming_locally => 'Трансляция остановлена, возобновление локально';
 
   @override
   String get cast_stop_casting => 'Остановить трансляцию';
@@ -2378,8 +2260,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get common_star => 'Звезда';
 
   @override
-  String get settings_interface_card_title_font_size =>
-      'Размер шрифта заголовка карточки';
+  String get settings_interface_card_title_font_size => 'Размер шрифта заголовка карточки';
 
   @override
   String get common_hint_date => 'ГГГГ-ММ-ДД';
@@ -2444,16 +2325,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get sort_scenes => 'Сортировать сцены';
 
   @override
-  String get failed_to_load_tap_to_retry =>
-      'Не удалось загрузить. Нажмите, чтобы повторить.';
+  String get failed_to_load_tap_to_retry => 'Не удалось загрузить. Нажмите, чтобы повторить.';
 
   @override
-  String get would_you_like_to_visit_the_release_page_to_download_it =>
-      'Хотите посетить страницу релиза, чтобы скачать его?';
+  String get would_you_like_to_visit_the_release_page_to_download_it => 'Хотите посетить страницу релиза, чтобы скачать его?';
 
   @override
-  String get to_get_started_configure_stash_server =>
-      'Для начала вам необходимо настроить данные подключения к серверу Stash.';
+  String get to_get_started_configure_stash_server => 'Для начала вам необходимо настроить данные подключения к серверу Stash.';
 
   @override
   String get loading => 'Загрузка';
@@ -2556,8 +2434,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get main_startup_failed => 'StashFlow не удалось запустить';
 
   @override
-  String get main_startup_failed_desc =>
-      'Служба запуска завершилась сбоем до того, как приложение смогло завершить инициализацию.Перезапустите приложение после проверки диагностики.';
+  String get main_startup_failed_desc => 'Служба запуска завершилась сбоем до того, как приложение смогло завершить инициализацию.Перезапустите приложение после проверки диагностики.';
 
   @override
   String common_searching_for(String query) {
@@ -2595,28 +2472,22 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_security_passcode_removed => 'Код доступа удален.';
 
   @override
-  String get settings_security_enable_app_lock =>
-      'Включить блокировку приложения';
+  String get settings_security_enable_app_lock => 'Включить блокировку приложения';
 
   @override
-  String get settings_security_enable_app_lock_subtitle =>
-      'Требовать пароль при возобновлении/запуске приложения.';
+  String get settings_security_enable_app_lock_subtitle => 'Требовать пароль при возобновлении/запуске приложения.';
 
   @override
-  String get settings_security_lock_on_launch =>
-      'Блокировка запуска приложения';
+  String get settings_security_lock_on_launch => 'Блокировка запуска приложения';
 
   @override
-  String get settings_security_lock_on_launch_subtitle =>
-      'Запросите пароль сразу после открытия приложения.';
+  String get settings_security_lock_on_launch_subtitle => 'Запросите пароль сразу после открытия приложения.';
 
   @override
-  String get settings_security_background_lock_timer =>
-      'Таймер блокировки фона';
+  String get settings_security_background_lock_timer => 'Таймер блокировки фона';
 
   @override
-  String get settings_security_background_lock_timer_subtitle =>
-      'Как долго приложение может оставаться в фоновом режиме перед блокировкой.';
+  String get settings_security_background_lock_timer_subtitle => 'Как долго приложение может оставаться в фоновом режиме перед блокировкой.';
 
   @override
   String get settings_security_set_passcode => 'Установить пароль';
@@ -2628,8 +2499,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_security_confirm_passcode => 'Подтверждать';
 
   @override
-  String get settings_security_error_numeric =>
-      'Используйте только цифры длиной 4–8.';
+  String get settings_security_error_numeric => 'Используйте только цифры длиной 4–8.';
 
   @override
   String get settings_security_error_mismatch => 'Пароли не совпадают.';
@@ -2662,15 +2532,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settings_security_title => 'Безопасность';
 
   @override
-  String get settings_security_subtitle =>
-      'Настройки блокировки приложения и пароля';
+  String get settings_security_subtitle => 'Настройки блокировки приложения и пароля';
 
   @override
   String get settings_security_app_lock => 'Блокировка приложения';
 
   @override
-  String get settings_security_app_lock_subtitle =>
-      'Защитите доступ с помощью пароля после фонового режима.';
+  String get settings_security_app_lock_subtitle => 'Защитите доступ с помощью пароля после фонового режима.';
 
   @override
   String get common_saved_filters => 'Сохраненные фильтры';
@@ -2679,16 +2547,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get tools => 'Инструменты';
 
   @override
-  String get tools_section_subtitle =>
-      'Рабочие процессы обслуживания и метаданных для сцен.';
+  String get tools_section_subtitle => 'Рабочие процессы обслуживания и метаданных для сцен.';
 
   @override
-  String get tools_scene_deduplication_subtitle =>
-      'Поиск и управление дубликатами сцен.';
+  String get tools_scene_deduplication_subtitle => 'Поиск и управление дубликатами сцен.';
 
   @override
-  String get tools_scene_tagger_subtitle =>
-      'Скрапинг страниц текущих сцен с помощью Stash-box.';
+  String get tools_scene_tagger_subtitle => 'Скрапинг страниц текущих сцен с помощью Stash-box.';
 
   @override
   String get preset_deleted => 'Предустановка удалена.';
@@ -2790,15 +2655,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get duration_difference => 'Разница в продолжительности';
 
   @override
-  String get only_select_matching_codecs =>
-      'Выбирайте только соответствующие кодеки';
+  String get only_select_matching_codecs => 'Выбирайте только соответствующие кодеки';
 
   @override
   String get select_scenes => 'Выберите сцены';
 
   @override
-  String get all_but_largest_resolution =>
-      'Все, кроме самого большого разрешения';
+  String get all_but_largest_resolution => 'Все, кроме самого большого разрешения';
 
   @override
   String get all_but_largest_file => 'Все, кроме самого большого файла';
@@ -2840,8 +2703,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get enter_preset_name => 'Введите имя пресета';
 
   @override
-  String get delete_scene_confirm =>
-      'Вы уверены, что хотите удалить эту сцену?';
+  String get delete_scene_confirm => 'Вы уверены, что хотите удалить эту сцену?';
 
   @override
   String delete_selected_count(int selectedCount) {
@@ -2858,12 +2720,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get available_presets => 'Доступные пресеты';
 
   @override
-  String get existing_names_are_overwritten =>
-      'Существующие имена будут перезаписаны';
+  String get existing_names_are_overwritten => 'Существующие имена будут перезаписаны';
 
   @override
-  String get active_settings_saved_server =>
-      'Текущие активные настройки будут сохранены на сервере.';
+  String get active_settings_saved_server => 'Текущие активные настройки будут сохранены на сервере.';
 
   @override
   String failed_to_save_filter(String error) {
@@ -2911,8 +2771,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get delete_scenes_help =>
-      'Выберите, удалить только метаданные Stash или также удалить файлы сцен и созданные вспомогательные файлы.';
+  String get delete_scenes_help => 'Выберите, удалить только метаданные Stash или также удалить файлы сцен и созданные вспомогательные файлы.';
 
   @override
   String deleted_n_scenes(int count) {
@@ -2933,8 +2792,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get merge_editing_not_wired =>
-      'Редактирование слияния в StashFlow пока не подключено.';
+  String get merge_editing_not_wired => 'Редактирование слияния в StashFlow пока не подключено.';
 
   @override
   String duplicate_sets_count(int count) {
@@ -2970,6 +2828,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String nTags(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2987,6 +2846,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String nGroups(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3004,6 +2864,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String nMarkers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3021,6 +2882,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String nGalleries(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3048,8 +2910,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get no_matched_scenes_yet => 'Пока нет совпавших сцен.';
 
   @override
-  String get no_scenes_match_configuration =>
-      'Нет сцен, соответствующих этой конфигурации.';
+  String get no_scenes_match_configuration => 'Нет сцен, соответствующих этой конфигурации.';
 
   @override
   String scene_tagger_checked_count(int count) {
@@ -3062,8 +2923,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get stats_library_stats_tooltip =>
-      'Удерживайте для статистики библиотеки';
+  String get stats_library_stats_tooltip => 'Удерживайте для статистики библиотеки';
 
   @override
   String get scene_details_marker_created => 'Маркер создан';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -45,6 +45,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String nScenes(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -61,6 +62,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String nPerformers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -77,6 +79,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String nPlays(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -1073,8 +1076,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_appearance_primary_color => '主色调';
 
   @override
-  String get settings_appearance_primary_color_subtitle =>
-      '为 Material 3 调色板选择种子颜色';
+  String get settings_appearance_primary_color_subtitle => '为 Material 3 调色板选择种子颜色';
 
   @override
   String get settings_appearance_advanced_theming => '高级主题';
@@ -1086,8 +1088,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_appearance_true_black => '纯黑 (AMOLED)';
 
   @override
-  String get settings_appearance_true_black_subtitle =>
-      '在深色模式下使用纯黑背景以节省 OLED 屏幕电量';
+  String get settings_appearance_true_black_subtitle => '在深色模式下使用纯黑背景以节省 OLED 屏幕电量';
 
   @override
   String get settings_appearance_custom_hex => '自定义 Hex 颜色';
@@ -1126,12 +1127,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_interface_show_random_subtitle => '在列表和详情页启用或禁用悬浮随机按钮';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation =>
-      '重力控制的方向（主页面）';
+  String get settings_interface_main_pages_gravity_orientation => '重力控制的方向（主页面）';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation_subtitle =>
-      '允许主页面使用设备传感器旋转。全屏视频播放将使用其自己的方向设置。';
+  String get settings_interface_main_pages_gravity_orientation_subtitle => '允许主页面使用设备传感器旋转。全屏视频播放将使用其自己的方向设置。';
 
   @override
   String get settings_interface_show_edit => '显示编辑按钮';
@@ -1140,19 +1139,16 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_interface_show_edit_subtitle => '在场景详情页启用或禁用编辑按钮';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer =>
-      '在迷你播放器中使用实际场景视频';
+  String get settings_interface_use_actual_scene_video_miniplayer => '在迷你播放器中使用实际场景视频';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer_subtitle =>
-      '播放时显示实时场景视频画面，而不是场景截图。';
+  String get settings_interface_use_actual_scene_video_miniplayer_subtitle => '播放时显示实时场景视频画面，而不是场景截图。';
 
   @override
   String get settings_interface_entity_image_filtering => '实体图像过滤';
 
   @override
-  String get settings_interface_entity_image_filtering_subtitle =>
-      '选择实体图像页面是匹配图像元数据还是关联图库。';
+  String get settings_interface_entity_image_filtering_subtitle => '选择实体图像页面是匹配图像元数据还是关联图库。';
 
   @override
   String get settings_interface_entity_image_filtering_direct => '直接实体';
@@ -1182,15 +1178,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_interface_max_performer_avatars => '最多出演者头像';
 
   @override
-  String get settings_interface_max_performer_avatars_subtitle =>
-      '在场景卡上显示的出演者头像的最大数量。';
+  String get settings_interface_max_performer_avatars_subtitle => '在场景卡上显示的出演者头像的最大数量。';
 
   @override
   String get settings_interface_show_performer_avatars => '显示出演者头像';
 
   @override
-  String get settings_interface_show_performer_avatars_subtitle =>
-      '在所有平台的场景卡上显示出演者图标。';
+  String get settings_interface_show_performer_avatars_subtitle => '在所有平台的场景卡上显示出演者图标。';
 
   @override
   String get settings_interface_performer_avatar_size => '出演者头像大小';
@@ -1283,8 +1277,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_server_url => 'Stash 地址';
 
   @override
-  String get settings_server_url_helper =>
-      '输入 Stash 服务器的 URL。如果配置了自定义路径，请在此处包含它。';
+  String get settings_server_url_helper => '输入 Stash 服务器的 URL。如果配置了自定义路径，请在此处包含它。';
 
   @override
   String get settings_server_url_example => 'http://192.168.1.100:9999';
@@ -1396,22 +1389,19 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_playback_prefer_streams => '优先使用 sceneStreams';
 
   @override
-  String get settings_playback_prefer_streams_subtitle =>
-      '关闭时，播放将直接使用 paths.stream';
+  String get settings_playback_prefer_streams_subtitle => '关闭时，播放将直接使用 paths.stream';
 
   @override
   String get settings_playback_feed_random => '从随机位置开始播放Feed';
 
   @override
-  String get settings_playback_feed_random_subtitle =>
-      '在Feed模式下播放场景时，从视频长度的0%到90%之间的随机位置开始播放';
+  String get settings_playback_feed_random_subtitle => '在Feed模式下播放场景时，从视频长度的0%到90%之间的随机位置开始播放';
 
   @override
   String get settings_playback_resume_position => '从上次播放位置恢复';
 
   @override
-  String get settings_playback_resume_position_subtitle =>
-      '打开视频时，自动从上次中断的地方继续播放';
+  String get settings_playback_resume_position_subtitle => '打开视频时，自动从上次中断的地方继续播放';
 
   @override
   String get settings_playback_end_behavior => '播放结束行为';
@@ -1500,12 +1490,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_playback_direct_play => '切换场景时直接播放';
 
   @override
-  String get settings_playback_direct_play_subtitle =>
-      '从另一个正在播放的场景切换过来时，直接播放新场景';
+  String get settings_playback_direct_play_subtitle => '从另一个正在播放的场景切换过来时，直接播放新场景';
 
   @override
-  String get settings_playback_gravity_orientation_subtitle =>
-      '允许使用设备传感器在匹配的方向之间旋转（例如：左右翻转横向）。';
+  String get settings_playback_gravity_orientation_subtitle => '允许使用设备传感器在匹配的方向之间旋转（例如：左右翻转横向）。';
 
   @override
   String get settings_playback_subtitle_lang_none_disabled => '无（禁用）';
@@ -1642,15 +1630,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_develop_web_auth => '允许在 Web 上使用密码登录';
 
   @override
-  String get settings_develop_web_auth_subtitle =>
-      '覆盖仅限原生的限制，并强制用户名 + 密码身份验证方式在 Flutter Web 上可见。';
+  String get settings_develop_web_auth_subtitle => '覆盖仅限原生的限制，并强制用户名 + 密码身份验证方式在 Flutter Web 上可见。';
 
   @override
   String get settings_develop_proxy_auth => '启用代理认证模式';
 
   @override
-  String get settings_develop_proxy_auth_subtitle =>
-      '启用高级 Basic Auth 和 Bearer Token 方法，以便在 Authentik 等代理背后的无认证后端中使用。';
+  String get settings_develop_proxy_auth_subtitle => '启用高级 Basic Auth 和 Bearer Token 方法，以便在 Authentik 等代理背后的无认证后端中使用。';
 
   @override
   String get settings_server_auth_basic => '基础认证';
@@ -1659,12 +1645,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_server_auth_bearer => 'Bearer 令牌';
 
   @override
-  String get settings_server_auth_basic_desc =>
-      '发送 \'Authorization: Basic <base64(user:pass)>\' 请求头。';
+  String get settings_server_auth_basic_desc => '发送 \'Authorization: Basic <base64(user:pass)>\' 请求头。';
 
   @override
-  String get settings_server_auth_bearer_desc =>
-      '发送 \'Authorization: Bearer <token>\' 请求头。';
+  String get settings_server_auth_bearer_desc => '发送 \'Authorization: Bearer <token>\' 请求头。';
 
   @override
   String get common_edit => '编辑';
@@ -2340,12 +2324,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get failed_to_load_tap_to_retry => '加载失败。点击重试。';
 
   @override
-  String get would_you_like_to_visit_the_release_page_to_download_it =>
-      '您想访问发布页面下载吗？';
+  String get would_you_like_to_visit_the_release_page_to_download_it => '您想访问发布页面下载吗？';
 
   @override
-  String get to_get_started_configure_stash_server =>
-      '要开始使用，您需要配置您的 Stash 服务器连接详细信息。';
+  String get to_get_started_configure_stash_server => '要开始使用，您需要配置您的 Stash 服务器连接详细信息。';
 
   @override
   String get loading => '加载中';
@@ -2501,8 +2483,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_security_background_lock_timer => '后台锁定定时器';
 
   @override
-  String get settings_security_background_lock_timer_subtitle =>
-      '应用程序在锁定之前可以在后台停留多长时间。';
+  String get settings_security_background_lock_timer_subtitle => '应用程序在锁定之前可以在后台停留多长时间。';
 
   @override
   String get settings_security_set_passcode => '设置密码';
@@ -2843,6 +2824,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String nTags(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2853,6 +2835,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String nGroups(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2863,6 +2846,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String nMarkers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2873,6 +2857,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String nGalleries(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -2955,7 +2940,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
 class AppLocalizationsZhHans extends AppLocalizationsZh {
-  AppLocalizationsZhHans() : super('zh_Hans');
+  AppLocalizationsZhHans(): super('zh_Hans');
 
   @override
   String get appTitle => 'StashFlow';
@@ -2994,6 +2979,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String nScenes(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3010,6 +2996,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String nPerformers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -3026,6 +3013,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String nPlays(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -4022,8 +4010,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get settings_appearance_primary_color => '主色调';
 
   @override
-  String get settings_appearance_primary_color_subtitle =>
-      '为 Material 3 调色板选择种子颜色';
+  String get settings_appearance_primary_color_subtitle => '为 Material 3 调色板选择种子颜色';
 
   @override
   String get settings_appearance_advanced_theming => '高级主题';
@@ -4035,8 +4022,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get settings_appearance_true_black => '纯黑 (AMOLED)';
 
   @override
-  String get settings_appearance_true_black_subtitle =>
-      '在深色模式下使用纯黑背景以节省 OLED 屏幕电量';
+  String get settings_appearance_true_black_subtitle => '在深色模式下使用纯黑背景以节省 OLED 屏幕电量';
 
   @override
   String get settings_appearance_custom_hex => '自定义 Hex 颜色';
@@ -4075,12 +4061,10 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get settings_interface_show_random_subtitle => '在列表和详情页启用或禁用悬浮随机按钮';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation =>
-      '重力控制的方向（主页面）';
+  String get settings_interface_main_pages_gravity_orientation => '重力控制的方向（主页面）';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation_subtitle =>
-      '允许主页面使用设备传感器旋转。全屏视频播放将使用其自己的方向设置。';
+  String get settings_interface_main_pages_gravity_orientation_subtitle => '允许主页面使用设备传感器旋转。全屏视频播放将使用其自己的方向设置。';
 
   @override
   String get settings_interface_show_edit => '显示编辑按钮';
@@ -4089,19 +4073,16 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get settings_interface_show_edit_subtitle => '在场景详情页启用或禁用编辑按钮';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer =>
-      '在迷你播放器中使用实际场景视频';
+  String get settings_interface_use_actual_scene_video_miniplayer => '在迷你播放器中使用实际场景视频';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer_subtitle =>
-      '播放时显示实时场景视频画面，而不是场景截图。';
+  String get settings_interface_use_actual_scene_video_miniplayer_subtitle => '播放时显示实时场景视频画面，而不是场景截图。';
 
   @override
   String get settings_interface_entity_image_filtering => '实体图像过滤';
 
   @override
-  String get settings_interface_entity_image_filtering_subtitle =>
-      '选择实体图像页面是匹配图像元数据还是关联图库。';
+  String get settings_interface_entity_image_filtering_subtitle => '选择实体图像页面是匹配图像元数据还是关联图库。';
 
   @override
   String get settings_interface_entity_image_filtering_direct => '直接实体';
@@ -4131,15 +4112,13 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get settings_interface_max_performer_avatars => '最多出演者头像';
 
   @override
-  String get settings_interface_max_performer_avatars_subtitle =>
-      '在场景卡上显示的出演者头像的最大数量。';
+  String get settings_interface_max_performer_avatars_subtitle => '在场景卡上显示的出演者头像的最大数量。';
 
   @override
   String get settings_interface_show_performer_avatars => '显示出演者头像';
 
   @override
-  String get settings_interface_show_performer_avatars_subtitle =>
-      '在所有平台的场景卡上显示出演者图标。';
+  String get settings_interface_show_performer_avatars_subtitle => '在所有平台的场景卡上显示出演者图标。';
 
   @override
   String get settings_interface_performer_avatar_size => '出演者头像大小';
@@ -4232,8 +4211,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get settings_server_url => 'Stash 地址';
 
   @override
-  String get settings_server_url_helper =>
-      '输入 Stash 服务器的 URL。如果配置了自定义路径，请在此处包含它。';
+  String get settings_server_url_helper => '输入 Stash 服务器的 URL。如果配置了自定义路径，请在此处包含它。';
 
   @override
   String get settings_server_url_example => 'http://192.168.1.100:9999';
@@ -4345,22 +4323,19 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get settings_playback_prefer_streams => '优先使用 sceneStreams';
 
   @override
-  String get settings_playback_prefer_streams_subtitle =>
-      '关闭时，播放将直接使用 paths.stream';
+  String get settings_playback_prefer_streams_subtitle => '关闭时，播放将直接使用 paths.stream';
 
   @override
   String get settings_playback_feed_random => '从随机位置开始播放Feed';
 
   @override
-  String get settings_playback_feed_random_subtitle =>
-      '在Feed模式下播放场景时，从视频长度的0%到90%之间的随机位置开始播放';
+  String get settings_playback_feed_random_subtitle => '在Feed模式下播放场景时，从视频长度的0%到90%之间的随机位置开始播放';
 
   @override
   String get settings_playback_resume_position => '从上次播放位置恢复';
 
   @override
-  String get settings_playback_resume_position_subtitle =>
-      '打开视频时，自动从上次中断的地方继续播放';
+  String get settings_playback_resume_position_subtitle => '打开视频时，自动从上次中断的地方继续播放';
 
   @override
   String get settings_playback_end_behavior => '播放结束行为';
@@ -4449,12 +4424,10 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get settings_playback_direct_play => '切换场景时直接播放';
 
   @override
-  String get settings_playback_direct_play_subtitle =>
-      '从另一个正在播放的场景切换过来时，直接播放新场景';
+  String get settings_playback_direct_play_subtitle => '从另一个正在播放的场景切换过来时，直接播放新场景';
 
   @override
-  String get settings_playback_gravity_orientation_subtitle =>
-      '允许使用设备传感器在匹配的方向之间旋转（例如：左右翻转横向）。';
+  String get settings_playback_gravity_orientation_subtitle => '允许使用设备传感器在匹配的方向之间旋转（例如：左右翻转横向）。';
 
   @override
   String get settings_playback_subtitle_lang_none_disabled => '无（禁用）';
@@ -4591,15 +4564,13 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get settings_develop_web_auth => '允许在 Web 上使用密码登录';
 
   @override
-  String get settings_develop_web_auth_subtitle =>
-      '覆盖仅限原生的限制，并强制用户名 + 密码身份验证方式在 Flutter Web 上可见。';
+  String get settings_develop_web_auth_subtitle => '覆盖仅限原生的限制，并强制用户名 + 密码身份验证方式在 Flutter Web 上可见。';
 
   @override
   String get settings_develop_proxy_auth => '启用代理认证模式';
 
   @override
-  String get settings_develop_proxy_auth_subtitle =>
-      '启用高级 Basic Auth 和 Bearer Token 方法，以便在 Authentik 等代理背后的无认证后端中使用。';
+  String get settings_develop_proxy_auth_subtitle => '启用高级 Basic Auth 和 Bearer Token 方法，以便在 Authentik 等代理背后的无认证后端中使用。';
 
   @override
   String get settings_server_auth_basic => '基础认证';
@@ -4608,12 +4579,10 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get settings_server_auth_bearer => 'Bearer 令牌';
 
   @override
-  String get settings_server_auth_basic_desc =>
-      '发送 \'Authorization: Basic <base64(user:pass)>\' 请求头。';
+  String get settings_server_auth_basic_desc => '发送 \'Authorization: Basic <base64(user:pass)>\' 请求头。';
 
   @override
-  String get settings_server_auth_bearer_desc =>
-      '发送 \'Authorization: Bearer <token>\' 请求头。';
+  String get settings_server_auth_bearer_desc => '发送 \'Authorization: Bearer <token>\' 请求头。';
 
   @override
   String get common_edit => '编辑';
@@ -5289,12 +5258,10 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get failed_to_load_tap_to_retry => '加载失败。点击重试。';
 
   @override
-  String get would_you_like_to_visit_the_release_page_to_download_it =>
-      '您想访问发布页面下载吗？';
+  String get would_you_like_to_visit_the_release_page_to_download_it => '您想访问发布页面下载吗？';
 
   @override
-  String get to_get_started_configure_stash_server =>
-      '要开始使用，您需要配置您的 Stash 服务器连接详细信息。';
+  String get to_get_started_configure_stash_server => '要开始使用，您需要配置您的 Stash 服务器连接详细信息。';
 
   @override
   String get loading => '加载中';
@@ -5450,8 +5417,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get settings_security_background_lock_timer => '后台锁定定时器';
 
   @override
-  String get settings_security_background_lock_timer_subtitle =>
-      '应用程序在锁定之前可以在后台停留多长时间。';
+  String get settings_security_background_lock_timer_subtitle => '应用程序在锁定之前可以在后台停留多长时间。';
 
   @override
   String get settings_security_set_passcode => '设置密码';
@@ -5792,6 +5758,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String nTags(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -5802,6 +5769,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String nGroups(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -5812,6 +5780,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String nMarkers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -5822,6 +5791,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String nGalleries(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -5904,7 +5874,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
 class AppLocalizationsZhHant extends AppLocalizationsZh {
-  AppLocalizationsZhHant() : super('zh_Hant');
+  AppLocalizationsZhHant(): super('zh_Hant');
 
   @override
   String get appTitle => 'StashFlow';
@@ -5943,6 +5913,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String nScenes(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -5960,6 +5931,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String nPerformers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -5977,6 +5949,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String nPlays(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -6973,8 +6946,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_appearance_primary_color => '主要顏色';
 
   @override
-  String get settings_appearance_primary_color_subtitle =>
-      '為 Material 3 調色盤挑選種子顏色';
+  String get settings_appearance_primary_color_subtitle => '為 Material 3 調色盤挑選種子顏色';
 
   @override
   String get settings_appearance_advanced_theming => '進階主題';
@@ -6986,8 +6958,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_appearance_true_black => '純黑 (AMOLED)';
 
   @override
-  String get settings_appearance_true_black_subtitle =>
-      '在深色模式下使用純黑背景，以節省 OLED 螢幕的電量';
+  String get settings_appearance_true_black_subtitle => '在深色模式下使用純黑背景，以節省 OLED 螢幕的電量';
 
   @override
   String get settings_appearance_custom_hex => '自訂 Hex 顏色';
@@ -7026,12 +6997,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_interface_show_random_subtitle => '在列表和詳情頁面啟用或停用浮動隨機按鈕';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation =>
-      '重力控制的方向（主頁面）';
+  String get settings_interface_main_pages_gravity_orientation => '重力控制的方向（主頁面）';
 
   @override
-  String get settings_interface_main_pages_gravity_orientation_subtitle =>
-      '允許主頁面使用裝置感測器旋轉。全螢幕影片播放將使用其自己的方向設定。';
+  String get settings_interface_main_pages_gravity_orientation_subtitle => '允許主頁面使用裝置感測器旋轉。全螢幕影片播放將使用其自己的方向設定。';
 
   @override
   String get settings_interface_show_edit => '顯示編輯按鈕';
@@ -7040,19 +7009,16 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_interface_show_edit_subtitle => '在場景詳情頁面上啟用或停用編輯按鈕';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer =>
-      '在迷你播放器中使用實際場景影片';
+  String get settings_interface_use_actual_scene_video_miniplayer => '在迷你播放器中使用實際場景影片';
 
   @override
-  String get settings_interface_use_actual_scene_video_miniplayer_subtitle =>
-      '播放時顯示即時場景影片畫面，而不是場景截圖。';
+  String get settings_interface_use_actual_scene_video_miniplayer_subtitle => '播放時顯示即時場景影片畫面，而不是場景截圖。';
 
   @override
   String get settings_interface_entity_image_filtering => '實體圖像過濾';
 
   @override
-  String get settings_interface_entity_image_filtering_subtitle =>
-      '選擇實體圖像頁面是匹配圖像元數據還是關聯圖庫。';
+  String get settings_interface_entity_image_filtering_subtitle => '選擇實體圖像頁面是匹配圖像元數據還是關聯圖庫。';
 
   @override
   String get settings_interface_entity_image_filtering_direct => '直接實體';
@@ -7082,15 +7048,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_interface_max_performer_avatars => '最多演出者頭像';
 
   @override
-  String get settings_interface_max_performer_avatars_subtitle =>
-      '在場景卡上顯示的演出者頭像的最大數量。';
+  String get settings_interface_max_performer_avatars_subtitle => '在場景卡上顯示的演出者頭像的最大數量。';
 
   @override
   String get settings_interface_show_performer_avatars => '顯示演出者頭像';
 
   @override
-  String get settings_interface_show_performer_avatars_subtitle =>
-      '在所有平台的場景卡上顯示演出者圖標。';
+  String get settings_interface_show_performer_avatars_subtitle => '在所有平台的場景卡上顯示演出者圖標。';
 
   @override
   String get settings_interface_performer_avatar_size => '演出者頭像大小';
@@ -7183,8 +7147,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_server_url => 'Stash 位址';
 
   @override
-  String get settings_server_url_helper =>
-      '輸入 Stash 伺服器的 URL。如果配置了自定義路徑，請在此處包含它。';
+  String get settings_server_url_helper => '輸入 Stash 伺服器的 URL。如果配置了自定義路徑，請在此處包含它。';
 
   @override
   String get settings_server_url_example => 'http://192.168.1.100:9999';
@@ -7202,8 +7165,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_server_auth_password => '使用者名稱 + 密碼';
 
   @override
-  String get settings_server_auth_password_desc =>
-      '建議：使用您的 Stash 使用者名稱/密碼工作階段。';
+  String get settings_server_auth_password_desc => '建議：使用您的 Stash 使用者名稱/密碼工作階段。';
 
   @override
   String get settings_server_auth_apikey_desc => '使用 API 金鑰進行靜態權杖驗證。';
@@ -7297,22 +7259,19 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_playback_prefer_streams => '優先使用 sceneStreams';
 
   @override
-  String get settings_playback_prefer_streams_subtitle =>
-      '關閉時，播放將直接使用 paths.stream';
+  String get settings_playback_prefer_streams_subtitle => '關閉時，播放將直接使用 paths.stream';
 
   @override
   String get settings_playback_feed_random => '從隨機位置開始播放Feed';
 
   @override
-  String get settings_playback_feed_random_subtitle =>
-      '在Feed模式下播放場景時，從影片長度的0%到90%之間的隨機位置開始播放';
+  String get settings_playback_feed_random_subtitle => '在Feed模式下播放場景時，從影片長度的0%到90%之間的隨機位置開始播放';
 
   @override
   String get settings_playback_resume_position => '從上次播放位置恢復';
 
   @override
-  String get settings_playback_resume_position_subtitle =>
-      '打開影片時，自動從上次中斷的地方繼續播放';
+  String get settings_playback_resume_position_subtitle => '打開影片時，自動從上次中斷的地方繼續播放';
 
   @override
   String get settings_playback_end_behavior => '播放結束行為';
@@ -7401,12 +7360,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_playback_direct_play => '切換場景時直接播放';
 
   @override
-  String get settings_playback_direct_play_subtitle =>
-      '從另一個正在播放的場景切換過來時，直接播放新場景';
+  String get settings_playback_direct_play_subtitle => '從另一個正在播放的場景切換過來時，直接播放新場景';
 
   @override
-  String get settings_playback_gravity_orientation_subtitle =>
-      '允許使用裝置感測器在相符方向之間旋轉（例如：將橫向向左/向右翻轉）。';
+  String get settings_playback_gravity_orientation_subtitle => '允許使用裝置感測器在相符方向之間旋轉（例如：將橫向向左/向右翻轉）。';
 
   @override
   String get settings_playback_subtitle_lang_none_disabled => '無（停用）';
@@ -7454,8 +7411,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_support_diagnostics => '診斷和專案資訊';
 
   @override
-  String get settings_support_diagnostics_subtitle =>
-      '當您需要協助時，開啟執行階段記錄或跳轉至儲存庫。';
+  String get settings_support_diagnostics_subtitle => '當您需要協助時，開啟執行階段記錄或跳轉至儲存庫。';
 
   @override
   String get settings_support_update_available => '有可用更新';
@@ -7544,15 +7500,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_develop_web_auth => '允許在網頁上使用密碼登入';
 
   @override
-  String get settings_develop_web_auth_subtitle =>
-      '覆寫僅限原生的限制，並強制「使用者名稱 + 密碼」驗證方式在 Flutter Web 上可見。';
+  String get settings_develop_web_auth_subtitle => '覆寫僅限原生的限制，並強制「使用者名稱 + 密碼」驗證方式在 Flutter Web 上可見。';
 
   @override
   String get settings_develop_proxy_auth => '啟用代理認證模式';
 
   @override
-  String get settings_develop_proxy_auth_subtitle =>
-      '啟用進階 Basic Auth 和 Bearer Token 方法，以便在 Authentik 等代理背後的無認證後端中使用。';
+  String get settings_develop_proxy_auth_subtitle => '啟用進階 Basic Auth 和 Bearer Token 方法，以便在 Authentik 等代理背後的無認證後端中使用。';
 
   @override
   String get settings_server_auth_basic => '基礎認證';
@@ -7561,12 +7515,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_server_auth_bearer => 'Bearer 權杖';
 
   @override
-  String get settings_server_auth_basic_desc =>
-      '發送 \'Authorization: Basic <base64(user:pass)>\' 請求頭。';
+  String get settings_server_auth_basic_desc => '發送 \'Authorization: Basic <base64(user:pass)>\' 請求頭。';
 
   @override
-  String get settings_server_auth_bearer_desc =>
-      '發送 \'Authorization: Bearer <token>\' 請求頭。';
+  String get settings_server_auth_bearer_desc => '發送 \'Authorization: Bearer <token>\' 請求頭。';
 
   @override
   String get common_edit => '編輯';
@@ -8242,12 +8194,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get failed_to_load_tap_to_retry => '載入失敗。點擊重試。';
 
   @override
-  String get would_you_like_to_visit_the_release_page_to_download_it =>
-      '您想訪問發佈頁面下載嗎？';
+  String get would_you_like_to_visit_the_release_page_to_download_it => '您想訪問發佈頁面下載嗎？';
 
   @override
-  String get to_get_started_configure_stash_server =>
-      '要開始使用，您需要配置您的 Stash 伺服器連接詳細資訊。';
+  String get to_get_started_configure_stash_server => '要開始使用，您需要配置您的 Stash 伺服器連接詳細資訊。';
 
   @override
   String get loading => '載入中';
@@ -8403,8 +8353,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get settings_security_background_lock_timer => '後台鎖定定時器';
 
   @override
-  String get settings_security_background_lock_timer_subtitle =>
-      '應用程式在鎖定之前可以在背景停留多長時間。';
+  String get settings_security_background_lock_timer_subtitle => '應用程式在鎖定之前可以在背景停留多長時間。';
 
   @override
   String get settings_security_set_passcode => '設定密碼';
@@ -8745,6 +8694,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String nTags(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -8755,6 +8705,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String nGroups(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -8765,6 +8716,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String nMarkers(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 
@@ -8775,6 +8727,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String nGalleries(num count) {
     final intl.NumberFormat countNumberFormat = intl.NumberFormat.compact(
       locale: localeName,
+
     );
     final String countString = countNumberFormat.format(count);
 


### PR DESCRIPTION
What: Replaced hardcoded 'filter saved to server' strings with l10n keys.
Why: To ensure complete app localization.
Impact: Saved filter success messages are now localized.
Measurement: N/A

---
*PR created automatically by Jules for task [16000513864350376583](https://jules.google.com/task/16000513864350376583) started by @Alchemist-Aloha*