### PR TITLE
⚡ Bolt: Throttle pagination data fetches in NotificationListener

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@
 ## 2024-05-30 - [Hoist textTheme and dimensions from ListView itemBuilder]
 **Learning:** Performing invariant lookups like `context.textTheme` and `context.dimensions.fontSizeFactor` inside a `ListView.builder`'s `itemBuilder` callback forces redundant O(1) inherited widget lookups on every single rendered item during scroll.
 **Action:** Always hoist these layout and styling variables out of the `itemBuilder` and into the parent widget's `build` (or builder) method to reduce GC pressure and ensure optimal rendering performance.
+
+## 2024-08-01 - [Throttle Pagination Fetches in NotificationListener]
+**Learning:** `NotificationListener<ScrollNotification>` fires rapidly on every single frame during scrolling. When verifying if a scroll position has reached a pagination threshold (e.g., checking `metrics.pixels >= maxScrollExtent - threshold`), this true condition can persist for dozens of frames as the user continues to scroll or overscroll. This triggers redundant `onFetchNextPage` callbacks that spam the backend, slow down the UI, and create duplicate state entries.
+**Action:** Always throttle pagination fetch callbacks triggered from a `NotificationListener<ScrollNotification>`. Use a cached `DateTime? _lastFetchTime` to track the last fetch, and skip redundant invocations using `now.difference(_lastFetchTime!) > threshold` (e.g. 500ms).

--- a/lib/core/presentation/widgets/list_page_scaffold.dart
+++ b/lib/core/presentation/widgets/list_page_scaffold.dart
@@ -169,6 +169,9 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
   DateTime? _lastHorizontalSwipeTime;
   static const _horizontalSwipeThreshold = Duration(milliseconds: 500);
 
+  DateTime? _lastFetchTime;
+  static const _fetchThreshold = Duration(milliseconds: 500);
+
   @override
   void initState() {
     super.initState();
@@ -762,7 +765,13 @@ class _ListPageScaffoldState<T> extends ConsumerState<ListPageScaffold<T>> {
                       return NotificationListener<ScrollNotification>(
                         onNotification: (ScrollNotification scrollInfo) {
                           if (shouldLoadNextPage(scrollInfo.metrics)) {
-                            widget.onFetchNextPage?.call();
+                            final now = DateTime.now();
+                            if (_lastFetchTime == null ||
+                                now.difference(_lastFetchTime!) >
+                                    _fetchThreshold) {
+                              _lastFetchTime = now;
+                              widget.onFetchNextPage?.call();
+                            }
                           }
                           return false;
                         },


### PR DESCRIPTION
**What**: Throttles the `onFetchNextPage` callback in `NotificationListener<ScrollNotification>` by introducing a 500ms `_fetchThreshold`.
**Why**: `NotificationListener` fires rapidly on every frame during scrolling. When verifying if a scroll position has reached the pagination threshold, this condition can persist for dozens of frames as the user scrolls, triggering redundant fetch calls that spam the backend and slow down the UI.
**Impact**: Prevents multiple rapid overlapping data fetch requests when the user scrolls near the bottom of a paginated list, reducing network overhead and potential duplicate state additions.
**Measurement**: Monitor backend request volume and app freeze events during rapid downward scrolling in paginated lists.

---
*PR created automatically by Jules for task [4740102759476447536](https://jules.google.com/task/4740102759476447536) started by @Alchemist-Aloha*