### PR TITLE
🌐 Localize remaining hardcoded strings in scene tagger

### DIFF
--- a/lib/features/scenes/presentation/pages/scene_tagger_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_tagger_page.dart
@@ -936,10 +936,16 @@ class _ScrapedSceneSummary extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (error != null) {
-      return _MetadataPanel(title: title, rows: [('Error', error!)]);
+      return _MetadataPanel(
+        title: title,
+        rows: [(context.l10n.error_label, error!)],
+      );
     }
     if (scraped == null) {
-      return _MetadataPanel(title: title, rows: [('Status', 'No match found')]);
+      return _MetadataPanel(
+        title: title,
+        rows: [(context.l10n.status, context.l10n.no_match_found)],
+      );
     }
 
     return _MetadataPanel(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1114,5 +1114,8 @@
   "stats_subtitle_0_unique_items": "0 einzigartige Artikel",
   "markers_search_hint": "Suchmarkierungen",
   "tags_title": "Schlagworte",
-  "scenes_title": "Szenen"
+  "scenes_title": "Szenen",
+  "error_label": "Fehler",
+  "status": "Status",
+  "no_match_found": "Keine Übereinstimmung gefunden"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1470,5 +1470,8 @@
   "stats_subtitle_0_unique_items": "0 unique items",
   "markers_search_hint": "Search markers",
   "tags_title": "Tags",
-  "scenes_title": "Scenes"
+  "scenes_title": "Scenes",
+  "status": "Status",
+  "no_match_found": "No match found",
+  "error_label": "Error"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1093,5 +1093,8 @@
   "stats_subtitle_0_unique_items": "0 artículos únicos",
   "markers_search_hint": "Marcadores de búsqueda",
   "tags_title": "Etiquetas",
-  "scenes_title": "Escenas"
+  "scenes_title": "Escenas",
+  "error_label": "Error",
+  "status": "Estado",
+  "no_match_found": "No se encontró ninguna coincidencia"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1093,5 +1093,8 @@
   "stats_subtitle_0_unique_items": "0 objets uniques",
   "markers_search_hint": "Marqueurs de recherche",
   "tags_title": "Balises",
-  "scenes_title": "Scènes"
+  "scenes_title": "Scènes",
+  "error_label": "Erreur",
+  "status": "Statut",
+  "no_match_found": "Aucune correspondance trouvée"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1098,5 +1098,8 @@
   "stats_subtitle_0_unique_items": "0 oggetti unici",
   "markers_search_hint": "Cerca marcatori",
   "tags_title": "Tag",
-  "scenes_title": "Scene"
+  "scenes_title": "Scene",
+  "error_label": "Errore",
+  "status": "Stato",
+  "no_match_found": "Nessuna corrispondenza trovata"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1093,5 +1093,8 @@
   "stats_subtitle_0_unique_items": "0 個のユニークなアイテム",
   "markers_search_hint": "検索マーカー",
   "tags_title": "タグ",
-  "scenes_title": "シーン"
+  "scenes_title": "シーン",
+  "error_label": "エラー",
+  "status": "状態",
+  "no_match_found": "一致するものが見つかりませんでした"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1093,5 +1093,8 @@
   "stats_subtitle_0_unique_items": "0개의 고유 아이템",
   "markers_search_hint": "검색 마커",
   "tags_title": "태그",
-  "scenes_title": "장면"
+  "scenes_title": "장면",
+  "error_label": "오류",
+  "status": "상태",
+  "no_match_found": "일치하는 항목이 없습니다."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5681,6 +5681,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Scenes'**
   String get scenes_title;
+
+  /// No description provided for @status.
+  ///
+  /// In en, this message translates to:
+  /// **'Status'**
+  String get status;
+
+  /// No description provided for @no_match_found.
+  ///
+  /// In en, this message translates to:
+  /// **'No match found'**
+  String get no_match_found;
+
+  /// No description provided for @error_label.
+  ///
+  /// In en, this message translates to:
+  /// **'Error'**
+  String get error_label;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3194,4 +3194,13 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get scenes_title => 'Szenen';
+
+  @override
+  String get status => 'Status';
+
+  @override
+  String get no_match_found => 'Keine Übereinstimmung gefunden';
+
+  @override
+  String get error_label => 'Fehler';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3148,4 +3148,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get scenes_title => 'Scenes';
+
+  @override
+  String get status => 'Status';
+
+  @override
+  String get no_match_found => 'No match found';
+
+  @override
+  String get error_label => 'Error';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3221,4 +3221,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get scenes_title => 'Escenas';
+
+  @override
+  String get status => 'Estado';
+
+  @override
+  String get no_match_found => 'No se encontró ninguna coincidencia';
+
+  @override
+  String get error_label => 'Error';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3213,4 +3213,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get scenes_title => 'Scènes';
+
+  @override
+  String get status => 'Statut';
+
+  @override
+  String get no_match_found => 'Aucune correspondance trouvée';
+
+  @override
+  String get error_label => 'Erreur';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3212,4 +3212,13 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get scenes_title => 'Scene';
+
+  @override
+  String get status => 'Stato';
+
+  @override
+  String get no_match_found => 'Nessuna corrispondenza trovata';
+
+  @override
+  String get error_label => 'Errore';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -3086,4 +3086,13 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get scenes_title => 'シーン';
+
+  @override
+  String get status => '状態';
+
+  @override
+  String get no_match_found => '一致するものが見つかりませんでした';
+
+  @override
+  String get error_label => 'エラー';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -3084,4 +3084,13 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get scenes_title => '장면';
+
+  @override
+  String get status => '상태';
+
+  @override
+  String get no_match_found => '일치하는 항목이 없습니다.';
+
+  @override
+  String get error_label => '오류';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3189,4 +3189,13 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get scenes_title => 'Сцены';
+
+  @override
+  String get status => 'Статус';
+
+  @override
+  String get no_match_found => 'Соответствие не найдено';
+
+  @override
+  String get error_label => 'Ошибка';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3029,6 +3029,15 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get scenes_title => '场景';
+
+  @override
+  String get status => '地位';
+
+  @override
+  String get no_match_found => '未找到匹配项';
+
+  @override
+  String get error_label => '错误';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -6056,6 +6065,15 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get scenes_title => '场景';
+
+  @override
+  String get status => '地位';
+
+  @override
+  String get no_match_found => '未找到匹配项';
+
+  @override
+  String get error_label => '错误';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -9087,4 +9105,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get scenes_title => '場景';
+
+  @override
+  String get status => '地位';
+
+  @override
+  String get no_match_found => '未找到匹配項';
+
+  @override
+  String get error_label => '錯誤';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1093,5 +1093,8 @@
   "stats_subtitle_0_unique_items": "0 уникальных предметов",
   "markers_search_hint": "Маркеры поиска",
   "tags_title": "Теги",
-  "scenes_title": "Сцены"
+  "scenes_title": "Сцены",
+  "error_label": "Ошибка",
+  "status": "Статус",
+  "no_match_found": "Соответствие не найдено"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1093,5 +1093,8 @@
   "stats_subtitle_0_unique_items": "0 件独特物品",
   "markers_search_hint": "搜索标记",
   "tags_title": "标签",
-  "scenes_title": "场景"
+  "scenes_title": "场景",
+  "error_label": "错误",
+  "status": "地位",
+  "no_match_found": "未找到匹配项"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1079,5 +1079,8 @@
   "stats_subtitle_0_unique_items": "0 件独特物品",
   "markers_search_hint": "搜索标记",
   "tags_title": "标签",
-  "scenes_title": "场景"
+  "scenes_title": "场景",
+  "error_label": "错误",
+  "status": "地位",
+  "no_match_found": "未找到匹配项"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1079,5 +1079,8 @@
   "stats_subtitle_0_unique_items": "0 件獨特物品",
   "markers_search_hint": "搜尋標記",
   "tags_title": "標籤",
-  "scenes_title": "場景"
+  "scenes_title": "場景",
+  "error_label": "錯誤",
+  "status": "地位",
+  "no_match_found": "未找到匹配項"
 }


### PR DESCRIPTION
## What
Replaced hardcoded strings ('Error', 'Status', 'No match found') in `scene_tagger_page.dart` with localized string keys (`error_label`, `status`, `no_match_found`).

## Why
To ensure complete translation coverage for the app, especially error and status panels in the scene tagger page, enabling accessibility for non-English speakers.

## Impact
Users will now see localized text for the scrape status and error messages in the Scene Tagger.

## Measurement
All tests pass. Manual UI verification confirms the hardcoded string replacement and the ARB translation automation was successful for all supported languages.

---
*PR created automatically by Jules for task [1188755393710865359](https://jules.google.com/task/1188755393710865359) started by @Alchemist-Aloha*